### PR TITLE
Add DEFAULT_KERNEL parameter

### DIFF
--- a/pipeline-steps/multi_node_aio_prepare.groovy
+++ b/pipeline-steps/multi_node_aio_prepare.groovy
@@ -17,6 +17,7 @@ def prepare() {
             "DEFAULT_NETWORK=eth0",
             "VM_DISK_SIZE=252",
             "DEFAULT_IMAGE=${env.DEFAULT_IMAGE}",
+            "DEFAULT_KERNEL=${env.DEFAULT_KERNEL}",
             "OSA_BRANCH=${env.OPENSTACK_ANSIBLE_BRANCH}",
             "SETUP_HOST=true",
             "SETUP_VIRSH_NET=true",

--- a/rpc-jobs/multi-node-aio.yml
+++ b/rpc-jobs/multi-node-aio.yml
@@ -58,6 +58,10 @@
           name: DEFAULT_IMAGE
           default: "{DEFAULT_IMAGE}"
           description: Version of Ubuntu image to use for VMs (14.04.5 or 16.04.2)
+      - string:
+          name: DEFAULT_KERNEL
+          default: "4.4.0-66"
+          description: Ubuntu Kernal Version to use for VMs (4.4.0-66, 3.13.0-34, etc.)
       - bool:
           name: PARTITION_HOST
           default: true


### PR DESCRIPTION
When we aren't setting this, the default kernel installed is 3.13.0-112-generic. Previous to https://github.com/openstack/openstack-ansible-ops/commit/9d9580d0912e9161cd16d6b61282204805c19ab1, 4.4.0-66-generic was used by default. With the 4.4.0-66-generic kernel, I'm no longer seeing the Trusty unreachable issues where some VMs are not available at the start of the RPC deployment.

https://rpc.jenkins.cit.rackspace.net/job/OnMetal_Multi_Node_AIO/177/
https://rpc.jenkins.cit.rackspace.net/job/OnMetal_Multi_Node_AIO/178/
https://rpc.jenkins.cit.rackspace.net/job/OnMetal_Multi_Node_AIO/179/
https://rpc.jenkins.cit.rackspace.net/job/OnMetal_Multi_Node_AIO_newton-trusty/8/
https://rpc.jenkins.cit.rackspace.net/job/OnMetal_Multi_Node_AIO_mitaka-trusty/6/
https://rpc.jenkins.cit.rackspace.net/job/OnMetal_Multi_Node_AIO_master-trusty/15/

Connects https://github.com/rcbops/u-suk-dev/issues/1383