### PR TITLE
Set RPC parameters in multi-node AIO

### DIFF
--- a/rpc-jobs/multi-node-aio.yml
+++ b/rpc-jobs/multi-node-aio.yml
@@ -6,7 +6,12 @@
     concurrent: true
     parameters:
       - rpc_gating_params
-      - rpc_params
+      - string:
+          name: "RPC_REPO"
+          default: "https://github.com/rcbops/rpc-openstack"
+      - string:
+          name: "RPC_BRANCH"
+          default: "master"
       - tempest_params
       - string:
           name: OSA_OPS_REPO


### PR DESCRIPTION
We haven't converted the multi-node AIO job to a project yet, so we can't set the default values for rpc_params. This is a temporary fix so that the jobs can have normal default values again instead of things like {RPC_BRANCH}.