### PR TITLE
Ignore failure to remove tempest results.

### DIFF
--- a/pipeline-steps/tempest.groovy
+++ b/pipeline-steps/tempest.groovy
@@ -31,7 +31,10 @@ def tempest(){
         print(e)
         throw(e)
       } finally{
-        sh "rm *tempest*.xml; cp /openstack/log/*utility*/**/*tempest*.xml . ||:"
+        sh """#!/bin/bash
+          rm *tempest*.xml ||:
+          cp /openstack/log/*utility*/**/*tempest*.xml . ||:"
+        """
         junit allowEmptyResults: true, testResults: '*tempest*.xml'
       } //finally
     } //stage


### PR DESCRIPTION
If there isn't an existing results file, it doesn't matter that it
couldn't be removed.

Connects rcbops/u-suk-dev#1130