### PR TITLE
Patience required when waiting for quota

### DIFF
--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -17,8 +17,8 @@
           auto_increment: no
       register: rax
       until: rax|success
-      retries: 5
-      delay: 30
+      retries: 120
+      delay: 60
 
     - name: Write inventory
       copy:


### PR DESCRIPTION
Jobs should not fail when there is not enough quota, however most jobs
are long running, so if theres no quota on the first try, its unlikely
that the situation is different after 5x30s delay.

This commit sets 120x60s retries. After a couple of hours
there should be some quota - or there is a problem that requires human
intervention.