### PR TITLE
Change vars from strings to bools

### DIFF
--- a/playbooks/vars/aio.yml
+++ b/playbooks/vars/aio.yml
@@ -18,7 +18,7 @@ gating_overrides:
       sha256: "95e77c7deaf0f515f959ffe329918d5dd23e417503d1d45e926a888853c90710"
   tempest_tempest_conf_overrides:
     volume-feature-enabled:
-      snapshot: "True"
+      snapshot: true
 
   # Ensure raw_multi_journal is False for upgrades.
   # This is because of the way migrate-yaml.py behaves with the
@@ -30,6 +30,6 @@ gating_overrides:
   # migrate-yaml.py adding 'raw_multi_journal: True' in the overrides.
   # To avoid this behavior in gate, it is overridden here.
   # The same is true for journal_size, and maas_notification_plan.
-  raw_multi_journal: "False"
+  raw_multi_journal: false
   journal_size: 1024
-  osd_directory: "True"
+  osd_directory: true


### PR DESCRIPTION
Currently, ceph-osd.yml fails to run on an AIO.  It looks like it's
expecting these vars to be bools, and not strings.