### PR TITLE
Remove swift from ceph job

### DIFF
--- a/pipeline-steps/aio_prepare.groovy
+++ b/pipeline-steps/aio_prepare.groovy
@@ -27,6 +27,7 @@ def prepare(){
           withEnv([
             "DEPLOY_AIO=yes",
             "DEPLOY_OA=no",
+            "DEPLOY_SWIFT=${env.DEPLOY_SWIFT}",
             "DEPLOY_ELK=${env.DEPLOY_ELK}",
             "DEPLOY_RPC=no",
             "ANSIBLE_FORCE_COLOR=true"

--- a/rpc-jobs/RPC-AIO.yml
+++ b/rpc-jobs/RPC-AIO.yml
@@ -18,6 +18,7 @@
     context:
       - swift
       - ceph:
+          DEPLOY_SWIFT: "no"
           DEPLOY_CEPH: "yes"
           USER_VARS: |
             cinder_cinder_conf_overrides:
@@ -25,6 +26,7 @@
                     default_volume_type: ceph
             cinder_service_backup_driver: cinder.backup.drivers.ceph
             cinder_service_backup_program_enabled: true
+            tempest_service_available_swift: false
       - upgrade:
           STAGES: "Allocate Resources, Connect Slave, Prepare Deployment, Deploy RPC w/ Script, Setup MaaS, Verify MaaS, Install Tempest, Tempest Tests, Upgrade, Cleanup"
       - xenial:
@@ -57,6 +59,7 @@
 - job-template:
     # DEFAULTS
     IMAGE: "Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)"
+    DEPLOY_SWIFT: "yes"
     DEPLOY_CEPH: "no"
     DEPLOY_ELK: "yes"
     CRON: "H H(9-21) * * 1-5"
@@ -76,6 +79,7 @@
       # See params.yml
       - rpc_params:
          RPC_BRANCH: "{branch}"
+         DEPLOY_SWIFT: "{DEPLOY_SWIFT}"
          DEPLOY_CEPH: "{DEPLOY_CEPH}"
          DEPLOY_ELK: "{DEPLOY_ELK}"
          USER_VARS: "{USER_VARS}"
@@ -126,6 +130,7 @@
               "DEPLOY_AIO=no",
               "DEPLOY_MAAS=no",
               "DEPLOY_TEMPEST=no",
+              "DEPLOY_SWIFT=${{DEPLOY_SWIFT}}",
               "DEPLOY_CEPH=${{DEPLOY_CEPH}}",
               "DEPLOY_ELK=${{DEPLOY_ELK}}",
               ]

--- a/rpc-jobs/params.yml
+++ b/rpc-jobs/params.yml
@@ -29,6 +29,10 @@
           name: "RPC_BRANCH"
           default: "{RPC_BRANCH}"
       - string:
+          name: "DEPLOY_SWIFT"
+          default: "{DEPLOY_SWIFT}"
+          description: "Deploy Swift? yes/no"
+      - string:
           name: "DEPLOY_CEPH"
           default: "{DEPLOY_CEPH}"
           description: "Deploy Ceph? yes/no"


### PR DESCRIPTION
Currently, all our builds include swift even when ceph is being used.  This commit explicitly removes swift from being deployed for the ceph job so that we have at least one job where swift is not being used.  This is necessary to partially cover the use case of swift not being present in an environment.