### PR TITLE
Use ssh_retry in ansible 1.9

### DIFF
--- a/pipeline-steps/common.groovy
+++ b/pipeline-steps/common.groovy
@@ -97,7 +97,10 @@ def openstack_ansible(Map args){
         'ANSIBLE_FORCE_COLOR=true',
         'ANSIBLE_HOST_KEY_CHECKING=False',
         "ANSIBLE_FORKS=${forks}",
-        'ANSIBLE_SSH_RETRIES=3'])
+        'ANSIBLE_SSH_RETRIES=3',
+        'ANSIBLE_GIT_RELEASE=ssh_retry', //only used in mitaka and below
+        'ANSIBLE_GIT_REPO="https://github.com/hughsaunders/ansible"' // only used in mitaka and below
+        ])
       {
         sh """#!/bin/bash
           openstack-ansible ${args.playbook} ${args.args}

--- a/pipeline-steps/deploy.groovy
+++ b/pipeline-steps/deploy.groovy
@@ -27,7 +27,10 @@ def deploy_sh(Map args) {
          'TERM=linux',
          "FORKS=${forks}",
          "ANSIBLE_FORKS=${forks}",
-         'ANSIBLE_SSH_RETRIES=3']
+         'ANSIBLE_SSH_RETRIES=3',
+         'ANSIBLE_GIT_RELEASE=ssh_retry', //only used in mitaka and below
+         'ANSIBLE_GIT_REPO="https://github.com/hughsaunders/ansible"' // only used in mitaka and below
+        ]
       withEnv(environment_vars) {
         ansiColor('xterm') {
           dir("/opt/rpc-openstack/") {


### PR DESCRIPTION
Upstream ansible doesn't have functionality for retrying failed ssh
connections before v2.

As we often see ssh connection failures, use a fork of ansible 1.9
that contains the ssh_retry connection plugin.

This only affects mitaka and below as newton and above use ansible v2.

Connects rcbops/u-suk-dev#1406