### PR TITLE
Remove plugin dependencies

### DIFF
--- a/playbooks/install_jenkins_plugins.yml
+++ b/playbooks/install_jenkins_plugins.yml
@@ -27,9 +27,7 @@
         - shiningpanda
         - categorized-view
         - rebuild
-        - workflow-aggregator        # Pipeline Plugin
-        - workflow-cps               # Pipeline Groovy Plugin
-        - workflow-durable-task-step # Pipeline Nodes and Processes Plugin
+        - workflow-aggregator # Pipeline Plugin
         # This are installed by default by CIT
         # - ansible
         # - ansicolor


### PR DESCRIPTION
The plugins workflow-durable-task-step and workflow-cps are
dependencies of workflow-aggregator, and therefore do not need to be
listed in playbooks/install_jenkins_plugins.yml.  Having them present
seems to cause workflow-related plugins to get re-installed each time
this playbook runs.