### PR TITLE
Don't run lint script as root

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ node(){
       checkout scm
     }
     stage("lint"){
-      sh "sudo ./lint.sh 2>&1"
+      sh "./lint.sh 2>&1"
     }
   }
 }


### PR DESCRIPTION
Currently, we run as root which causes all the ansible roles, etc. to
get created as root user/group.  Subsequent runs of a job w/ this dirty
workspace will then fail when deleteDir runs as jenkins user is unable
to delete those files owned by root.