### PR TITLE
Password syncing

### DIFF
--- a/rpc-jobs/sync-credential-store.yml
+++ b/rpc-jobs/sync-credential-store.yml
@@ -1,0 +1,68 @@
+- job:
+    name: 'Sync-Credential-Store'
+    project-type: workflow
+    concurrent: false
+    parameters:
+      - rpc_gating_params
+      - string:
+          name: "PWSAFE_PROJECT_ID"
+          description: |
+            PasswordSafe Project ID
+      - password:
+          name: "SSO_USERNAME"
+          description: |
+            SSO username to connect to PasswordSafe with
+      - password:
+          name: "SSO_PASSWORD"
+          description: |
+            SSO password to connect to PasswordSafe with
+      - password:
+          name: "PIP_PWSAFE_LOCATION"
+          description: |
+            pip location to install pwsafe library from,
+            eg. git+ssh://git@repo_url/user/pwsafe.git
+
+    dsl: |
+      node(){ // CIT slave node
+        withCredentials([
+          file(
+            credentialsId: 'service_account_jenkins_ssh_key',
+            variable: 'JENKINS_SSH_KEY'
+          )
+        ]){
+          dir("rpc-gating"){
+            git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
+            dir("scripts"){
+              TMP_DIR = pwd(tmp:true)
+              withEnv([
+                "TMP_DIR=${TMP_DIR}",
+                "PWSAFE_PROJECT_ID=${PWSAFE_PROJECT_ID}",
+                "JENKINS_URL=${JENKINS_URL}",
+                "JENKINS_SSH_KEY=${JENKINS_SSH_KEY}",
+                "SSO_USERNAME=${SSO_USERNAME}",
+                "SSO_PASSWORD=${SSO_PASSWORD}"])
+              {
+                sshagent (credentials: ['rpc-jenkins-svc-github-key']) {
+                  sh """#!/bin/bash
+                    scl enable python27 bash
+
+                    if [[ ! -d ".venv" ]]; then
+                        virtualenv -p /opt/rh/python27/root/usr/bin/python .venv
+                    fi
+                    source .venv/bin/activate
+
+                    pip install ${PIP_PWSAFE_LOCATION}
+                    pip install functools32
+
+                    if [[ ! -f "jenkins-cli.jar" ]]; then
+                        wget ${JENKINS_URL}/jnlpJars/jenkins-cli.jar
+                    fi
+
+                    python pull_passwords.py
+                  """
+                } // sshagent
+              } // withEnv
+            } // dir
+          } // dir
+        } // withCred
+      } // CIT slave node

--- a/scripts/add_jenkins_cred.groovy
+++ b/scripts/add_jenkins_cred.groovy
@@ -1,0 +1,61 @@
+/* This code is heavily borrowed from
+   http://stackoverflow.com/questions/35025829/i-want-to-create-jenkins-credentials-via-ansible */
+
+import com.cloudbees.plugins.credentials.CredentialsScope
+import hudson.util.Secret
+import java.nio.file.Files
+import jenkins.model.*
+import org.apache.commons.fileupload.*
+import org.apache.commons.fileupload.disk.*
+import org.jenkinsci.plugins.plaincredentials.impl.*
+
+def addJenkinsCred = { cred_type, cred_id, secret ->
+    def creds = com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentials(
+        com.cloudbees.plugins.credentials.common.StandardCredentials.class,
+        Jenkins.instance
+    )
+
+    def c = creds.findResult { it.id == cred_id ? it : null }
+
+    if ( c ) {
+        println "found credential with id of ${cred_id}"
+    } else {
+        def credentials_store = Jenkins.instance.getExtensionList(
+            'com.cloudbees.plugins.credentials.SystemCredentialsProvider'
+            )[0].getStore()
+
+        def scope = CredentialsScope.GLOBAL
+        def result = null
+
+        if (cred_type == 'text') {
+            result = credentials_store.addCredentials(
+                com.cloudbees.plugins.credentials.domains.Domain.global(),
+                new StringCredentialsImpl(scope, cred_id, cred_id, Secret.fromString(secret))
+                )
+        } else if (cred_type == 'file') {
+            def file = new File(secret)
+            def factory = new DiskFileItemFactory()
+            def dfi = factory.createItem("", "application/octet-stream", false, file.getName())
+            def out = dfi.getOutputStream()
+
+            Files.copy(file.toPath(), out)
+
+            result = credentials_store.addCredentials(
+                com.cloudbees.plugins.credentials.domains.Domain.global(),
+                new FileCredentialsImpl(scope, cred_id, cred_id, dfi, "", "")
+                )
+
+        } else {
+            println "invalid credential type specified"
+            System.exit(1)
+        }
+
+        if (result) {
+            println "credential added for ${cred_id}"
+        } else {
+            println "failed to add credential for ${cred_id}"
+        }
+    }
+}
+
+addJenkinsCred(args[0], args[1], args[2])

--- a/scripts/pull_passwords.py
+++ b/scripts/pull_passwords.py
@@ -1,0 +1,64 @@
+import os
+import subprocess
+import sys
+import pwsafe
+
+CREDS = [
+    {'type': 'text', 'username': 'dev_pubcloud_api_key'},
+    {'type': 'text', 'username': 'dev_pubcloud_username'},
+    {'type': 'text', 'username': 'dev_pubcloud_tenant_id'},
+    {'type': 'text', 'username': 'rpc-jenkins-svc-github-pat'},
+    {
+        'type': 'file',
+        'username': 'id_rsa_cloud10_jenkins_file',
+        'filename': 'id_rsa_cloud10_jenkins'
+    },
+]
+
+
+def add_cred(jenkins, ssh_key, secret_type, username, secret):
+    cmd = "java -jar jenkins-cli.jar -s %s -i %s groovy " \
+          "add_jenkins_cred.groovy %s %s %s" % \
+          (jenkins, ssh_key, secret_type, username, secret)
+    print(subprocess.check_output(cmd.split()))
+
+
+def main():
+    sso_username = os.environ.get('SSO_USERNAME', None)
+    sso_password = os.environ.get('SSO_PASSWORD', None)
+    project_id = os.environ.get('PWSAFE_PROJECT_ID', None)
+    jenkins_url = os.environ.get('JENKINS_URL', None)
+    jenkins_ssh_key = os.environ.get('JENKINS_SSH_KEY', None)
+    tmp_dir = os.environ.get('TMP_DIR', None)
+
+    if not (sso_username and sso_password and project_id and jenkins_url and
+            tmp_dir):
+        print("Exiting, one or more environment vars not set.")
+        sys.exit(1)
+
+    cli = pwsafe.PWSafeClient(sso_username, sso_password)
+    proj = cli.projects[project_id]
+
+    for cred in proj.credentials.list():
+        for c in CREDS:
+            if cred.username == c['username']:
+                if c['type'] == 'text':
+                    add_cred(
+                        jenkins_url, jenkins_ssh_key, c['type'], c['username'], cred.password
+                    )
+                elif c['type'] == 'file':
+                    secret_path = os.path.join(tmp_dir, c['filename'])
+                    secret_file = open(secret_path, 'w')
+                    secret_file.write(cred.password)
+                    secret_file.close()
+                    add_cred(
+                        jenkins_url, jenkins_ssh_key, c['type'], c['username'], secret_path
+                    )
+                    # The temp workspace should get cleaned up when the build
+                    # finishes, but let's just remove the secret file anyway
+                    # once it's no longer needed.
+                    os.remove(secret_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit adds a job which is intended to run on a clean jenkins
deployment to sync passwords from the safe to jenkins' credential
store.  The list of passwords to sync is hard-coded in
pull_passwords.py and will need to be pulled out at a later date.

At time of writing add_jenkins_cred.groovy supports text or file
credential types.

As this is a bootstrap job, we have tried to limit the amount of
credentials that already need to be in place before this runs.  The
only one that will need to be manually created are
service_account_jenkins_ssh_key and rpc-jenkins-svc-github-key.
The former is the ssh key assigned to the service account jenkins user
(in jenkins itself) which gets used when running jenkins-cli.jar, and
the latter is the GitHub private key to install pwsafe.

Connects https://github.com/rcbops/u-suk-dev/issues/801