### PR TITLE
Add Mitaka Horizon selenium integration tests

### DIFF
--- a/pipeline-steps/horizon.groovy
+++ b/pipeline-steps/horizon.groovy
@@ -1,0 +1,83 @@
+def horizon_integration(){
+  common.conditionalStage(
+    stage_name: "Prepare Horizon Selenium",
+    stage: {
+      if (env.RPC_BRANCH.contains("mitaka") || env.RPC_BRANCH.contains("r13.")) {
+        mitaka_prep()
+      }
+    }
+  )
+  common.conditionalStage(
+    stage_name: "Horizon Tests",
+    stage: {
+      if (env.RPC_BRANCH.contains("mitaka") || env.RPC_BRANCH.contains("r13.")) {
+        mitaka_tests()
+      }
+    }
+  )
+}
+
+def mitaka_prep() {
+  dir("horizon") {
+    git url: "https://github.com/openstack/horizon.git", branch: "stable/mitaka"
+
+    sh """#!/bin/bash
+    apt-get install -y xvfb firefox
+    apt-get remove -y firefox
+    wget -q https://ftp.mozilla.org/pub/firefox/releases/44.0/linux-x86_64/en-US/firefox-44.0.tar.bz2
+    tar -xjf firefox-44.0.tar.bz2
+    mv firefox /opt/firefox44/
+    ln -s /opt/firefox44/firefox /usr/bin/firefox
+
+    if [[ ! -d ".venv" ]]; then
+        pip install virtualenv
+        virtualenv .venv
+    fi
+    source .venv/bin/activate
+
+    mv ~/.pip/pip.conf ~/.pip/pip.conf.bak
+    pip install selenium==2.53.1
+    pip install -r test-requirements.txt
+    pip install -r requirements.txt
+    mv ~/.pip/pip.conf.bak ~/.pip/pip.conf
+    """
+  }
+}
+
+def mitaka_tests(){
+    try {
+      dir("horizon") {
+        git url: "https://github.com/openstack/horizon.git", branch: "stable/mitaka"
+
+        sh """#!/bin/bash
+        # Create Horizon config file
+        export DASHBOARD_URL=\$(sudo grep external_lb_vip_address /etc/openstack_deploy/openstack_user_config.yml | awk '{print \$2}')
+        export DASHBOARD_URL=https://\$(echo \$DASHBOARD_URL | tr -d '\"')
+        sed -i "/dashboard_url/c\\dashboard_url=\$DASHBOARD_URL" openstack_dashboard/test/integration_tests/horizon.conf
+
+        set +x
+        sed -i "s/^password=.*/password=demo/g" openstack_dashboard/test/integration_tests/horizon.conf
+        export ADMIN_PWD=\$(sudo grep keystone_auth_admin_password /etc/openstack_deploy/user_osa_secrets.yml | awk '{print \$2}')
+        sed -i "s/^admin_password=.*/admin_password=\$ADMIN_PWD/g" openstack_dashboard/test/integration_tests/horizon.conf
+        set -x
+
+        # Run Horizon tests
+        source .venv/bin/activate
+        export TMP_CONF="/tmp/\${BUILD_TAG}_horizon_conf"
+        mv openstack_dashboard/test/integration_tests/horizon.conf \$TMP_CONF
+        export HORIZON_INTEGRATION_TESTS_CONFIG_FILE=\$TMP_CONF
+
+        export NOSE_WITH_XUNIT=1
+        rm -f nosetests.xml
+        ./run_tests.sh -N --selenium-headless --integration
+        """
+      }
+    } catch (e){
+      print(e)
+      throw(e)
+    } finally {
+      junit allowEmptyResults: true, testResults: 'horizon/nosetests.xml'
+    }
+}
+
+return this;

--- a/rpc-jobs/multi-node-aio.yml
+++ b/rpc-jobs/multi-node-aio.yml
@@ -34,12 +34,10 @@
           name: OPENSTACK_ANSIBLE_BRANCH
           default: stable/newton
           description: Openstack Ansible branch to use in setup
-      - choice:
+      - string:
           name: DEFAULT_IMAGE
-          description: Version of Ubuntu image to use for VMs (14.04.4 or 16.04)
-          choices:
-            - '16.04'
-            - '14.04.4'
+          description: Version of Ubuntu image to use for VMs (14.04.5 or 16.04.2)
+          default: '16.04.2'
       - bool:
           name: PARTITION_HOST
           default: true
@@ -48,7 +46,8 @@
           name: STAGES
           default: |
             Allocate Resources, Connect Slave, Prepare Multi-Node AIO, Prepare RPC Configs,
-             Deploy RPC w/ Script, Install Tempest, Tempest Tests, Cleanup
+             Deploy RPC w/ Script, Install Tempest, Tempest Tests, Prepare Horizon Selenium,
+             Horizon Tests, Cleanup
           description: |
             Pipeline stages to run CSV. Note that this list does not influence execution order.
             Options:
@@ -59,6 +58,8 @@
               Deploy RPC w/ Script
               Install Tempest
               Tempest Tests
+              Prepare Horizon Selenium
+              Horizon Tests
               Pause (use to hold instance for investigation before cleanup)
               Cleanup
 
@@ -72,6 +73,7 @@
             multi_node_aio_prepare = load 'pipeline-steps/multi_node_aio_prepare.groovy'
             deploy = load 'pipeline-steps/deploy.groovy'
             tempest = load 'pipeline-steps/tempest.groovy'
+            horizon = load 'pipeline-steps/horizon.groovy'
           }
           instance_name = common.gen_instance_name()
           pubCloudSlave.getPubCloudSlave(instance_name: instance_name)
@@ -89,6 +91,7 @@
                 ]
             ) // deploy_sh
             tempest.tempest(vm: "infra1")
+            horizon.horizon_integration()
 
           }// public cloud node
         } catch (e){


### PR DESCRIPTION
The Horizon integration test suite is no longer supported in Newton, and there's only a stable branch going back to Mitaka, so these particular tests will run only for Mitaka builds.

Connects https://github.com/rcbops/u-suk-dev/issues/1124