### PR TITLE
Fix docker name conflict

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ node(){
   deleteDir()
   stage("Prepare"){
     checkout scm
-    lint_container = docker.build 'lint'
+    lint_container = docker.build env.BUILD_TAG.toLowerCase()
   }
   lint_container.inside {
     stage("Checkout"){


### PR DESCRIPTION
The rpc-openstack and jjb-run jobs both create a docker image
tagged lint. Unfortunately they contain different packages. This causes
a race as one job may build its container, but the other job retags it
before the first job uses it.

The solution is to use different image tags for each job.
connects u-suk-dev#1313