### PR TITLE
Copy from Mitaka/Liberty tempest results location

### DIFF
--- a/pipeline-steps/tempest.groovy
+++ b/pipeline-steps/tempest.groovy
@@ -53,7 +53,11 @@ def tempest(Map args){
         print(e)
         throw(e)
       } finally{
-        sh "rm -f *tempest*.xml; ${copy_cmd}/openstack/log/*utility*/**/*tempest*.xml . ||:"
+        sh """
+        rm -f *tempest*.xml
+        ${copy_cmd}/openstack/log/*utility*/**/*tempest*.xml . ||:
+        ${copy_cmd}/openstack/log/*utility*/*tempest*.xml . ||:
+        """
         junit allowEmptyResults: true, testResults: '*tempest*.xml'
       } //finally
     } //stage


### PR DESCRIPTION
The tempest test results are in a different place for Mitaka and Liberty, so these results weren't getting published properly.

Mitaka: https://rpc.jenkins.cit.rackspace.net/job/OnMetal_Multi_Node_AIO/148/
Newton: https://rpc.jenkins.cit.rackspace.net/view/Multi-Node%20AIO/job/OnMetal_Multi_Node_AIO/147/