### PR TITLE
Remove node label from JJB job

### DIFF
--- a/rpc-jobs/jjb-setup.yml
+++ b/rpc-jobs/jjb-setup.yml
@@ -3,7 +3,6 @@
     description: Creates and updates jobs with Jenkins Job Builder.
     logrotate:
         daysToKeep: 20
-    node: general
     parameters:
         - string:
             name: JOBS


### PR DESCRIPTION
The CIT Jenkins slave doesn't have the general label by default, so
whenever it is reconfigured, that label is removed.

ITs better to not specify a label, then jenkins will automatically
allocate a slave based on the configuration of slaves.

connects rcbops/u-suk-dev#1070