### PR TITLE
Add Upgrade stage

### DIFF
--- a/pipeline-steps/aio_prepare.groovy
+++ b/pipeline-steps/aio_prepare.groovy
@@ -3,7 +3,11 @@ def prepare(){
     stage_name: "Prepare Deployment",
     stage: {
       dir("/opt/rpc-openstack"){
-        git branch: env.RPC_BRANCH, url: env.RPC_REPO
+        if (env.STAGES.contains("Upgrade")) {
+          git branch: env.UPGRADE_FROM_REF, url: env.RPC_REPO
+        } else {
+          git branch: env.RPC_BRANCH, url: env.RPC_REPO
+        }
         sh "git submodule update --init"
         ansiColor('xterm'){
           withEnv([

--- a/pipeline-steps/common.groovy
+++ b/pipeline-steps/common.groovy
@@ -61,7 +61,7 @@ def venvPlaybook(Map args){
         sh """
           which scl && source /opt/rh/python27/enable
           . ${args.venv}/bin/activate
-          ansible-playbook -v --ssh-extra-args="-o  UserKnownHostsFile=/dev/null" ${args.args.join(' ')} -e@${vars_file} ${playbook}
+          ansible-playbook -v ${args.args.join(' ')} -e@${vars_file} ${playbook}
         """
       } //for
     } //color
@@ -83,9 +83,7 @@ def openstack_ansible(Map args){
         'ANSIBLE_HOST_KEY_CHECKING=False'])
       {
         sh """#!/bin/bash
-          openstack-ansible ${args.playbook} \
-            -v --ssh-extra-args="-o  UserKnownHostsFile=/dev/null" \
-            ${args.args}
+          openstack-ansible ${args.playbook} ${args.args}
         """
       } //withEnv
     } //dir

--- a/pipeline-steps/deploy.groovy
+++ b/pipeline-steps/deploy.groovy
@@ -21,7 +21,7 @@ def deploy_sh(Map args) {
     stage_name: "Deploy RPC w/ Script",
     stage: {
       environment_vars = args.environment_vars +
-        ['ANSIBLE_FORCE_COLOR=true', 'ANSIBLE_HOST_KEY_CHECKING=False']
+        ['ANSIBLE_FORCE_COLOR=true', 'ANSIBLE_HOST_KEY_CHECKING=False', 'TERM=linux']
       withEnv(environment_vars) {
         ansiColor('xterm') {
           dir("/opt/rpc-openstack/") {
@@ -33,6 +33,40 @@ def deploy_sh(Map args) {
       } // withEnv
     } // stage
   ) // conditionalStage
+}
+
+def upgrade(Map args) {
+  common.conditionalStage(
+    stage_name: "Upgrade",
+    stage: {
+      environment_vars = args.environment_vars +
+        ['ANSIBLE_FORCE_COLOR=true', 'ANSIBLE_HOST_KEY_CHECKING=False', 'TERM=linux']
+      withEnv(environment_vars){
+        dir("/opt/rpc-openstack/openstack-ansible"){
+          sh "git reset --hard"
+        }
+        dir("/opt/rpc-openstack"){
+          git branch: env.RPC_BRANCH, url: env.RPC_REPO
+          sh """
+            git submodule update --init
+            scripts/test-upgrade.sh
+          """
+        } // dir
+      } // withEnv
+    } // stage
+  ) // conditionalStage
+}
+
+def addChecksumRule(){
+  sh """#!/bin/bash
+    cd /opt/rpc-openstack/rpcd/playbooks
+    ansible neutron_agent \
+      -m command \
+      -a '/sbin/iptables -t mangle -A POSTROUTING -p tcp --sport 80 -j CHECKSUM --checksum-fill'
+    ansible neutron_agent \
+      -m shell \
+      -a 'DEBIAN_FRONTEND=noninteractive apt-get install iptables-persistent'
+  """
 }
 
 return this;

--- a/rpc-jobs/RPC-AIO.yml
+++ b/rpc-jobs/RPC-AIO.yml
@@ -25,6 +25,8 @@
                     default_volume_type: ceph
             cinder_service_backup_driver: cinder.backup.drivers.ceph
             cinder_service_backup_program_enabled: true
+      - upgrade:
+          STAGES: "Allocate Resources, Connect Slave, Prepare Deployment, Deploy RPC w/ Script, Install Tempest, Tempest Tests, Upgrade, Cleanup"
       - xenial:
           IMAGE: "Ubuntu 16.04 LTS"
 
@@ -38,6 +40,12 @@
       - periodic:
           branches: "do_not_build_on_pr"
     exclude:
+      - series: liberty
+        context: upgrade
+      - series: newton
+        context: upgrade
+      - series: master
+        context: upgrade
       # Xenial builds are run for newton and above.
       - series: liberty
         context: xenial
@@ -53,6 +61,8 @@
     DEPLOY_ELK: "yes"
     CRON: "H H(9-21) * * 1-5"
     USER_VARS: ""
+    UPGRADE_FROM_REF: "liberty-12.2"
+    STAGES: "Allocate Resources, Connect Slave, Prepare Deployment, Deploy RPC w/ Script, Install Tempest, Tempest Tests, Cleanup"
 
     # TEMPLATE
     name: 'RPC-AIO_{series}-{context}-{ztrigger}'
@@ -68,13 +78,14 @@
          DEPLOY_CEPH: "{DEPLOY_CEPH}"
          DEPLOY_ELK: "{DEPLOY_ELK}"
          USER_VARS: "{USER_VARS}"
+         UPGRADE_FROM_REF: "{UPGRADE_FROM_REF}"
       - rpc_gating_params
       - single_use_slave_params:
          IMAGE: "{IMAGE}"
       - tempest_params
       - string:
           name: STAGES
-          default: "Allocate Resources, Connect Slave, Prepare Deployment, Deploy RPC w/ Script, Install Tempest, Tempest Tests, Cleanup"
+          default: "{STAGES}"
           description: |
             Pipeline stages to run CSV. Note that this list does not influence execution order.
             Options:
@@ -85,6 +96,7 @@
               Install Tempest
               Tempest Tests
               Holland (test holland mysql backup)
+              Upgrade
               Pause (use to hold instance for investigation before cleanup)
               Cleanup
     triggers:
@@ -106,19 +118,22 @@
           pubCloudSlave.getPubCloudSlave(instance_name: instance_name)
           node(instance_name) {{
             try {{
+              environment_vars = [
+                "DEPLOY_HAPROXY=yes",
+                "DEPLOY_AIO=no",
+                "DEPLOY_MAAS=no",
+                "DEPLOY_TEMPEST=no",
+                "DEPLOY_CEPH={DEPLOY_CEPH}",
+                "DEPLOY_ELK={DEPLOY_ELK}",
+                ]
               aio_prepare.prepare()
-              deploy.deploy_sh(
-                environment_vars: [
-                  "DEPLOY_HAPROXY=yes",
-                  "DEPLOY_AIO=no",
-                  "DEPLOY_MAAS=no",
-                  "DEPLOY_TEMPEST=no",
-                  "DEPLOY_CEPH={DEPLOY_CEPH}",
-                  "DEPLOY_ELK={DEPLOY_ELK}",
-                  ]
-              ) // deploy_sh
+              deploy.deploy_sh(environment_vars: environment_vars)
+              deploy.addChecksumRule()
               tempest.tempest()
               holland.holland()
+              deploy.upgrade(environment_vars: environment_vars)
+              deploy.addChecksumRule()
+              tempest.tempest()
             }} catch (e) {{
               print(e)
               throw e

--- a/rpc-jobs/params.yml
+++ b/rpc-jobs/params.yml
@@ -31,12 +31,19 @@
       - string:
           name: "DEPLOY_CEPH"
           default: "{DEPLOY_CEPH}"
+          description: "Deploy Ceph? yes/no"
       - string:
           name: "DEPLOY_ELK"
           default: "{DEPLOY_ELK}"
+          description: "Deploy ELK? yes/no"
       - text:
           name: "USER_VARS"
           default: "{USER_VARS}"
+          description: "OSA/RPC USER_VARS to inject for this build"
+      - string:
+          name: "UPGRADE_FROM_REF"
+          default: "{UPGRADE_FROM_REF}"
+          description: "An tag/sha/ref to upgrade from"
 
 - parameter:
     name: rpc_gating_params


### PR DESCRIPTION
This commit does the following:

1. Adds an UPGRADE_FROM_REF parameter to params.yml
2. Adds an upgrade stage to deploy.groovy and adds TERM=linux to deploy
   environment vars which needs to be set by one of the upgrade scripts
3. Updates common.groovy to strip out ansible args that don't work
   across all ansible versions
4. Updates RPC-AIO.yml to set a default STAGE var and overrides it on
   upgrades with the necessary stage
5. Updates RPC-AIO.yml to exclude upgrades on certain series since we
   don't test upgrades across all
5. Updates RPC-AIO.yml to manually apply an iptables rule, which is
   necessary since we run deploy.sh with DEPLOY_OA=no and
   DEPLOY_AIO=yes and then DEPLOY_OA=yes and DEPLOY_AIO=no (these
   combinations means that it will never get applied via deploy.sh)

Connects rcbops/u-suk-dev#1270