### PR TITLE
Add multi-node AIO MaaS deployment/verification

### DIFF
--- a/pipeline-steps/aio_prepare.groovy
+++ b/pipeline-steps/aio_prepare.groovy
@@ -19,33 +19,10 @@ def prepare(){
           } //env
         } //color
       } //dir
-      withCredentials([
-        string(
-          credentialsId: "dev_pubcloud_username",
-          variable: "PUBCLOUD_USERNAME"
-        ),
-        string(
-          credentialsId: "dev_pubcloud_api_key",
-          variable: "PUBCLOUD_API_KEY"
-        ),
-        string(
-          credentialsId: "dev_pubcloud_tenant_id",
-          variable: "PUBCLOUD_TENANT_ID"
-        )
-      ]){
-        dir("/opt/rpc-gating"){
-          git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-        } //dir
-        dir("/opt/rpc-gating/playbooks"){
-          common.install_ansible()
-          common.venvPlaybook(
-            playbooks: ["aio_config.yml"],
-            venv: ".venv",
-            args: [ "-i inventory" ]
-          )
-        } //dir
-      } //withCredentials
+      common.prepareConfigs(
+        deployment_type: "aio"
+      )
     } //stage param
-  ) //conditional stage
+  )
 }
 return this;

--- a/pipeline-steps/common.groovy
+++ b/pipeline-steps/common.groovy
@@ -269,4 +269,36 @@ api_key = ${args.api_key}
   return pyrax_cfg
 }
 
+def prepareConfigs(Map args){
+  withCredentials([
+    string(
+      credentialsId: "dev_pubcloud_username",
+      variable: "PUBCLOUD_USERNAME"
+    ),
+    string(
+      credentialsId: "dev_pubcloud_api_key",
+      variable: "PUBCLOUD_API_KEY"
+    ),
+    string(
+      credentialsId: "dev_pubcloud_tenant_id",
+      variable: "PUBCLOUD_TENANT_ID"
+    )
+    ]){
+      dir("/opt/rpc-gating"){
+        git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
+      } //dir
+      dir("/opt/rpc-gating/playbooks"){
+        common.install_ansible()
+        common.venvPlaybook(
+          playbooks: ["aio_config.yml"],
+          venv: ".venv",
+          args: [
+            "-i inventory",
+            "--extra-vars \"@vars/${args.deployment_type}.yml\""
+          ]
+        )
+      } //dir
+  } //withCredentials
+}
+
 return this

--- a/pipeline-steps/maas.groovy
+++ b/pipeline-steps/maas.groovy
@@ -1,0 +1,67 @@
+def prepare(Map args) {
+  common.conditionalStage(
+    stage_name: 'Prepare MaaS',
+    stage: {
+      withCredentials([
+        string(
+          credentialsId: "dev_pubcloud_username",
+          variable: "PUBCLOUD_USERNAME"
+        ),
+        string(
+          credentialsId: "dev_pubcloud_api_key",
+          variable: "PUBCLOUD_API_KEY"
+        ),
+        string(
+          credentialsId: "dev_pubcloud_tenant_id",
+          variable: "PUBCLOUD_TENANT_ID"
+        )
+      ]){
+        dir("rpc-gating/playbooks"){
+          pyrax_cfg = common.writePyraxCfg(
+            username: env.PUBCLOUD_USERNAME,
+            api_key: env.PUBCLOUD_API_KEY
+          )
+          withEnv(["RAX_CREDS_FILE=${pyrax_cfg}"]){
+            common.venvPlaybook(
+              playbooks: ['aio-maas-entities.yml'],
+              venv: ".venv",
+              args: [
+                "-e server_name=\"${args.instance_name}\""
+              ],
+              vars: args
+            )
+          } // withEnv
+        } // dir
+      } // withCredentials
+    } // stage
+  ) // conditionalStage
+}
+
+def deploy() {
+  common.conditionalStage(
+    stage_name: 'Setup MaaS',
+    stage: {
+      common.prepareConfigs(
+        deployment_type: "onmetal"
+      )
+      common.openstack_ansible(
+        path: '/opt/rpc-openstack/rpcd/playbooks',
+        playbook: 'setup-maas.yml'
+      ) //openstack_ansible
+    } //stage
+  ) //conditionalStage
+}
+
+def verify() {
+  common.conditionalStage(
+    stage_name: 'Verify MaaS',
+    stage: {
+      common.openstack_ansible(
+        path: '/opt/rpc-openstack/rpcd/playbooks',
+        playbook: 'verify-maas.yml'
+      ) //openstack_ansible
+    } //stage
+  ) //conditionalStage
+}
+
+return this;

--- a/pipeline-steps/multi_node_aio_prepare.groovy
+++ b/pipeline-steps/multi_node_aio_prepare.groovy
@@ -56,4 +56,5 @@ def prepare() {
     } //stage
   ) //conditionalStage
 }
+
 return this;

--- a/playbooks/aio-maas-cleanup.yml
+++ b/playbooks/aio-maas-cleanup.yml
@@ -1,0 +1,19 @@
+---
+- hosts: localhost
+  connection: local
+  vars:
+    entity_labels:
+      - "cinder1.{{ server_name }}"
+      - "cinder2.{{ server_name }}"
+      - "compute2.{{ server_name }}"
+      - "infra1.{{ server_name }}"
+      - "infra2.{{ server_name }}"
+      - "logging1.{{ server_name }}"
+      - "infra3.{{ server_name }}"
+      - "swift1.{{ server_name }}"
+      - "swift3.{{ server_name }}"
+      - "swift2.{{ server_name }}"
+      - "compute1.{{ server_name }}"
+      - "loadbalancer1.{{ server_name }}"
+  roles:
+    - { role: maas-entities, state: 'absent'}

--- a/playbooks/aio-maas-entities.yml
+++ b/playbooks/aio-maas-entities.yml
@@ -1,0 +1,19 @@
+---
+- hosts: localhost
+  connection: local
+  vars:
+    entity_labels:
+      - "cinder1.{{ server_name }}"
+      - "cinder2.{{ server_name }}"
+      - "compute2.{{ server_name }}"
+      - "infra1.{{ server_name }}"
+      - "infra2.{{ server_name }}"
+      - "logging1.{{ server_name }}"
+      - "infra3.{{ server_name }}"
+      - "swift1.{{ server_name }}"
+      - "swift3.{{ server_name }}"
+      - "swift2.{{ server_name }}"
+      - "compute1.{{ server_name }}"
+      - "loadbalancer1.{{ server_name }}"
+  roles:
+    - { role: maas-entities, state: 'present'}

--- a/playbooks/aio_config.yml
+++ b/playbooks/aio_config.yml
@@ -1,46 +1,8 @@
 ---
 - hosts: localhost
   user: root
-  vars:
-    gating_overrides_file: "/etc/openstack_deploy/user_zzz_gating_variables.yml"
-
-    gating_overrides:
-      # (alextricity25) Adding the cirros_*_url vars. This var has been dropped from OSA in
-      # newton so we are carrying it here so we have support for both newton and earlier releases.
-      cirros_tgz_url: "http://download.cirros-cloud.net/{{ '{{' }} cirros_version {{ '}}' }}/cirros-{{ '{{' }}cirros_version{{ '}}' }}-x86_64-uec.tar.gz"
-      cirros_img_url: "http://rpc-repo.rackspace.com/rpcgating/cirros-0.3.4-x86_64-dropbearmod.img"
-      # (alextricity25) This variable is used to populate the image directives in tempest.conf in stable/newton.
-      # We can't rely on the upstream value of this variable to be the same as cirros_img_url, so we also
-      # override this variable here.
-      tempest_image_file: "cirros-0.3.4-x86_64-dropbearmod.img"
-      tempest_images:
-        - url: "{{ '{{' }}cirros_img_url{{ '}}' }}"
-          sha256: "ec1120a9310ac3987feee4e3c5108d5d0fd0e594c4283804c17d673ebb2d3769"
-        - url: "{{ '{{' }}cirros_tgz_url{{ '}}' }}"
-          sha256: "95e77c7deaf0f515f959ffe329918d5dd23e417503d1d45e926a888853c90710"
-      tempest_tempest_conf_overrides:
-        volume-feature-enabled:
-          snapshot: True
-
-      # Ensure raw_multi_journal is False for upgrades.
-      # This is because of the way migrate-yaml.py behaves with the
-      # '--for-testing-take-new-vars-only'; meaning that the new
-      # default variables will be set in the user_*_variables_overrides.yml
-      # file. Since raw_multi_journal is set to False as part of the deploy.sh
-      # process, but is set to True in Mitaka's
-      # user_rpco_user_variables_defaults.yml file, this will result in
-      # migrate-yaml.py adding 'raw_multi_journal: True' in the overrides.
-      # To avoid this behavior in gate, it is overridden here.
-      # The same is true for journal_size, and maas_notification_plan.
-      raw_multi_journal: false
-      journal_size: 1024
-      maas_notification_plan: npTechnicalContactsEmail
-      osd_directory: true
-      rackspace_cloud_auth_url: "https://identity.api.rackspacecloud.com/v2.0/"
-      rackspace_cloud_tenant_id: "{{lookup('env', 'PUBCLOUD_TENANT_ID')}}"
-      rackspace_cloud_username: "{{lookup('env', 'PUBCLOUD_USERNAME')}}"
-      rackspace_cloud_api_key: "{{lookup('env', 'PUBCLOUD_API_KEY')}}"
-
+  vars_files:
+    - vars/all.yml
   tasks:
     - name: write overrides
       copy:

--- a/playbooks/roles/maas-entities/tasks/main.yml
+++ b/playbooks/roles/maas-entities/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Create or delete entities for each host
+  local_action:
+      module: rax_mon_entity
+      username: "{{ lookup('env', 'PUBCLOUD_USERNAME') }}"
+      api_key: "{{ lookup('env', 'PUBCLOUD_API_KEY') }}"
+      state: "{{ state }}"
+      label: "{{ item }}"
+      region: "{{ lookup('env', 'REGION') }}"
+  with_items: "{{ entity_labels }}"

--- a/playbooks/vars/aio.yml
+++ b/playbooks/vars/aio.yml
@@ -1,0 +1,35 @@
+---
+gating_overrides:
+  # (alextricity25) Adding the cirros_*_url vars. This var has been dropped
+  # from OSA in newton so we are carrying it here so we have support for both
+  # newton and earlier releases.
+  cirros_tgz_url: "http://download.cirros-cloud.net/{{ '{{' }} cirros_version {{ '}}' }}/cirros-{{ '{{' }}cirros_version{{ '}}' }}-x86_64-uec.tar.gz"
+  cirros_img_url: "http://rpc-repo.rackspace.com/rpcgating/cirros-0.3.4-x86_64-dropbearmod.img"
+
+  # (alextricity25) This variable is used to populate the image directives in
+  # tempest.conf in stable/newton.
+  # We can't rely on the upstream value of this variable to be the same as
+  # cirros_img_url, so we also override this variable here.
+  tempest_image_file: "cirros-0.3.4-x86_64-dropbearmod.img"
+  tempest_images:
+    - url: "{{ '{{' }}cirros_img_url{{ '}}' }}"
+      sha256: "ec1120a9310ac3987feee4e3c5108d5d0fd0e594c4283804c17d673ebb2d3769"
+    - url: "{{ '{{' }}cirros_tgz_url{{ '}}' }}"
+      sha256: "95e77c7deaf0f515f959ffe329918d5dd23e417503d1d45e926a888853c90710"
+  tempest_tempest_conf_overrides:
+    volume-feature-enabled:
+      snapshot: "True"
+
+  # Ensure raw_multi_journal is False for upgrades.
+  # This is because of the way migrate-yaml.py behaves with the
+  # '--for-testing-take-new-vars-only'; meaning that the new
+  # default variables will be set in the user_*_variables_overrides.yml
+  # file. Since raw_multi_journal is set to False as part of the deploy.sh
+  # process, but is set to True in Mitaka's
+  # user_rpco_user_variables_defaults.yml file, this will result in
+  # migrate-yaml.py adding 'raw_multi_journal: True' in the overrides.
+  # To avoid this behavior in gate, it is overridden here.
+  # The same is true for journal_size, and maas_notification_plan.
+  raw_multi_journal: "False"
+  journal_size: 1024
+  osd_directory: "True"

--- a/playbooks/vars/all.yml
+++ b/playbooks/vars/all.yml
@@ -1,0 +1,9 @@
+---
+gating_overrides_file: "/etc/openstack_deploy/user_zzz_gating_variables.yml"
+
+gating_overrides:
+  maas_notification_plan: npTechnicalContactsEmail
+  rackspace_cloud_auth_url: "https://identity.api.rackspacecloud.com/v2.0/"
+  rackspace_cloud_tenant_id: "{{lookup('env', 'PUBCLOUD_TENANT_ID')}}"
+  rackspace_cloud_username: "{{lookup('env', 'PUBCLOUD_USERNAME')}}"
+  rackspace_cloud_api_key: "{{lookup('env', 'PUBCLOUD_API_KEY')}}"

--- a/playbooks/vars/onmetal.yml
+++ b/playbooks/vars/onmetal.yml
@@ -1,0 +1,7 @@
+---
+gating_overrides:
+  maas_fqdn_extension: ".{{ lookup('env', 'NODE_NAME') }}"
+  memory_used_percentage_warning_threshold: 99.0
+  memory_used_percentage_critical_threshold: 99.5
+  net_max_speed: 1000
+  lb_name: "{{ lookup('env', 'NODE_NAME') }}"

--- a/rpc-jobs/multi-node-aio.yml
+++ b/rpc-jobs/multi-node-aio.yml
@@ -2,7 +2,7 @@
     name: 'OnMetal_Multi_Node_AIO'
     project-type: workflow
     build-discarder:
-        days-to-keep: 30
+      days-to-keep: 30
     concurrent: true
     parameters:
       - rpc_gating_params
@@ -45,9 +45,11 @@
       - string:
           name: STAGES
           default: |
-            Allocate Resources, Connect Slave, Prepare Multi-Node AIO, Prepare RPC Configs,
-             Deploy RPC w/ Script, Install Tempest, Tempest Tests, Prepare Horizon Selenium,
-             Horizon Tests, Prepare Kibana Selenium, Kibana Tests, Cleanup
+            Allocate Resources, Connect Slave, Prepare Multi-Node AIO,
+             Prepare RPC Configs, Deploy RPC w/ Script, Prepare MaaS,
+             Setup MaaS, Verify MaaS, Install Tempest, Tempest Tests,
+             Prepare Horizon Selenium, Horizon Tests, Prepare Kibana Selenium,
+             Kibana Tests, Cleanup
           description: |
             Pipeline stages to run CSV. Note that this list does not influence execution order.
             Options:
@@ -56,6 +58,9 @@
               Prepare Multi-Node AIO
               Prepare RPC Configs
               Deploy RPC w/ Script
+              Prepare MaaS
+              Setup MaaS
+              Verify MaaS
               Install Tempest
               Tempest Tests
               Prepare Horizon Selenium
@@ -74,6 +79,7 @@
             common = load 'pipeline-steps/common.groovy'
             multi_node_aio_prepare = load 'pipeline-steps/multi_node_aio_prepare.groovy'
             deploy = load 'pipeline-steps/deploy.groovy'
+            maas = load 'pipeline-steps/maas.groovy'
             tempest = load 'pipeline-steps/tempest.groovy'
             horizon = load 'pipeline-steps/horizon.groovy'
             kibana = load 'pipeline-steps/kibana.groovy'
@@ -81,6 +87,7 @@
           instance_name = common.gen_instance_name()
           pubCloudSlave.getPubCloudSlave(instance_name: instance_name)
 
+          maas.prepare(instance_name: instance_name)
           node(instance_name){
             multi_node_aio_prepare.prepare()
             deploy.deploy_sh(
@@ -93,6 +100,8 @@
                 "DEPLOY_MAAS=no"
                 ]
             ) // deploy_sh
+            maas.deploy()
+            maas.verify()
             tempest.tempest(vm: "infra1")
             horizon.horizon_integration()
             kibana.kibana()


### PR DESCRIPTION
Add `deploy_maas` function which configures MaaS, creates entities, and runs the MaaS setup and verification playbooks.

Add MaaS entitiy cleanup playbook to the main cleanup function.

Connects https://github.com/rcbops/u-suk-dev/issues/1125