### PR TITLE
Install ansible before cleanup

### DIFF
--- a/pipeline-steps/pubcloud.groovy
+++ b/pipeline-steps/pubcloud.groovy
@@ -68,6 +68,7 @@ def cleanup(){
       )
     ]){
       dir("rpc-gating/playbooks"){
+        common.install_ansible()
         pyrax_cfg = common.writePyraxCfg(
           username: env.PUBCLOUD_USERNAME,
           api_key: env.PUBCLOUD_API_KEY


### PR DESCRIPTION
Ran into an issue where I was trying to run just the clean up step on an old server, but it failed because the virtualenv wasn't installed in that particular workspace (since parallel runs create separate workspaces).