### PR TITLE
AIO Prep Changes

### DIFF
--- a/pipeline-steps/aio_prepare.groovy
+++ b/pipeline-steps/aio_prepare.groovy
@@ -37,7 +37,12 @@ def prepare(){
           git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
         } //dir
         dir("/opt/rpc-gating/playbooks"){
-          ansiblePlaybook playbook: "aio_config.yml"
+          common.install_ansible()
+          common.venvPlaybook(
+            playbooks: ["aio_config.yml"],
+            venv: ".venv",
+            args: [ "-i inventory" ]
+          )
         } //dir
       } //withCredentials
     } //stage param

--- a/pipeline-steps/common.groovy
+++ b/pipeline-steps/common.groovy
@@ -3,9 +3,11 @@ import groovy.json.JsonOutput
 
 // Install ansible on a jenkins slave
 def install_ansible(){
-  sh """
-    #!/bin/bash
+  sh """#!/bin/bash
     if [[ ! -d ".venv" ]]; then
+      if ! which virtualenv; then
+        pip install virtualenv
+      fi
       if which scl
       then
         source /opt/rh/python27/enable

--- a/playbooks/aio_config.yml
+++ b/playbooks/aio_config.yml
@@ -2,7 +2,6 @@
 - hosts: localhost
   user: root
   vars:
-    rpco_defaults_file: "/etc/openstack_deploy/user_rpco_variables_defaults.yml"
     gating_overrides_file: "/etc/openstack_deploy/user_zzz_gating_variables.yml"
 
     gating_overrides:
@@ -37,8 +36,6 @@
       journal_size: 1024
       maas_notification_plan: npTechnicalContactsEmail
       osd_directory: true
-    defaults: "{{ lookup('file', rpco_defaults_file)|from_yaml }}"
-    maas_creds:
       rackspace_cloud_auth_url: "https://identity.api.rackspacecloud.com/v2.0/"
       rackspace_cloud_tenant_id: "{{lookup('env', 'PUBCLOUD_TENANT_ID')}}"
       rackspace_cloud_username: "{{lookup('env', 'PUBCLOUD_USERNAME')}}"
@@ -54,8 +51,3 @@
       lineinfile:
         dest: "{{ gating_overrides_file }}"
         line: "{{ lookup('env', 'USER_VARS') }}"
-
-    - name: write rpco defaults file
-      copy:
-        content: "{{ defaults|combine(maas_creds)|to_nice_yaml }}"
-        dest: "{{ rpco_defaults_file }}"


### PR DESCRIPTION
This commit does the following:

1. Updates aio_prepary.groovy to install ansible into a venv and run
   aio_config.yml with that version of ansible.
2. Updates common.groovy to first install virtualenv before attempting
   to use it.
3. Updates aio_config.yml to write the rackspace vars to
   user_zzz_gating_variables.yml so we don't have to check if this is a
   liberty, mitaka, etc. deployment.

Note that 1. is being done as different rpc-openstack versions use
different versions of ansible, and aio_config.yml did not run cleanly
across them all. The 2. task was done as a liberty deployment does not
have virtualenv installed when common.install_ansible() is executed.

Connects https://github.com/rcbops/u-suk-dev/issues/1270