### PR TITLE
Initial JJB job

### DIFF
--- a/rpc-jobs/jjb-setup.yml
+++ b/rpc-jobs/jjb-setup.yml
@@ -53,12 +53,13 @@
 
             [jenkins]
             url=${JENKINS_URL}
-            user=${JENKINS_USER}
-            password=${JENKINS_API_PASSWORD}
             EOF
 
             if [ "$IGNORE_CACHE" = "true" ]; then
                 JJB_ARGS="--ignore-cache"
             fi
 
-            jenkins-jobs --conf jenkins_jobs.ini $JJB_ARGS update $JOBS
+            jenkins-jobs --conf jenkins_jobs.ini \
+                         --user $JENKINS_USER \
+                         --password $JENKINS_API_PASSWORD \
+                         $JJB_ARGS update $JOBS

--- a/rpc-jobs/jjb-setup.yml
+++ b/rpc-jobs/jjb-setup.yml
@@ -25,6 +25,12 @@
                 - $JJB_BRANCH
             skip-tag: true
             wipe-workspace: false
+    wrappers:
+      - credentials-binding:
+          - username-password-separated:
+             credential-id: service_account_jenkins_api_creds
+             username: JENKINS_USER
+             password: JENKINS_API_PASSWORD
     builders:
         - shell: |
             scl enable python27 bash
@@ -36,8 +42,23 @@
 
             pip install jenkins-job-builder
 
+            cat > jenkins_jobs.ini << EOF
+            [job-builder]
+            ignore_cache=False
+            keep_descriptions=False
+            include_path=.:scripts:~/git/
+            recursive=True
+            exclude=.*manual:./development
+            allow_deplicates=False
+
+            [jenkins]
+            url=${JENKINS_URL}
+            user=${JENKINS_USER}
+            password=${JENKINS_API_PASSWORD}
+            EOF
+
             if [ "$IGNORE_CACHE" = "true" ]; then
                 JJB_ARGS="--ignore-cache"
             fi
 
-            jenkins-jobs --conf ~/jenkins_jobs.ini $JJB_ARGS update $JOBS
+            jenkins-jobs --conf jenkins_jobs.ini $JJB_ARGS update $JOBS

--- a/rpc-jobs/jjb-setup.yml
+++ b/rpc-jobs/jjb-setup.yml
@@ -1,0 +1,43 @@
+- job:
+    name: 'Jenkins-Job-Builder'
+    description: Creates and updates jobs with Jenkins Job Builder.
+    logrotate:
+        daysToKeep: 20
+    node: general
+    parameters:
+        - string:
+            name: JOBS
+            description: "Which jobs to update and with what options."
+            default: -r rpc-jobs
+        - bool:
+            name: IGNORE_CACHE
+            description: "Ignore cache when updating jobs."
+        - string:
+            name: JJB_REPO
+            default: https://github.com/rcbops/rpc-gating
+        - string:
+            name: JJB_BRANCH
+            default: master
+    scm:
+        - git:
+            url: $JJB_REPO
+            branches:
+                - $JJB_BRANCH
+            skip-tag: true
+            wipe-workspace: false
+    builders:
+        - shell: |
+            scl enable python27 bash
+
+            if [[ ! -d ".venv" ]]; then
+                virtualenv -p /opt/rh/python27/root/usr/bin/python .venv
+            fi
+            source .venv/bin/activate
+
+            pip install jenkins-job-builder
+
+            if [ "$IGNORE_CACHE" = "true" ]; then
+                JJB_ARGS="--ignore-cache"
+            fi
+
+            jenkins-jobs --conf ~/jenkins_jobs.ini $JJB_ARGS update $JOBS


### PR DESCRIPTION
This commit creates the initial JJB bootstrap job. This is based off
the change in [1], but moves the scl outside of the if statement and
removes the installation of virtualenv (since it should already be
installed).

[1] https://github.com/rcbops-qe/jenkins-jobs/pull/2

Connects https://github.com/rcbops/u-suk-dev/issues/960