### PR TITLE
CIT Stages: Add tempest testing stage

### DIFF
--- a/pipeline-steps/tempest.groovy
+++ b/pipeline-steps/tempest.groovy
@@ -1,0 +1,41 @@
+def tempest_install(){
+  common.openstack_ansible(
+    playbook: "os-tempest-install.yml",
+    path: "/opt/rpc-openstack/openstack-ansible/playbooks"
+  )
+}
+
+def tempest_run(Map args){
+  withEnv(["RUN_TEMPEST_OPTS=${env.RUN_TEMPEST_OPTS}"]){
+    sh """#!/bin/bash
+      utility_container="\$(lxc-ls |grep -m1 utility)"
+      lxc-attach \
+        --keep-env \
+        -n \$utility_container \
+        -- /opt/openstack_tempest_gate.sh \
+        ${env.TEMPEST_TEST_SETS}
+    """
+  }
+}
+/* if tempest install fails, don't bother trying to run or collect test results
+ * however if runnig fails, we should still collect the failed results
+ */
+def tempest(){
+  common.conditionalStage(
+    stage_name: "Tempest",
+    stage: {
+      tempest_install()
+      try{
+        tempest_run()
+      } catch (e){
+        print(e)
+        throw(e)
+      } finally{
+        sh "rm *tempest*.xml; cp /openstack/log/*utility*/**/*tempest*.xml . ||:"
+        junit allowEmptyResults: true, testResults: '*tempest*.xml'
+      } //finally
+    } //stage
+  ) //conditionalStage
+} //func
+
+return this;

--- a/rpc-jobs/RPC-AIO.yml
+++ b/rpc-jobs/RPC-AIO.yml
@@ -2,13 +2,18 @@
     name: RPC_AIO
     project-type: workflow
     concurrent: true
+    properties:
+      - build-discarder:
+          num-to-keep: 30
     parameters:
       # See params.yml
-      - single_use_slave_params
       - rpc_params
+      - rpc_gating_params
+      - single_use_slave_params
+      - tempest_params
       - string:
           name: STAGES
-          default: "Allocate Resources, Connect Slave, Prepare Deployment, Deploy, Cleanup"
+          default: "Allocate Resources, Connect Slave, Prepare Deployment, Deploy, Tempest, Cleanup"
           description: |
             Pipeline stages to run CSV. Note that this list does not influence execution order.
             Options:
@@ -16,6 +21,7 @@
               Connect Slave
               Prepare Deployment
               Deploy
+              Tempest
               Pause (use to hold instance for investigation before cleanup)
               Cleanup
       - text:
@@ -33,6 +39,8 @@
             ]
           description: |
             OSA/RPC playbooks to run.
+            Format: JSON list of dicts. Each dict must have keys playbook, path.
+             Optional keys: args. All values are strings.
 
     dsl: |
       // CIT Slave node
@@ -40,19 +48,29 @@
         try {
           dir("rpc-gating"){
               git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-              pubCloudSlave = load 'pipeline-steps/pubcloud.groovy'
               common = load 'pipeline-steps/common.groovy'
+              pubCloudSlave = load 'pipeline-steps/pubcloud.groovy'
               aio_prepare = load 'pipeline-steps/aio_prepare.groovy'
               deploy = load 'pipeline-steps/deploy.groovy'
+              tempest = load 'pipeline-steps/tempest.groovy'
           }
           instance_name = common.gen_instance_name()
           pubCloudSlave.getPubCloudSlave(instance_name: instance_name)
           node(instance_name){
-            aio_prepare.prepare()
-            deploy.deploy()
+            try {
+              aio_prepare.prepare()
+              deploy.deploy()
+              tempest.tempest()
+            } catch (e) {
+              print(e)
+              throw e
+            } finally {
+              common.archive_artifacts()
+            }
           } // pub cloud node
         } catch (e){
           currentBuild.result = 'FAILURE'
+          print(e)
           throw e
         } finally {
           pubCloudSlave.delPubCloudSlave()

--- a/rpc-jobs/params.yml
+++ b/rpc-jobs/params.yml
@@ -3,12 +3,6 @@
     name: single_use_slave_params
     parameters:
       - string:
-          name: RPC_GATING_REPO
-          default: "https://github.com/rcbops/rpc-gating"
-      - string:
-          name: RPC_GATING_BRANCH
-          default: "master"
-      - string:
           name: REGION
           default: "IAD"
       - string:
@@ -44,3 +38,19 @@
       - string:
           name: RPC_GATING_BRANCH
           default: "master"
+
+- parameter:
+    name: tempest_params
+    parameters:
+      - string:
+          name: "TEMPEST_TEST_SETS"
+          default: "scenario defcore cinder_backup"
+          description: |
+            Test sets (space seperated). Test sets are defined in
+            https://github.com/openstack/openstack-ansible-os_tempest/blob/master/templates/openstack_tempest_gate.sh.j2
+      - string:
+          name: "RUN_TEMPEST_OPTS"
+          default: "--serial"
+          description: |
+            Options to pass to run_tempest.sh via openstack_tempest_gate.sh
+            Note that both are deprecated and will be replaced in future.


### PR DESCRIPTION
 * Runs tempest playbook

 * Runs openstack-tempest-gate to execute tempest tests.

 * Adds try/catch within the single use slave block so that artifacts
   are retrieved before that node is destroyed

 * Adds shell script for collecting and compressing relevant logs and
   config. Compression is inconvenient but we don't have much space on
   the Jenkins master.

 * Adds tempest test result collection for display in the jenkins ui.

Connects rcbops/u-suk-dev#1130
Co-Authored-By: Matt Thompson <mattt@defunct.ca>