### PR TITLE
Run post-deployment steps in parallel

### DIFF
--- a/pipeline-steps/maas.groovy
+++ b/pipeline-steps/maas.groovy
@@ -21,6 +21,7 @@ def prepare(Map args) {
             username: env.PUBCLOUD_USERNAME,
             api_key: env.PUBCLOUD_API_KEY
           )
+          common.install_ansible()
           withEnv(["RAX_CREDS_FILE=${pyrax_cfg}"]){
             common.venvPlaybook(
               playbooks: ['aio-maas-entities.yml'],

--- a/rpc-jobs/multi-node-aio.yml
+++ b/rpc-jobs/multi-node-aio.yml
@@ -124,6 +124,9 @@
             parallel(
               "maas": {{
                 node(){{
+                  dir("rpc-gating"){{
+                    git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
+                  }}
                   maas.prepare(instance_name: instance_name)
                 }}
                 maas.deploy()

--- a/rpc-jobs/multi-node-aio.yml
+++ b/rpc-jobs/multi-node-aio.yml
@@ -109,7 +109,6 @@
           instance_name = common.gen_instance_name()
           pubCloudSlave.getPubCloudSlave(instance_name: instance_name)
 
-          maas.prepare(instance_name: instance_name)
           node(instance_name){{
             multi_node_aio_prepare.prepare()
             deploy.deploy_sh(
@@ -124,6 +123,9 @@
             ) // deploy_sh
             parallel(
               "maas": {{
+                node(){{
+                  maas.prepare(instance_name: instance_name)
+                }}
                 maas.deploy()
                 maas.verify()
               }},

--- a/rpc-jobs/multi-node-aio.yml
+++ b/rpc-jobs/multi-node-aio.yml
@@ -122,12 +122,24 @@
                 "DEPLOY_MAAS=no"
                 ]
             ) // deploy_sh
-            maas.deploy()
-            maas.verify()
-            tempest.tempest(vm: "infra1")
-            horizon.horizon_integration()
-            kibana.kibana()
-            holland.holland()
+            parallel(
+              "maas": {{
+                maas.deploy()
+                maas.verify()
+              }},
+              "tempest": {{
+                tempest.tempest(vm: "infra1")
+              }},
+              "horizon": {{
+                horizon.horizon_integration()
+              }},
+              "kibana": {{
+                kibana.kibana()
+              }},
+              "holland": {{
+                holland.holland()
+              }}
+            ) // parallel
           }}// public cloud node
         }} catch (e){{
             currentBuild.result = 'FAILURE'


### PR DESCRIPTION
The MaaS and test stages don't depend on each other, so I'm running them in parallel so that they don't block each other. We should probably revisit the Blue Ocean plugin at some point so that we can more easily view parallel steps in the UI.

https://rpc.jenkins.cit.rackspace.net/job/OnMetal_Multi_Node_AIO/171/


Connects https://github.com/rcbops/u-suk-dev/issues/1382