### PR TITLE
Credential cleanup

### DIFF
--- a/pipeline-steps/aio_prepare.groovy
+++ b/pipeline-steps/aio_prepare.groovy
@@ -19,13 +19,16 @@ def prepare(){
         } //color
       } //dir
       withCredentials([
-        usernamePassword(
-          credentialsId: "dev_pubcloud_user_key",
-          usernameVariable: "PUBCLOUD_USERNAME",
-          passwordVariable: "PUBCLOUD_APIKEY"
+        string(
+          credentialsId: "dev_pubcloud_username",
+          variable: "PUBCLOUD_USERNAME"
         ),
         string(
-          credentialsId: "dev_pubcloud_tennant",
+          credentialsId: "dev_pubcloud_api_key",
+          variable: "PUBCLOUD_API_KEY"
+        ),
+        string(
+          credentialsId: "dev_pubcloud_tenant_id",
           variable: "PUBCLOUD_TENANT_ID"
         )
       ]){

--- a/playbooks/aio_config.yml
+++ b/playbooks/aio_config.yml
@@ -42,7 +42,7 @@
       rackspace_cloud_auth_url: "https://identity.api.rackspacecloud.com/v2.0/"
       rackspace_cloud_tenant_id: "{{lookup('env', 'PUBCLOUD_TENANT_ID')}}"
       rackspace_cloud_username: "{{lookup('env', 'PUBCLOUD_USERNAME')}}"
-      rackspace_cloud_api_key: "{{lookup('env', 'PUBCLOUD_APIKEY')}}"
+      rackspace_cloud_api_key: "{{lookup('env', 'PUBCLOUD_API_KEY')}}"
 
   tasks:
     - name: write overrides


### PR DESCRIPTION
This commit oves from using the dev_pubcloud_user_key user/password
credential to using dev_pubcloud_username and dev_pubcloud_api_key
credential strings instead.

We also use the newly created credential dev_pubcloud_tenant_id
instead of dev_pubcloud_tennant.

Connects https://github.com/rcbops/u-suk-dev/issues/801