### PR TITLE
Wait for server startup tasks to finish

### DIFF
--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -28,9 +28,18 @@
       copy:
         content: '{{ rax.success|to_json }}'
         dest: '{{lookup("env", "WORKSPACE")}}/rpc-gating/playbooks/resources.json'
+
     - name: Write inventory
       copy:
         content: |
           [job_nodes]
           {% for instance in rax.success %} {{instance.name}} ansible_host={{instance.accessIPv4}}{% endfor %}
         dest: '{{lookup("env", "WORKSPACE")}}/rpc-gating/playbooks/inventory/hosts'
+
+    - name: Wait for SSH to be available on all hosts
+      wait_for: port=22 host="{{ item.accessIPv4 }}"
+      with_items: "{{ rax.success }}"
+
+    - name: Wait an additional amount of time for any remaning startup tasks to finish
+      pause:
+        minutes: 5


### PR DESCRIPTION
OnMetal servers take longer for SSH to be available, and the only way I've found to keep the Jenkins nodes from disconnecting after a few minutes is to wait before doing the first connection.

Connects rcbops/u-suk-dev#1115