### PR TITLE
Skip linting scripts/add_jenkins_cred.groovy

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -38,7 +38,7 @@ check_groovy(){
   grc=0
   while read scriptf
   do groovy -classpath pipeline-steps $scriptf || grc=1
-  done < <(find ${fargs[@]} -name \*.groovy \! -name NonCPS.groovy )
+  done < <(find ${fargs[@]} -name \*.groovy \! -name NonCPS.groovy \! -name add_jenkins_cred.groovy)
 
   if [[ $grc == 0 ]]
   then


### PR DESCRIPTION
The lint job is currently failing because it cannot find classes that
are imported in scripts/add_jenkins_cred.groovy.  This commit adds a
temporary exclusion until we figure out how to best handle this
situation.