### PR TITLE
Multi-Node AIO: Tempest Tests

### DIFF
--- a/pipeline-steps/tempest.groovy
+++ b/pipeline-steps/tempest.groovy
@@ -5,11 +5,11 @@ def tempest_install(){
   )
 }
 
-def tempest_run(Map args){
+def tempest_run(Map args) {
   withEnv(["RUN_TEMPEST_OPTS=${env.RUN_TEMPEST_OPTS}"]){
     sh """#!/bin/bash
-      utility_container="\$(lxc-ls |grep -m1 utility)"
-      lxc-attach \
+      utility_container="\$(${args.wrapper} lxc-ls |grep -m1 utility)"
+      ${args.wrapper} lxc-attach \
         --keep-env \
         -n \$utility_container \
         -- /opt/openstack_tempest_gate.sh \
@@ -18,56 +18,39 @@ def tempest_run(Map args){
   }
 }
 
-def multi_node_tempest_run(Map args){
-  withEnv(["RUN_TEMPEST_OPTS=${env.RUN_TEMPEST_OPTS}"]) {
-    sh """#!/bin/bash
-      utility_container="\$(sudo ssh -T -oStrictHostKeyChecking=no infra1 lxc-ls |grep -m1 utility)"
-      sudo ssh -T -oStrictHostKeyChecking=no infra1 lxc-attach \
-        --keep-env
-        -n \$utility_container \
-        -- /opt/openstack_tempest_gate.sh \
-        ${env.TEMPEST_TEST_SETS}
-  """
-  }
-}
 
 /* if tempest install fails, don't bother trying to run or collect test results
- * however if runnig fails, we should still collect the failed results
+ * however if running fails, we should still collect the failed results
  */
-def tempest(){
+def tempest(Map args){
+  if (args != null && args.containsKey("vm")) {
+    wrapper = "sudo ssh -T -oStrictHostKeyChecking=no ${args.vm} "
+    copy_cmd = "scp -o StrictHostKeyChecking=no -p  -r infra1:"
+  } else{
+    wrapper = ""
+    copy_cmd = "cp -p "
+  }
   common.conditionalStage(
-    stage_name: "Tempest",
+    stage_name: "Install Tempest",
     stage: {
       tempest_install()
+    }
+  )
+  common.conditionalStage(
+    stage_name: "Tempest Tests",
+    stage: {
       try{
-        tempest_run()
+        tempest_run(wrapper: wrapper)
       } catch (e){
         print(e)
         throw(e)
       } finally{
-        sh "rm *tempest*.xml; cp /openstack/log/*utility*/**/*tempest*.xml . ||:"
+        sh "rm -f *tempest*.xml; ${copy_cmd}/openstack/log/*utility*/**/*tempest*.xml . ||:"
         junit allowEmptyResults: true, testResults: '*tempest*.xml'
       } //finally
     } //stage
   ) //conditionalStage
 } //func
 
-def multi_node_tempest(){
-  common.conditionalStage(
-    stage_name: "Tempest",
-    stage: {
-      tempest_install()
-      try{
-        multi_node_tempest_run()
-      } catch (e){
-        print(e)
-        throw(e)
-      } finally{
-        sh "rm *tempest*.xml; scp -o StrictHostKeyChecking=no -r infra1:/openstack/log/*utility*/**/*tempest*.xml . ||:"
-        junit allowEmptyResults: true, testResults: '*tempest*.xml'
-      } //finally
-    } //stage
-  ) //conditionalStage
-} //func
 
 return this;

--- a/pipeline-steps/tempest.groovy
+++ b/pipeline-steps/tempest.groovy
@@ -17,6 +17,20 @@ def tempest_run(Map args){
     """
   }
 }
+
+def multi_node_tempest_run(Map args){
+  withEnv(["RUN_TEMPEST_OPTS=${env.RUN_TEMPEST_OPTS}"]) {
+    sh """#!/bin/bash
+      utility_container="\$(sudo ssh -T -oStrictHostKeyChecking=no infra1 lxc-ls |grep -m1 utility)"
+      sudo ssh -T -oStrictHostKeyChecking=no infra1 lxc-attach \
+        --keep-env
+        -n \$utility_container \
+        -- /opt/openstack_tempest_gate.sh \
+        ${env.TEMPEST_TEST_SETS}
+  """
+  }
+}
+
 /* if tempest install fails, don't bother trying to run or collect test results
  * however if runnig fails, we should still collect the failed results
  */
@@ -32,6 +46,24 @@ def tempest(){
         throw(e)
       } finally{
         sh "rm *tempest*.xml; cp /openstack/log/*utility*/**/*tempest*.xml . ||:"
+        junit allowEmptyResults: true, testResults: '*tempest*.xml'
+      } //finally
+    } //stage
+  ) //conditionalStage
+} //func
+
+def multi_node_tempest(){
+  common.conditionalStage(
+    stage_name: "Tempest",
+    stage: {
+      tempest_install()
+      try{
+        multi_node_tempest_run()
+      } catch (e){
+        print(e)
+        throw(e)
+      } finally{
+        sh "rm *tempest*.xml; scp -o StrictHostKeyChecking=no -r infra1:/openstack/log/*utility*/**/*tempest*.xml . ||:"
         junit allowEmptyResults: true, testResults: '*tempest*.xml'
       } //finally
     } //stage

--- a/pipeline-steps/tempest.groovy
+++ b/pipeline-steps/tempest.groovy
@@ -6,16 +6,15 @@ def tempest_install(){
 }
 
 def tempest_run(Map args) {
-  withEnv(["RUN_TEMPEST_OPTS=${env.RUN_TEMPEST_OPTS}"]){
-    sh """#!/bin/bash
-      utility_container="\$(${args.wrapper} lxc-ls |grep -m1 utility)"
-      ${args.wrapper} lxc-attach \
-        --keep-env \
-        -n \$utility_container \
-        -- /opt/openstack_tempest_gate.sh \
-        ${env.TEMPEST_TEST_SETS}
-    """
-  }
+  sh """#!/bin/bash
+    utility_container="\$(${args.wrapper} lxc-ls |grep -m1 utility)"
+    ${args.wrapper} lxc-attach \
+      --keep-env \
+      -n \$utility_container \
+      -v RUN_TEMPEST_OPTS=${env.RUN_TEMPEST_OPTS} \
+      -- /opt/openstack_tempest_gate.sh \
+      ${env.TEMPEST_TEST_SETS}
+  """
 }
 
 

--- a/rpc-jobs/RPC-AIO.yml
+++ b/rpc-jobs/RPC-AIO.yml
@@ -13,7 +13,7 @@
       - tempest_params
       - string:
           name: STAGES
-          default: "Allocate Resources, Connect Slave, Prepare Deployment, Deploy, Tempest, Cleanup"
+          default: "Allocate Resources, Connect Slave, Prepare Deployment, Deploy, Install Tempest, Tempest Tests, Cleanup"
           description: |
             Pipeline stages to run CSV. Note that this list does not influence execution order.
             Options:
@@ -21,7 +21,8 @@
               Connect Slave
               Prepare Deployment
               Deploy
-              Tempest
+              Install Tempest
+              Tempest Tests
               Pause (use to hold instance for investigation before cleanup)
               Cleanup
       - text:

--- a/rpc-jobs/multi-node-aio.yml
+++ b/rpc-jobs/multi-node-aio.yml
@@ -7,6 +7,7 @@
     parameters:
       - rpc_gating_params
       - rpc_params
+      - tempest_params
       - string:
           name: OSA_OPS_REPO
           default: https://github.com/openstack/openstack-ansible-ops
@@ -47,7 +48,7 @@
           name: STAGES
           default: |
             Allocate Resources, Connect Slave, Setup Host, Setup Cobbler, Setup Virtual Networks,
-            Deploy VMs, Setup OpenStack Ansible, Prepare Configs, Deploy RPC w/ Script, Cleanup
+             Deploy VMs, Setup OpenStack Ansible, Prepare Configs, Deploy RPC w/ Script, Tempest, Cleanup
           description: |
             Pipeline stages to run CSV. Note that this list does not influence execution order.
             Options:
@@ -60,6 +61,7 @@
               Setup OpenStack Ansible
               Prepare Configs
               Deploy RPC w/ Script
+              Tempest
               Pause (use to hold instance for investigation before cleanup)
               Cleanup
 
@@ -72,6 +74,7 @@
             common = load 'pipeline-steps/common.groovy'
             multi_node_aio_prepare = load 'pipeline-steps/multi_node_aio_prepare.groovy'
             deploy = load 'pipeline-steps/deploy.groovy'
+            tempest = load 'pipeline-steps/tempest.groovy'
           }
           instance_name = common.gen_instance_name()
           pubCloudSlave.getPubCloudSlave(instance_name: instance_name)
@@ -83,11 +86,12 @@
                 "FORKS=10",
                 "DEPLOY_HAPROXY=yes",
                 "DEPLOY_ELK=yes",
-                "DEPLOY_TEMPEST=yes",
+                "DEPLOY_TEMPEST=no",
                 "DEPLOY_AIO=no",
                 "DEPLOY_MAAS=no"
                 ]
             ) // deploy_sh
+            tempest.multi_node_tempest()
 
           }// public cloud node
         } catch (e){

--- a/rpc-jobs/multi-node-aio.yml
+++ b/rpc-jobs/multi-node-aio.yml
@@ -48,7 +48,8 @@
           name: STAGES
           default: |
             Allocate Resources, Connect Slave, Setup Host, Setup Cobbler, Setup Virtual Networks,
-             Deploy VMs, Setup OpenStack Ansible, Prepare Configs, Deploy RPC w/ Script, Tempest, Cleanup
+             Deploy VMs, Setup OpenStack Ansible, Prepare Configs, Deploy RPC w/ Script, Install Tempest,
+             Tempest Tests, Cleanup
           description: |
             Pipeline stages to run CSV. Note that this list does not influence execution order.
             Options:
@@ -61,7 +62,8 @@
               Setup OpenStack Ansible
               Prepare Configs
               Deploy RPC w/ Script
-              Tempest
+              Install Tempest
+              Tempest Tests
               Pause (use to hold instance for investigation before cleanup)
               Cleanup
 
@@ -91,7 +93,7 @@
                 "DEPLOY_MAAS=no"
                 ]
             ) // deploy_sh
-            tempest.multi_node_tempest()
+            tempest.tempest(vm: "infra1")
 
           }// public cloud node
         } catch (e){


### PR DESCRIPTION
I couldn't find a way for Jenkins to switch context from the host node to a VM on the host node, so I added some parameters in order to have the same commands work for both AIO and multi-node AIO. 

I did some separate work not in this PR to run openstack_tempest_gate.sh using ansible, similar to how this script does it: https://github.com/openstack/openstack-ansible/blob/stable/newton/scripts/run-tempest.sh If that's a more preferable way, I can close this PR and open one with those changes.

Connects https://github.com/rcbops/u-suk-dev/issues/1093