### PR TITLE
[WIP] 1080 Global Library and RPC-Gating lint job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu
+RUN apt-get update && apt-get install -y groovy2 python-pip build-essential python-dev libssl-dev
+RUN apt-get install -y libffi-dev
+RUN apt-get install -y sudo
+RUN pip install jenkins-job-builder ansible
+RUN useradd jenkins --shell /bin/bash --create-home --uid 500
+RUN echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,39 @@
+properties([
+  parameters([
+    string(name: 'REGION',
+           defaultValue: 'IAD'),
+    string(name: 'FLAVOR',
+           defaultValue: '2'),
+    string(name: 'IMAGE',
+           defaultValue: 'Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)'),
+    string(name: 'STAGES',
+           defaultValue: 'Allocate Resources, Connect Slave, Cleanup'),
+    string(name: 'INSTANCE_NAME_RAW',
+           defaultValue: 'AUTO'),
+    string(name: 'RPC_GATING_REPO',
+           defaultValue: 'https://github.com/rcbops/rpc-gating'),
+    string(name: 'RPC_GATING_BRANCH',
+           defaultValue: 'bug/1080_globallib')
+  ]) //parameters
+]) //properties
+
+node(){
+  deleteDir()
+  checkout scm
+  sh "env"
+  pubcloud.runonpubcloud(step: {
+    stage("Prepare"){
+      sh """#!/bin/bash
+        apt-get update
+        apt-get -y install groovy2
+        pip install jenkins-job-builder
+      """
+    }
+    stage("checkout"){
+      checkout scm
+    }
+    stage("lint"){
+      sh "./lint.sh"
+    }
+  })
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,39 +1,16 @@
-properties([
-  parameters([
-    string(name: 'REGION',
-           defaultValue: 'IAD'),
-    string(name: 'FLAVOR',
-           defaultValue: '2'),
-    string(name: 'IMAGE',
-           defaultValue: 'Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)'),
-    string(name: 'STAGES',
-           defaultValue: 'Allocate Resources, Connect Slave, Cleanup'),
-    string(name: 'INSTANCE_NAME_RAW',
-           defaultValue: 'AUTO'),
-    string(name: 'RPC_GATING_REPO',
-           defaultValue: 'https://github.com/rcbops/rpc-gating'),
-    string(name: 'RPC_GATING_BRANCH',
-           defaultValue: 'bug/1080_globallib')
-  ]) //parameters
-]) //properties
-
+properties([])
 node(){
   deleteDir()
-  checkout scm
-  sh "env"
-  pubcloud.runonpubcloud(step: {
-    stage("Prepare"){
-      sh """#!/bin/bash
-        apt-get update
-        apt-get -y install groovy2
-        pip install jenkins-job-builder
-      """
-    }
+  stage("Prepare"){
+    checkout scm
+    lint_container = docker.build 'lint'
+  }
+  lint_container.inside {
     stage("checkout"){
       checkout scm
     }
     stage("lint"){
-      sh "./lint.sh"
+      sh "sudo ./lint.sh 2>&1"
     }
-  })
+  }
 }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
  - pipeline-steps: Groovy Functions for use in pipelines
  - playbooks: Ansible Playbooks
  - scripts: Bash scripts
+ - vars: link to pipeline-steps as thats the expected location of groovy
+   files for jenkins plugin cps-global-lib.
 
 
 ## Git Hooks

--- a/pipeline-steps/aio_prepare.groovy
+++ b/pipeline-steps/aio_prepare.groovy
@@ -32,9 +32,7 @@ def prepare(){
           variable: "PUBCLOUD_TENANT_ID"
         )
       ]){
-        dir("/opt/rpc-gating"){
-          git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-        } //dir
+        common.clone_rpc_gating("/opt/rpc-gating")
         dir("/opt/rpc-gating/playbooks"){
           ansiblePlaybook playbook: "aio_config.yml"
         } //dir

--- a/pipeline-steps/common.groovy
+++ b/pipeline-steps/common.groovy
@@ -10,12 +10,15 @@ def install_ansible(){
         virtualenv --python=/opt/rh/python27/root/usr/bin/python .venv
     fi
     # hack the selinux module into the venv
+    virtualenv --relocatable .venv
     cp -r /usr/lib64/python2.6/site-packages/selinux .venv/lib64/python2.7/site-packages/
     source .venv/bin/activate
 
     # These pip commands cannot be combined into one.
     pip install -U six packaging appdirs
     pip install -U setuptools pip
+    # installing pip resets the shebang to be absolute
+    virtualenv --relocatable .venv
     pip install -U ansible pyrax
   """
 }

--- a/pipeline-steps/common.groovy
+++ b/pipeline-steps/common.groovy
@@ -195,7 +195,7 @@ def acronym(Map args){
 
 def gen_instance_name(){
   if (env.INSTANCE_NAME == "AUTO"){
-    job_name_acronym = common.acronym(string: env.JOB_NAME)
+    job_name_acronym = acronym(string: env.JOB_NAME)
     instance_name = "${job_name_acronym}-${env.BUILD_NUMBER}"
   }
   else {

--- a/pipeline-steps/common.groovy
+++ b/pipeline-steps/common.groovy
@@ -194,12 +194,11 @@ def acronym(Map args){
 }
 
 def gen_instance_name(){
-  if (env.INSTANCE_NAME == "AUTO"){
+  if (env.INSTANCE_NAME_RAW == "AUTO"){
     job_name_acronym = acronym(string: env.JOB_NAME)
     instance_name = "${job_name_acronym}-${env.BUILD_NUMBER}"
-  }
-  else {
-    instance_name = env.INSTANCE_NAME
+  } else {
+    instance_name = env.INSTANCE_NAME_RAW
   }
   //Hostname should match instance name for MaaS. Hostnames are converted
   //to lower case, so we'll do the same for instance name.

--- a/pipeline-steps/common.groovy
+++ b/pipeline-steps/common.groovy
@@ -20,6 +20,7 @@ def install_ansible(){
     # installing pip resets the shebang to be absolute
     virtualenv --relocatable .venv
     pip install -U ansible pyrax
+    virtualenv --relocatable .venv
   """
 }
 

--- a/pipeline-steps/common.groovy
+++ b/pipeline-steps/common.groovy
@@ -259,4 +259,14 @@ api_key = ${args.api_key}
   return pyrax_cfg
 }
 
+/* Could optimise this to not run if the dir exists, but better for reruns
+ * to always checkout, as it ensures the correct version is available.
+ */
+def clone_rpc_gating(tdir="rpc-gating"){
+  dir(tdir){
+    git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
+  }
+}
+
+
 return this

--- a/pipeline-steps/holland.groovy
+++ b/pipeline-steps/holland.groovy
@@ -3,10 +3,7 @@ def holland(){
     stage_name: "Holland",
     stage: {
       //TODO: move test_holland into RPC to avoid this mess.
-      dir("rpc-gating"){
-        // only needed to pull the test_holland from the repo.
-        git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-      }
+      common.clone_rpc_gating()
       / * recent versions of openstack-ansible allow execution of playbooks
         * from any directory, but that doesn't work all the way back to liberty
         */

--- a/pipeline-steps/horizon.groovy
+++ b/pipeline-steps/horizon.groovy
@@ -32,6 +32,7 @@ def mitaka_prep() {
     if [[ ! -d ".venv" ]]; then
         pip install virtualenv
         virtualenv .venv
+        virtualenv --relocatable .venv
     fi
     source .venv/bin/activate
 
@@ -39,6 +40,7 @@ def mitaka_prep() {
     pip install selenium==2.53.1
     pip install -r test-requirements.txt
     pip install -r requirements.txt
+    virtualenv --relocatable .venv
     mv ~/.pip/pip.conf.bak ~/.pip/pip.conf
     """
   }

--- a/pipeline-steps/kibana.groovy
+++ b/pipeline-steps/kibana.groovy
@@ -28,9 +28,11 @@ def kibana_prep(){
     if [ -f ~/.pip/pip.conf ]; then
       mv ~/.pip/pip.conf ~/.pip/pip.conf.bak
       pip install -r requirements.txt
+      virtualenv --relocatable .venv
       mv ~/.pip/pip.conf.bak ~/.pip/pip.conf
     else
       pip install -r requirements.txt
+      virtualenv --relocatable .venv
     fi
     """
   }

--- a/pipeline-steps/pubcloud.groovy
+++ b/pipeline-steps/pubcloud.groovy
@@ -52,7 +52,7 @@ def create(Map args){
 
 /* Remove public cloud instances
  */
-def cleanup(){
+def cleanup(Map args){
   withEnv(['ANSIBLE_FORCE_COLOR=true']){
     withCredentials([
       string(
@@ -81,7 +81,7 @@ def cleanup(){
             args: [
               "--private-key=\"${env.JENKINS_SSH_PRIVKEY}\"",
             ],
-            vars: ["instance_name": instance_name]
+            vars: ["instance_name": args.instance_name]
           )
         } // withEnv
       } // directory
@@ -120,8 +120,8 @@ def delPubCloudSlave(Map args){
   common.conditionalStep(
     step_name: 'Cleanup',
     step: {
-      ssh_slave.destroy()
-      cleanup()
+      ssh_slave.destroy(instance_name: args.instance_name)
+      cleanup(instance_name: args.instance_name)
     } //stage
   ) //conditionalStage
 }
@@ -138,7 +138,7 @@ def runonpubcloud(Map args){
     print(e)
     throw e
   }finally {
-    delPubCloudSlave()
+    delPubCloudSlave(instance_name: instance_name)
   }
 }
 

--- a/pipeline-steps/pubcloud.groovy
+++ b/pipeline-steps/pubcloud.groovy
@@ -89,7 +89,6 @@ def cleanup(){
 
 
 def getPubCloudSlave(Map args){
-  ssh_slave = load 'rpc-gating/pipeline-steps/ssh_slave.groovy'
   common.conditionalStage(
     stage_name: 'Allocate Resources',
     stage: {
@@ -110,7 +109,6 @@ def getPubCloudSlave(Map args){
   })
 }
 def delPubCloudSlave(Map args){
-  ssh_slave = load 'rpc-gating/pipeline-steps/ssh_slave.groovy'
   common.conditionalStep(
     step_name: "Pause",
     step: {

--- a/pipeline-steps/pubcloud.groovy
+++ b/pipeline-steps/pubcloud.groovy
@@ -25,9 +25,7 @@ def create(Map args){
         variable: 'JENKINS_SSH_PRIVKEY'
       )
     ]){
-      dir("rpc-gating"){
-        git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-      }
+      common.clone_rpc_gating()
       dir("rpc-gating/playbooks"){
         common.install_ansible()
         pyrax_cfg = common.writePyraxCfg(
@@ -70,6 +68,7 @@ def cleanup(){
         variable: 'JENKINS_SSH_PRIVKEY'
       )
     ]){
+      common.clone_rpc_gating()
       dir("rpc-gating/playbooks"){
         pyrax_cfg = common.writePyraxCfg(
           username: env.PUBCLOUD_USERNAME,

--- a/pipeline-steps/ssh_slave.groovy
+++ b/pipeline-steps/ssh_slave.groovy
@@ -17,9 +17,7 @@ def connect(){
       passwordVariable: "JENKINS_API_KEY"
     )
   ]){
-    dir("rpc-gating"){
-        git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-    }
+    common.clone_rpc_gating()
     dir("rpc-gating/playbooks"){
       common.venvPlaybook(
         playbooks: ["setup-jenkins-slave.yml"],

--- a/pipeline-steps/ssh_slave.groovy
+++ b/pipeline-steps/ssh_slave.groovy
@@ -35,7 +35,7 @@ def connect(){
 /* Disconnect slave
  * Reads global var: instance_name
  */
-def destroy(){
+def destroy(Map args){
   withCredentials([
     usernamePassword(
       credentialsId: "service_account_jenkins_api_creds",
@@ -48,7 +48,7 @@ def destroy(){
         . ../playbooks/.venv/bin/activate
         pip install jenkinsapi
         python jenkins_node.py \
-          delete --name "${instance_name}"
+          delete --name "${args.instance_name}"
       """
     } //dir
   } //withCredentials

--- a/pipeline-steps/ssh_slave.groovy
+++ b/pipeline-steps/ssh_slave.groovy
@@ -17,6 +17,9 @@ def connect(){
       passwordVariable: "JENKINS_API_KEY"
     )
   ]){
+    dir("rpc-gating"){
+        git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
+    }
     dir("rpc-gating/playbooks"){
       common.venvPlaybook(
         playbooks: ["setup-jenkins-slave.yml"],

--- a/pipeline-steps/ssh_slave.groovy
+++ b/pipeline-steps/ssh_slave.groovy
@@ -47,6 +47,7 @@ def destroy(Map args){
       sh """
         . ../playbooks/.venv/bin/activate
         pip install jenkinsapi
+        virtualenv --relocatable ../playbooks/.venv
         python jenkins_node.py \
           delete --name "${args.instance_name}"
       """

--- a/playbooks/setup-jenkins-slave.yml
+++ b/playbooks/setup-jenkins-slave.yml
@@ -76,6 +76,7 @@
         cd  {{ lookup('env', 'WORKSPACE') }}/rpc-gating/playbooks
         . .venv/bin/activate
         pip install jenkinsapi
+        virtualenv --relocatable .venv
         python ../scripts/jenkins_node.py \
           create \
           --name {{inventory_hostname}} \

--- a/rpc-jobs/RPC-AIO.yml
+++ b/rpc-jobs/RPC-AIO.yml
@@ -48,36 +48,17 @@
       @Library("common@${env.RPC_GATING_BRANCH}")
       // CIT Slave node
       node(){
-        try {
-          dir("rpc-gating"){
-              git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-              common = load 'pipeline-steps/common.groovy'
-              pubCloudSlave = load 'pipeline-steps/pubcloud.groovy'
-              aio_prepare = load 'pipeline-steps/aio_prepare.groovy'
-              deploy = load 'pipeline-steps/deploy.groovy'
-              tempest = load 'pipeline-steps/tempest.groovy'
-              holland = load 'pipeline-steps/holland.groovy'
+        pubcloud.runonpubcloud(step: {
+          try {
+            aio_prepare.prepare()
+            deploy.deploy()
+            tempest.tempest()
+            holland.holland()
+          } catch (e) {
+            print(e)
+            throw e
+          } finally {
+            common.archive_artifacts()
           }
-          instance_name = common.gen_instance_name()
-          pubCloudSlave.getPubCloudSlave(instance_name: instance_name)
-          node(instance_name){
-            try {
-              aio_prepare.prepare()
-              deploy.deploy()
-              tempest.tempest()
-              holland.holland()
-            } catch (e) {
-              print(e)
-              throw e
-            } finally {
-              common.archive_artifacts()
-            }
-          } // pub cloud node
-        } catch (e){
-          currentBuild.result = 'FAILURE'
-          print(e)
-          throw e
-        } finally {
-          pubCloudSlave.delPubCloudSlave()
-        }
+        })
       } // cit node

--- a/rpc-jobs/RPC-AIO.yml
+++ b/rpc-jobs/RPC-AIO.yml
@@ -45,6 +45,7 @@
              Optional keys: args. All values are strings.
 
     dsl: |
+      @Library("common@${env.RPC_GATING_BRANCH}")
       // CIT Slave node
       node(){
         try {

--- a/rpc-jobs/RPC-AIO.yml
+++ b/rpc-jobs/RPC-AIO.yml
@@ -45,7 +45,7 @@
              Optional keys: args. All values are strings.
 
     dsl: |
-      @Library("common@${env.RPC_GATING_BRANCH}")
+      @Library("rpc-gating") _
       // CIT Slave node
       node(){
         pubcloud.runonpubcloud(step: {

--- a/rpc-jobs/install-jenkins-plugins.yml
+++ b/rpc-jobs/install-jenkins-plugins.yml
@@ -16,7 +16,6 @@
         ]){
           dir("rpc-gating"){
             git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-            common = load 'pipeline-steps/common.groovy'
             common.install_ansible()
             sh """#!/bin/bash
               . .venv/bin/activate

--- a/rpc-jobs/install-jenkins-plugins.yml
+++ b/rpc-jobs/install-jenkins-plugins.yml
@@ -20,6 +20,7 @@
             sh """#!/bin/bash
               . .venv/bin/activate
               pip install urllib3==1.18.1
+              virtualenv --relocatable .venv
             """
             common.venvPlaybook(
               playbooks: ["playbooks/install_jenkins_plugins.yml"],

--- a/rpc-jobs/jjb-setup.yml
+++ b/rpc-jobs/jjb-setup.yml
@@ -40,6 +40,7 @@
             source .venv/bin/activate
 
             pip install jenkins-job-builder
+            virtualenv --relocatable .venv
 
             cat > jenkins_jobs.ini << EOF
             [job-builder]

--- a/rpc-jobs/multi-node-aio.yml
+++ b/rpc-jobs/multi-node-aio.yml
@@ -95,6 +95,6 @@
             currentBuild.result = 'FAILURE'
             throw e
         } finally {
-            pubCloudSlave.delPubCloudSlave()
+            pubCloudSlave.delPubCloudSlave(instance_name: instance_name)
         }
       } // cit node

--- a/rpc-jobs/multi-node-aio.yml
+++ b/rpc-jobs/multi-node-aio.yml
@@ -66,17 +66,11 @@
               Cleanup
 
     dsl: |
+      @Library("common@${env.RPC_GATING_BRANCH}")
       node(){
         try {
           dir("rpc-gating"){
             git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-            pubCloudSlave = load 'pipeline-steps/pubcloud.groovy'
-            common = load 'pipeline-steps/common.groovy'
-            multi_node_aio_prepare = load 'pipeline-steps/multi_node_aio_prepare.groovy'
-            deploy = load 'pipeline-steps/deploy.groovy'
-            tempest = load 'pipeline-steps/tempest.groovy'
-            horizon = load 'pipeline-steps/horizon.groovy'
-            kibana = load 'pipeline-steps/kibana.groovy'
           }
           instance_name = common.gen_instance_name()
           pubCloudSlave.getPubCloudSlave(instance_name: instance_name)

--- a/rpc-jobs/multi-node-aio.yml
+++ b/rpc-jobs/multi-node-aio.yml
@@ -66,7 +66,7 @@
               Cleanup
 
     dsl: |
-      @Library("common@${env.RPC_GATING_BRANCH}")
+      @Library("rpc-gating") _
       node(){
         try {
           dir("rpc-gating"){

--- a/rpc-jobs/params.yml
+++ b/rpc-jobs/params.yml
@@ -12,7 +12,7 @@
           name: IMAGE
           default: "Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)"
       - string:
-          name: INSTANCE_NAME
+          name: INSTANCE_NAME_RAW
           default: AUTO
           description: |
             Set instance name or "AUTO" to have it generated based on job

--- a/rpc-jobs/single_use_slave_template.yml
+++ b/rpc-jobs/single_use_slave_template.yml
@@ -18,7 +18,7 @@
               Pause (use to hold instance for investigation before cleanup)
               Cleanup
     dsl: |
-      @Library("common@${env.RPC_GATING_BRANCH}")
+      @Library("rpc-gating") _
       // CIT Slave node
       node(){
         pubcloud.runonpubcloud(

--- a/rpc-jobs/single_use_slave_template.yml
+++ b/rpc-jobs/single_use_slave_template.yml
@@ -6,9 +6,10 @@
       # Default params are provided by macro, add any extra params, or
       # params you want to override the defaults for.
       - single_use_slave_params
+      - rpc_gating_params
       - string:
           name: STAGES
-          default: "Allocate Resources, Connect Slave, Your Stage, Cleanup"
+          default: "Allocate Resources, Connect Slave, Cleanup"
           description: |
             Pipeline stages to run CSV. Note that this list does not influence execution order.
             Options:
@@ -20,27 +21,12 @@
       @Library("common@${env.RPC_GATING_BRANCH}")
       // CIT Slave node
       node(){
-        try {
-          dir("rpc-gating"){
-              git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-              pubCloudSlave = load 'pipeline-steps/pubcloud.groovy'
-              common = load 'pipeline-steps/common.groovy'
-          }
-          instance_name = common.gen_instance_name()
-          pubCloudSlave.getPubCloudSlave(instance_name: instance_name)
-          //pub cloud single use slave
-          node(instance_name){
-            stage("Your Stage"){
+        pubcloud.runonpubcloud(
+          step: {
               sh """
                 hostname; date
                 echo "your script here"
               """
-            }
-          } // pub cloud node
-        } catch (Exception e){
-          currentBuild.result = 'FAILURE'
-          print e
-        } finally {
-          pubCloudSlave.delPubCloudSlave()
-        }
-      } // cit node
+            } //pubcloud step
+        ) //runonpubcloud
+      } //cit node

--- a/rpc-jobs/single_use_slave_template.yml
+++ b/rpc-jobs/single_use_slave_template.yml
@@ -17,6 +17,7 @@
               Pause (use to hold instance for investigation before cleanup)
               Cleanup
     dsl: |
+      @Library("common@${env.RPC_GATING_BRANCH}")
       // CIT Slave node
       node(){
         try {

--- a/vars
+++ b/vars
@@ -1,0 +1,1 @@
+pipeline-steps


### PR DESCRIPTION
This PR paves the way for triggering AIOs via Jenkinsfile.

* Adds rpc-gating as a 'Global Library' which means that scripts are automatically loaded and available to all pipelines. This is very useful for Jenkinsfiles as they will be placed in other repos (eg rpc-openstack) and wouldn't have direct access to rpc-gating/pipeline-steps. Using a global library prevents boilerplate code that clones rpc-gating and loads the various steps. This change also removes all the current load statements as they are no longer required.
* Adds a runonpublcoud function that allows a user to easily run a script or some steps on a public cloud slave. The RPC-AIO and Single_Use_Slave_Example jobs have been updated to reflect this.
* Adds a Jenkinsfile to rpc-gating, which will be used to test PRs to this repo. Currently it runs lint.sh

In addition to the change in this commit, I have created a github organisation folder in Jenkins for rcbops, this will scan all repos looking for Jenkinsfile, and will build branches and PRs found to contain one. **The job that has run against this PR is a good demonstration of this mechanism working.**

Connects rcbops/u-suk-dev#1080