### PR TITLE
Fix deleteDir error in lint job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ node(){
       checkout scm
     }
     stage("lint"){
-      sh "sudo ./lint.sh 2>&1"
+      sh "sudo chown -R jenkins:jenkins .; ./lint.sh 2>&1"
     }
   }
 }


### PR DESCRIPTION
Jenkins bind mounts the workspace into the docker instance, so if the
root user within the container creates uid 0 files/dirs, then the
jenkins user outside the instance can't clean them up. This causes
problems with the deleteDir() step.

Instead of running lint jobs as root, ensure the jenkins user fully owns
the workspace.

Connects rcbops/u-suk-dev#1080