### PR TITLE
1313 jenkinsfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.retry
 *.swp
 *.pyc
+.lintvenv
+playbooks/roles/geerlingguy.nginx/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,11 @@ node(){
       checkout scm
     }
     stage("lint"){
-      sh "./lint.sh 2>&1"
-    }
-  }
-}
+      withEnv([
+        'RPC_GATING_LINT_USE_VENV=no'
+      ]){
+        sh "./lint.sh 2>&1"
+      }// withenv
+    }// stage
+  }// inside
+}// node

--- a/pipeline-steps/aio_prepare.groovy
+++ b/pipeline-steps/aio_prepare.groovy
@@ -4,10 +4,24 @@ def prepare(){
     stage: {
       dir("/opt/rpc-openstack"){
         if (env.STAGES.contains("Upgrade")) {
-          git branch: env.UPGRADE_FROM_REF, url: env.RPC_REPO
+          branch = env.UPGRADE_FROM_REF
         } else {
-          git branch: env.RPC_BRANCH, url: env.RPC_REPO
+          branch = env.RPC_BRANCH
         }
+        // checkout used instead of git as a custom refspec is required
+        // to checkout pull requests
+        checkout([$class: 'GitSCM',
+          branches: [[name: branch ]],
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [[$class: 'CleanCheckout']],
+          submoduleCfg: [],
+          userRemoteConfigs: [
+            [
+              url: RPC_REPO,
+              refspec: '+refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*'
+            ]
+          ]
+        ])
         sh "git submodule update --init"
         ansiColor('xterm'){
           withEnv([

--- a/pipeline-steps/common.groovy
+++ b/pipeline-steps/common.groovy
@@ -204,7 +204,9 @@ def acronym(Map args){
 def gen_instance_name(){
   if (env.INSTANCE_NAME == "AUTO"){
     job_name_acronym = common.acronym(string: env.JOB_NAME)
-    instance_name = "${job_name_acronym}-${env.BUILD_NUMBER}"
+    //4 digit hex string to avoid name colisions
+    rand_str = Integer.toString(Math.abs((new Random()).nextInt(0xFFFF)), 16)
+    instance_name = "${job_name_acronym}-${env.BUILD_NUMBER}-${rand_str}"
   }
   else {
     instance_name = env.INSTANCE_NAME

--- a/rpc-jobs/RPC-AIO.yml
+++ b/rpc-jobs/RPC-AIO.yml
@@ -73,8 +73,8 @@
                 "DEPLOY_AIO=no",
                 "DEPLOY_MAAS=no",
                 "DEPLOY_TEMPEST=no",
-                "DEPLOY_CEPH={DEPLOY_CEPH}",
-                "DEPLOY_ELK={DEPLOY_ELK}",
+                "DEPLOY_CEPH=${{DEPLOY_CEPH}}",
+                "DEPLOY_ELK=${{DEPLOY_ELK}}",
                 ]
               aio_prepare.prepare()
               deploy.deploy_sh(environment_vars: environment_vars)

--- a/rpc-jobs/RPC-AIO.yml
+++ b/rpc-jobs/RPC-AIO.yml
@@ -1,58 +1,7 @@
 - project:
-    name: 'RPC-AIO-Jobs'
-    # Note: branch is the branch for periodics to build
-    #       branches is the branch pattern to match for PR Jobs.
-    series:
-      - liberty:
-          branch: liberty-12.2
-          branches: "liberty-.*"
-      - mitaka:
-          branch: mitaka-13.1
-          branches: "mitaka-.*"
-      - newton:
-          branch: newton-14.0
-          branches: "newton-.*"
-      - master:
-          branch: master
-          branches: "master"
-    context:
-      - swift
-      - ceph:
-          DEPLOY_CEPH: "yes"
-          USER_VARS: |
-            cinder_cinder_conf_overrides:
-                DEFAULT:
-                    default_volume_type: ceph
-            cinder_service_backup_driver: cinder.backup.drivers.ceph
-            cinder_service_backup_program_enabled: true
-      - upgrade:
-          STAGES: "Allocate Resources, Connect Slave, Prepare Deployment, Deploy RPC w/ Script, Install Tempest, Tempest Tests, Upgrade, Cleanup"
-      - xenial:
-          IMAGE: "Ubuntu 16.04 LTS"
-
-    # NOTE: Hugh tested this and found that ztrigger overrides series and
-    #       trigger doesn't, which is odd because both trigger and ztrigger
-    #       sort after series.
-    ztrigger:
-      - pr:
-          CRON: ""
-          USER_VARS: "maas_use_api: false"
-      - periodic:
-          branches: "do_not_build_on_pr"
-    exclude:
-      - series: liberty
-        context: upgrade
-      - series: newton
-        context: upgrade
-      - series: master
-        context: upgrade
-      # Xenial builds are run for newton and above.
-      - series: liberty
-        context: xenial
-      - series: mitaka
-        context: xenial
+    name: "RPC-AIO Single Job"
     jobs:
-      - 'RPC-AIO_{series}-{context}-{ztrigger}'
+      - 'RPC-AIO'
 
 - job-template:
     # DEFAULTS
@@ -63,9 +12,10 @@
     USER_VARS: ""
     UPGRADE_FROM_REF: "liberty-12.2"
     STAGES: "Allocate Resources, Connect Slave, Prepare Deployment, Deploy RPC w/ Script, Install Tempest, Tempest Tests, Cleanup"
+    branch: master
 
     # TEMPLATE
-    name: 'RPC-AIO_{series}-{context}-{ztrigger}'
+    name: 'RPC-AIO'
     project-type: workflow
     concurrent: true
     properties:


### PR DESCRIPTION
RPC-Gating side of Jenkinsfile job trigger. The Jenkinsfile itself is in the RPC repo.

- Add PR refspec, so PRs can be checked out directly
- Fix DEPLOY_* quoting so they can be overridden at build time.
- Remove the JJB AIO matrix. No need for an explosion of jobs in JJB as Jenkins githb org folder plugin will create a job for each branch and pr that contain a Jenkinsfile. These Jobs call a single AIO build with the appropriate parameters for each scenario.

Connects rcbops/u-suk-dev#1313
