### PR TITLE
Adding pipeline step and jobs for running multi-node aio setup

### DIFF
--- a/pipeline-steps/common.groovy
+++ b/pipeline-steps/common.groovy
@@ -94,6 +94,20 @@ def write_json(Map args){
   )
 }
 
+/* Run a bash script
+ * Args:
+ *  script: Script or path to script from the current directory to run
+ *  environment_vars: Environment variables to set
+ */
+def run_script(Map args) {
+  withEnv(args.environment_vars) {
+    sh """
+        #!/bin/bash
+        sudo -E ./${args.script}
+        """
+  }
+}
+
 /* Run a stage if the stage name is contained in an env var
  * Args:
  *   - stage_name: String name of this stage

--- a/rpc-jobs/multi-node-aio.yml
+++ b/rpc-jobs/multi-node-aio.yml
@@ -1,0 +1,148 @@
+- job:
+    name: 'OnMetal_Multi_Node_AIO_Prepare_Deployment'
+    project-type: workflow
+    build-discarder:
+        days-to-keep: 30
+    concurrent: true
+    parameters:
+      - string:
+          name: NODE
+          description: "Name or label of Jenkins node to run on"
+      - string:
+          name: OPENSTACK_ANSIBLE_BRANCH
+          default: stable/newton
+          description: Openstack Ansible branch to use in setup
+      - choice:
+          name: DEFAULT_IMAGE
+          description: Version of Ubuntu image to use for VMs (14.04.4 or 16.04)
+          choices:
+            - '14.04.4'
+            - '16.04'
+      - bool:
+          name: PARTITION_HOST
+          default: true
+          description: Enable partitioning of host data disk device
+      - string:
+          name: OSA_OPS_REPO
+          default: https://github.com/openstack/openstack-ansible-ops
+      - string:
+          name: OSA_OPS_BRANCH
+          default: master
+
+    dsl: |
+      node(env.NODE){
+        dir("rpc-gating"){
+          git url: "https://github.com/rcbops/rpc-gating", branch: "master"
+        }
+        dir("openstack-ansible-ops"){
+          git url: env.OSA_OPS_REPO, branch: env.OSA_OPS_BRANCH
+        }
+        def common = load 'rpc-gating/pipeline-steps/common.groovy'
+
+        dir("openstack-ansible-ops/multi-node-aio"){
+          stage ('Setup Host'){
+            common.run_script (
+              script: 'setup-host.sh',
+              environment_vars: ["PARTITION_HOST=${env.PARTITION_HOST}"]
+            )
+          }
+          stage ('Setup Cobbler'){
+            common.run_script (
+              script: 'setup-cobbler.sh',
+              environment_vars: ["DEFAULT_IMAGE=${env.DEFAULT_IMAGE}"]
+            )
+          }
+          stage ('Setup Virtual Networks'){
+            common.run_script (
+              script: 'setup-virsh-net.sh',
+              environment_vars: []
+            )
+          }
+          stage ('Deploy VMs'){
+            common.run_script (
+              script: 'deploy-vms.sh',
+              environment_vars: []
+            )
+          }
+          stage ('Setup OpenStack Ansible'){
+            common.run_script (
+              script: 'deploy-osa.sh',
+              environment_vars: [
+              "OSA_BRANCH=${env.OPENSTACK_ANSIBLE_BRANCH}",
+              "RUN_OSA=false"]
+            )
+          }
+        }
+      }
+
+- project:
+    name: multi-node-all-in-one-individual
+    setup-action:
+        - Setup_Host:
+            script: setup-host.sh
+        - Setup_Cobbler:
+            script: setup-cobbler.sh
+        - Virtual_Networks:
+            script: setup-virsh-net.sh
+        - Deploy_VMs:
+            script: deploy-vms.sh
+        - OpenStack_Setup:
+            script: deploy-osa.sh
+    jobs:
+        - 'OnMetal_Multi_Node_AIO_{setup-action}'
+
+- job-template:
+    name: 'OnMetal_Multi_Node_AIO_{setup-action}'
+    project-type: workflow
+    build-discarder:
+      days-to-keep: 30
+    concurrent: true
+    parameters:
+      - string:
+          name: NODE
+          description: "Name or label of Jenkins node to run on"
+      - string:
+          name: OPENSTACK_ANSIBLE_BRANCH
+          default: stable/newton
+          description: Openstack Ansible branch to use in OnMetal_Multi_Node_AIO_OpenStack_Setup
+      - choice:
+          name: DEFAULT_IMAGE
+          description: Version of Ubuntu image to use for VMs (14.04.4 or 16.04) in OnMetal_Multi_Node_AIO_Setup_Cobbler
+          choices:
+            - '14.04.4'
+            - '16.04'
+      - bool:
+          name: PARTITION_HOST
+          default: true
+          description: Enable partitioning of host data disk device in Used only in OnMetal_Multi_Node_AIO_Setup_Host
+      - string:
+          name: OSA_OPS_REPO
+          default: https://github.com/openstack/openstack-ansible-ops
+      - string:
+          name: OSA_OPS_BRANCH
+          default: master
+    dsl: |
+      node(env.NODE){{
+        dir("rpc-gating"){{
+          git url: "https://github.com/rcbops/rpc-gating", branch: "master"
+        }}
+        dir("openstack-ansible-ops"){{
+          git url: env.OSA_OPS_REPO, branch: env.OSA_OPS_BRANCH
+        }}
+        def common = load 'rpc-gating/pipeline-steps/common.groovy'
+
+        dir("openstack-ansible-ops/multi-node-aio"){{
+          stage ('{setup-action}'){{
+            environment_vars = [
+            "PARTITION_HOST=${{env.PARTITION_HOST}}",
+            "DEFAULT_IMAGE=${{env.DEFAULT_IMAGE}}",
+            "PARTITION_HOST=${{env.PARTITION_HOST}}",
+            "RUN_OSA=false"
+            ]
+            common.run_script.call (
+              script: '{script}',
+              environment_vars: environment_vars
+            )
+          }}
+        }}
+      }}

--- a/rpc-jobs/multi-node-aio.yml
+++ b/rpc-jobs/multi-node-aio.yml
@@ -28,11 +28,28 @@
       - string:
           name: OSA_OPS_BRANCH
           default: master
+      - string:
+          name: RPC_GATING_REPO
+          default: "https://github.com/rcbops/rpc-gating"
+      - string:
+          name: RPC_GATING_BRANCH
+          default: "master"
+      - string:
+          name: STAGES
+          default: "Setup Host, Setup Cobbler, Setup Virtual Networks, Deploy VMs, Setup OpenStack Ansible"
+          description: |
+            Pipeline stages to run CSV
+            Options:
+              Setup Host
+              Setup Cobbler
+              Setup Virtual Networks
+              Deploy VMs
+              Setup OpenStack Ansible
 
     dsl: |
       node(env.NODE){
         dir("rpc-gating"){
-          git url: "https://github.com/rcbops/rpc-gating", branch: "master"
+          git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
         }
         dir("openstack-ansible-ops"){
           git url: env.OSA_OPS_REPO, branch: env.OSA_OPS_BRANCH
@@ -40,109 +57,56 @@
         def common = load 'rpc-gating/pipeline-steps/common.groovy'
 
         dir("openstack-ansible-ops/multi-node-aio"){
-          stage ('Setup Host'){
-            common.run_script (
-              script: 'setup-host.sh',
-              environment_vars: ["PARTITION_HOST=${env.PARTITION_HOST}"]
-            )
-          }
-          stage ('Setup Cobbler'){
-            common.run_script (
-              script: 'setup-cobbler.sh',
-              environment_vars: ["DEFAULT_IMAGE=${env.DEFAULT_IMAGE}"]
-            )
-          }
-          stage ('Setup Virtual Networks'){
-            common.run_script (
-              script: 'setup-virsh-net.sh',
-              environment_vars: []
-            )
-          }
-          stage ('Deploy VMs'){
-            common.run_script (
-              script: 'deploy-vms.sh',
-              environment_vars: []
-            )
-          }
-          stage ('Setup OpenStack Ansible'){
-            common.run_script (
-              script: 'deploy-osa.sh',
-              environment_vars: [
-              "OSA_BRANCH=${env.OPENSTACK_ANSIBLE_BRANCH}",
-              "RUN_OSA=false"]
-            )
-          }
-        }
-      }
+          common.conditionalStage(
+            stage_name: 'Setup Host',
+            stage: {
+              common.run_script (
+                script: 'setup-host.sh',
+                environment_vars: ["PARTITION_HOST=${env.PARTITION_HOST}"]
+              )
+            } //stage
+          ) //conditionalStage
 
-- project:
-    name: multi-node-all-in-one-individual
-    setup-action:
-        - Setup_Host:
-            script: setup-host.sh
-        - Setup_Cobbler:
-            script: setup-cobbler.sh
-        - Virtual_Networks:
-            script: setup-virsh-net.sh
-        - Deploy_VMs:
-            script: deploy-vms.sh
-        - OpenStack_Setup:
-            script: deploy-osa.sh
-    jobs:
-        - 'OnMetal_Multi_Node_AIO_{setup-action}'
+          common.conditionalStage(
+            stage_name: 'Setup Cobbler',
+            stage: {
+              common.run_script (
+                script: 'setup-cobbler.sh',
+                environment_vars: ["DEFAULT_IMAGE=${env.DEFAULT_IMAGE}"]
+              )
+            } //stage
+          ) //conditionalStage
 
-- job-template:
-    name: 'OnMetal_Multi_Node_AIO_{setup-action}'
-    project-type: workflow
-    build-discarder:
-      days-to-keep: 30
-    concurrent: true
-    parameters:
-      - string:
-          name: NODE
-          description: "Name or label of Jenkins node to run on"
-      - string:
-          name: OPENSTACK_ANSIBLE_BRANCH
-          default: stable/newton
-          description: Openstack Ansible branch to use in OnMetal_Multi_Node_AIO_OpenStack_Setup
-      - choice:
-          name: DEFAULT_IMAGE
-          description: Version of Ubuntu image to use for VMs (14.04.4 or 16.04) in OnMetal_Multi_Node_AIO_Setup_Cobbler
-          choices:
-            - '14.04.4'
-            - '16.04'
-      - bool:
-          name: PARTITION_HOST
-          default: true
-          description: Enable partitioning of host data disk device in Used only in OnMetal_Multi_Node_AIO_Setup_Host
-      - string:
-          name: OSA_OPS_REPO
-          default: https://github.com/openstack/openstack-ansible-ops
-      - string:
-          name: OSA_OPS_BRANCH
-          default: master
-    dsl: |
-      node(env.NODE){{
-        dir("rpc-gating"){{
-          git url: "https://github.com/rcbops/rpc-gating", branch: "master"
-        }}
-        dir("openstack-ansible-ops"){{
-          git url: env.OSA_OPS_REPO, branch: env.OSA_OPS_BRANCH
-        }}
-        def common = load 'rpc-gating/pipeline-steps/common.groovy'
+          common.conditionalStage(
+            stage_name: 'Setup Virtual Networks',
+            stage: {
+              common.run_script (
+                script: 'setup-virsh-net.sh',
+                environment_vars: []
+              )
+            } //stage
+          ) //conditionalStage
 
-        dir("openstack-ansible-ops/multi-node-aio"){{
-          stage ('{setup-action}'){{
-            environment_vars = [
-            "PARTITION_HOST=${{env.PARTITION_HOST}}",
-            "DEFAULT_IMAGE=${{env.DEFAULT_IMAGE}}",
-            "PARTITION_HOST=${{env.PARTITION_HOST}}",
-            "RUN_OSA=false"
-            ]
-            common.run_script.call (
-              script: '{script}',
-              environment_vars: environment_vars
-            )
-          }}
-        }}
-      }}
+          common.conditionalStage(
+            stage_name: 'Deploy VMs',
+            stage: {
+              common.run_script (
+                script: 'deploy-vms.sh',
+                environment_vars: []
+              )
+            } //stage
+          ) //conditionalStage
+
+          common.conditionalStage(
+            stage_name: 'Setup OpenStack Ansible',
+            stage: {
+              common.run_script (
+                script: 'deploy-osa.sh',
+                environment_vars: [
+                "OSA_BRANCH=${env.OPENSTACK_ANSIBLE_BRANCH}",
+                "RUN_OSA=false"]
+              )
+            } //stage
+          ) //conditionalStage
+        } // dir
+      } // node


### PR DESCRIPTION
Based on the groovy script formatting in https://github.com/rcbops/rpc-gating/pull/4

I treated the pipeline as a job to just do the prepare step of the entire multi-node AIO, but we can change it into the full pipeline once the other pieces are complete. I also made the individual jobs that just run a single script, though I'm not sure if that's going to be our preferred method of running specific steps (instead of conditional stages).

https://rpc.jenkins.cit.rackspace.net/job/OnMetal_Multi_Node_AIO_Prepare_Deployment/

Connects https://github.com/rcbops/u-suk-dev/issues/1047