### PR TITLE
Create jenkins instance inside __main__

### DIFF
--- a/scripts/jenkins_node.py
+++ b/scripts/jenkins_node.py
@@ -19,15 +19,7 @@ import os
 from jenkinsapi.jenkins import Jenkins
 
 
-username = os.environ.get("JENKINS_USERNAME")
-password = os.environ.get("JENKINS_API_KEY")
-jenkins_url = (os.environ.get("JENKINS_URL")
-               or "https://rpc.jenkins.cit.rackspace.net/")
-
-jenkins = Jenkins(baseurl=jenkins_url, username=username, password=password)
-
-
-def create_node(host_ip, name, credential_description, labels=None,
+def create_node(jenkins, host_ip, name, credential_description, labels=None,
                 remote_root_dir=None):
     node_dict = {
         "num_executors": 15,
@@ -47,7 +39,7 @@ def create_node(host_ip, name, credential_description, labels=None,
     jenkins.nodes.create_node(name, node_dict)
 
 
-def delete_node(name):
+def delete_node(jenkins, name):
     jenkins.delete_node(nodename=name)
 
 
@@ -64,10 +56,16 @@ if __name__ == "__main__":
                         help="Path to use as the home directory on the node")
     args = parser.parse_args()
 
+    username = os.environ.get("JENKINS_USERNAME")
+    password = os.environ.get("JENKINS_API_KEY")
+    jenkins_url = (os.environ.get("JENKINS_URL") or
+                   "https://rpc.jenkins.cit.rackspace.net/")
+    j = Jenkins(baseurl=jenkins_url, username=username, password=password)
+
     if args.action == "create":
-        create_node(host_ip=args.ip, name=args.name,
+        create_node(jenkins=j, host_ip=args.ip, name=args.name,
                     credential_description=args.creds,
                     labels=args.labels,
                     remote_root_dir=args.remote_dir)
     elif args.action == "delete":
-        delete_node(name=args.name)
+        delete_node(jenkins=j, name=args.name)


### PR DESCRIPTION
This minor update moves the creation of the jenkins instance into
\_\_main\_\_ so that the script can be run without having valid
jenkins environment vars set.