### PR TITLE
Dynamically build pyrax config

### DIFF
--- a/pipeline-steps/common.groovy
+++ b/pipeline-steps/common.groovy
@@ -244,4 +244,19 @@ def archive_artifacts(){
   }
 }
 
+def writePyraxCfg(Map args){
+  cfg = """[rackspace_cloud]
+username = ${args.username}
+api_key = ${args.api_key}
+"""
+
+  tmp_dir = pwd(tmp:true)
+  pyrax_cfg = "${tmp_dir}/.pyrax.cfg"
+  sh """
+    echo "${cfg}" > ${pyrax_cfg}
+  """
+
+  return pyrax_cfg
+}
+
 return this


### PR DESCRIPTION
Currently we store the pyrax config as a credential but we should store
individual cloud credentials instead.  This commit builds a pyrax
config and writes it to temporary space using existing credentials.

Additionally, we remove some unnecessary indentation in create and
cleanup in pubcloud.groovy.

Connects https://github.com/rcbops/u-suk-dev/issues/801