### PR TITLE
Run JJB update job on merges to rpc-gating master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,15 +6,22 @@ node(){
     lint_container = docker.build 'lint'
   }
   lint_container.inside {
-    stage("checkout"){
+    stage("Checkout"){
       checkout scm
     }
-    stage("lint"){
+    stage("Lint"){
       withEnv([
         'RPC_GATING_LINT_USE_VENV=no'
       ]){
         sh "./lint.sh 2>&1"
       }// withenv
     }// stage
+    //if this is a branch build for master
+    // (not a pr), run the JJB job to apply the changes.
+    stage("Apply"){
+      if(env.BRANCH_NAME=="master"){
+        build job: "Jenkins-Job-Builder"
+      }
+    }
   }// inside
 }// node


### PR DESCRIPTION
Prevents errors where jobs in repo don't match the live jobs.