### PR TITLE
Set cpu_quota for test_minimum_basic_scenario

### DIFF
--- a/pipeline-steps/tempest.groovy
+++ b/pipeline-steps/tempest.groovy
@@ -18,6 +18,16 @@ def tempest_run(Map args) {
   return output
 }
 
+def tempest_update_flavors(){
+  dir("/opt/rpc-openstack/openstack-ansible/playbooks") {
+    sh"""
+      ansible utility[0] -m shell \
+                         -a '. /root/openrc && nova flavor-key 201 set quota:cpu_quota=20000'
+      ansible utility[0] -m shell \
+                         -a '. /root/openrc && nova flavor-key 202 set quota:cpu_quota=20000'
+    """
+  }
+}
 
 /* if tempest install fails, don't bother trying to run or collect test results
  * however if running fails, we should still collect the failed results
@@ -35,6 +45,9 @@ def tempest(Map args){
     stage_name: "Install Tempest",
     stage: {
       tempest_install()
+      if (args != null && args.containsKey("vm")) {
+         tempest_update_flavors()
+      }
     }
   )
   common.conditionalStage(


### PR DESCRIPTION
The test_minimum_basic_scenario test is failing consistently on the
OnMetal AIO.  This commit attempts to limit the CPU quota (defaults
to "infinite CPU bandwidth") which seems to help prevent this test
from failing.

This will need to be tested more, but two initial tests:

https://rpc.jenkins.cit.rackspace.net/job/OnMetal_Multi_Node_AIO_master-trusty/30/
https://rpc.jenkins.cit.rackspace.net/job/OnMetal_Multi_Node_AIO_master-trusty/31/

Connects https://github.com/rcbops/u-suk-dev/issues/1312