### PR TITLE
Use variables.sh again for deployments

### DIFF
--- a/pipeline-steps/multi_node_aio_prepare.groovy
+++ b/pipeline-steps/multi_node_aio_prepare.groovy
@@ -19,7 +19,6 @@ def prepare() {
             "DEFAULT_IMAGE=${env.DEFAULT_IMAGE}",
             "OSA_BRANCH=${env.OPENSTACK_ANSIBLE_BRANCH}",
             "SETUP_HOST=true",
-            "PARTITION_HOST=true",
             "SETUP_VIRSH_NET=true",
             "VM_IMAGE_CREATE=true",
             "DEPLOY_OSA=true",

--- a/pipeline-steps/multi_node_aio_prepare.groovy
+++ b/pipeline-steps/multi_node_aio_prepare.groovy
@@ -6,9 +6,6 @@ def prepare() {
     common.conditionalStage(
       stage_name: 'Prepare Multi-Node AIO',
       stage: {
-        sh """
-        rm -f variables.sh
-        """
         common.run_script(
           script: 'build.sh',
           environment_vars: [


### PR DESCRIPTION
Environment variables are no longer being overridden by variables.sh, so I'm removing that workaround.

https://rpc.jenkins.cit.rackspace.net/job/OnMetal_Multi_Node_AIO/157/execution/node/156/log/?consoleFull