### PR TITLE
Install urllib3

### DIFF
--- a/rpc-jobs/install-jenkins-plugins.yml
+++ b/rpc-jobs/install-jenkins-plugins.yml
@@ -18,6 +18,10 @@
             git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
             common = load 'pipeline-steps/common.groovy'
             common.install_ansible()
+            sh """#!/bin/bash
+              . .venv/bin/activate
+              pip install urllib3==1.18.1
+            """
             common.venvPlaybook(
               playbooks: ["playbooks/install_jenkins_plugins.yml"],
               venv: ".venv",


### PR DESCRIPTION
CIT Jenkins has a python27-python-libs package w/ ssl that does not
support create_default_context and SSLContext, which are needed for
SNI handling.  ansible.module_utils.urls will fall back to using
urllib3 for SNI handling, however it uses a method that is no longer
available in urllib3.  As such, we have to install 1.18.1 specifically
so that ansible.module_utils.urls will detect the SNI support
correctly.

Side note, there is an ansible PR [1] to update
ansible.module_utils.urls accordingly.

[1] https://github.com/ansible/ansible/pull/19962

Connects https://github.com/rcbops/u-suk-dev/issues/1178