### PR TITLE
Remove variable file for multi node AIO setup

### DIFF
--- a/pipeline-steps/multi_node_aio_prepare.groovy
+++ b/pipeline-steps/multi_node_aio_prepare.groovy
@@ -6,13 +6,27 @@ def prepare() {
     common.conditionalStage(
       stage_name: 'Prepare Multi-Node AIO',
       stage: {
+        sh """
+        rm -f variables.sh
+        """
         common.run_script(
           script: 'build.sh',
           environment_vars: [
             "PARTITION_HOST=${env.PARTITION_HOST}",
             "NETWORK_BASE=172.29",
+            "DNS_NAMESERVER=8.8.8.8",
+            "OVERRIDE_SOURCES=true",
+            "DEVICE_NAME=vda",
+            "DEFAULT_NETWORK=eth0",
+            "VM_DISK_SIZE=252",
             "DEFAULT_IMAGE=${env.DEFAULT_IMAGE}",
             "OSA_BRANCH=${env.OPENSTACK_ANSIBLE_BRANCH}",
+            "SETUP_HOST=true",
+            "PARTITION_HOST=true",
+            "SETUP_VIRSH_NET=true",
+            "VM_IMAGE_CREATE=true",
+            "DEPLOY_OSA=true",
+            "PRE_CONFIG_OSA=true",
             "RUN_OSA=false"]
         )
       } //stage


### PR DESCRIPTION
The multi-node setup has a variables.sh file now that takes precedent over environment variables, so I'm removing that file completely. I've got a review open to fix setup-host.sh, so once that merges, I'll test this change out.

https://review.openstack.org/#/c/436700/
https://review.openstack.org/#/c/437040/

Connects https://github.com/rcbops/u-suk-dev/issues/1274