### PR TITLE
Calculate and set ANSIBLE_FORKS

### DIFF
--- a/pipeline-steps/common.groovy
+++ b/pipeline-steps/common.groovy
@@ -100,7 +100,6 @@ def openstack_ansible(Map args){
         'ANSIBLE_SSH_RETRIES=3'])
       {
         sh """#!/bin/bash
-          echo ${ANSIBLE_FORKS}
           openstack-ansible ${args.playbook} ${args.args}
         """
       } //withEnv

--- a/pipeline-steps/deploy.groovy
+++ b/pipeline-steps/deploy.groovy
@@ -31,7 +31,6 @@ def deploy_sh(Map args) {
         ansiColor('xterm') {
           dir("/opt/rpc-openstack/") {
             sh """#!/bin/bash
-            echo ${ANSIBLE_FORKS}
             scripts/deploy.sh
             """
           } // dir

--- a/pipeline-steps/deploy.groovy
+++ b/pipeline-steps/deploy.groovy
@@ -25,6 +25,7 @@ def deploy_sh(Map args) {
         ['ANSIBLE_FORCE_COLOR=true',
          'ANSIBLE_HOST_KEY_CHECKING=False',
          'TERM=linux',
+         "FORKS=${forks}",
          "ANSIBLE_FORKS=${forks}",
          'ANSIBLE_SSH_RETRIES=3']
       withEnv(environment_vars) {

--- a/pipeline-steps/deploy.groovy
+++ b/pipeline-steps/deploy.groovy
@@ -20,12 +20,18 @@ def deploy_sh(Map args) {
   common.conditionalStage(
     stage_name: "Deploy RPC w/ Script",
     stage: {
+      forks = common.calc_ansible_forks()
       environment_vars = args.environment_vars +
-        ['ANSIBLE_FORCE_COLOR=true', 'ANSIBLE_HOST_KEY_CHECKING=False', 'TERM=linux']
+        ['ANSIBLE_FORCE_COLOR=true',
+         'ANSIBLE_HOST_KEY_CHECKING=False',
+         'TERM=linux',
+         "ANSIBLE_FORKS=${forks}",
+         'ANSIBLE_SSH_RETRIES=3']
       withEnv(environment_vars) {
         ansiColor('xterm') {
           dir("/opt/rpc-openstack/") {
             sh """#!/bin/bash
+            echo ${ANSIBLE_FORKS}
             scripts/deploy.sh
             """
           } // dir

--- a/rpc-jobs/multi-node-aio.yml
+++ b/rpc-jobs/multi-node-aio.yml
@@ -118,7 +118,6 @@
             multi_node_aio_prepare.prepare()
             deploy.deploy_sh(
               environment_vars: [
-                "FORKS=10",
                 "DEPLOY_HAPROXY=yes",
                 "DEPLOY_ELK=yes",
                 "DEPLOY_TEMPEST=no",


### PR DESCRIPTION
This commit adds a function to common.groovy to calculate a reasonable #
for ANSIBLE_FORKS, and then modifies any functions that call deploy.sh
or openstack-ansible to pass in the env var ANSIBLE_FORKS.

The reason for doing this is that on rpc-openstack's liberty and mitaka
branches, deploy.sh does not correctly set forks when running
rpc-openstack playbooks.  This is resulting in a number of job failures
due to ssh connection failures because it's picking up the forks = 15
in rpcd/playbooks/ansible.cfg.

We also set env var ANSIBLE_SSH_RETRIES=3 when running deploy.sh or
openstack-ansible.  This env var is ansible 2.x and above only, so will
have no affect on liberty and mitaka branches.

Connects https://github.com/rcbops/u-suk-dev/issues/1406