### PR TITLE
Apply ssh env vars to upgrades

### DIFF
--- a/pipeline-steps/aio_prepare.groovy
+++ b/pipeline-steps/aio_prepare.groovy
@@ -24,13 +24,12 @@ def prepare(){
         ])
         sh "git submodule update --init"
         ansiColor('xterm'){
-          withEnv([
+          withEnv( common.get_deploy_script_env() + [
             "DEPLOY_AIO=yes",
             "DEPLOY_OA=no",
             "DEPLOY_SWIFT=${env.DEPLOY_SWIFT}",
             "DEPLOY_ELK=${env.DEPLOY_ELK}",
-            "DEPLOY_RPC=no",
-            "ANSIBLE_FORCE_COLOR=true"
+            "DEPLOY_RPC=no"
           ]){
             sh """#!/bin/bash
             scripts/deploy.sh

--- a/pipeline-steps/deploy.groovy
+++ b/pipeline-steps/deploy.groovy
@@ -20,17 +20,7 @@ def deploy_sh(Map args) {
   common.conditionalStage(
     stage_name: "Deploy RPC w/ Script",
     stage: {
-      forks = common.calc_ansible_forks()
-      environment_vars = args.environment_vars +
-        ['ANSIBLE_FORCE_COLOR=true',
-         'ANSIBLE_HOST_KEY_CHECKING=False',
-         'TERM=linux',
-         "FORKS=${forks}",
-         "ANSIBLE_FORKS=${forks}",
-         'ANSIBLE_SSH_RETRIES=3',
-         'ANSIBLE_GIT_RELEASE=ssh_retry', //only used in mitaka and below
-         'ANSIBLE_GIT_REPO=https://github.com/hughsaunders/ansible' // only used in mitaka and below
-        ]
+      environment_vars = args.environment_vars + common.get_deploy_script_env()
       withEnv(environment_vars) {
         ansiColor('xterm') {
           dir("/opt/rpc-openstack/") {
@@ -48,8 +38,7 @@ def upgrade(Map args) {
   common.conditionalStage(
     stage_name: "Upgrade",
     stage: {
-      environment_vars = args.environment_vars +
-        ['ANSIBLE_FORCE_COLOR=true', 'ANSIBLE_HOST_KEY_CHECKING=False', 'TERM=linux']
+      environment_vars = args.environment_vars + common.get_deploy_script_env()
       withEnv(environment_vars){
         dir("/opt/rpc-openstack/openstack-ansible"){
           sh "git reset --hard"
@@ -57,6 +46,7 @@ def upgrade(Map args) {
         dir("/opt/rpc-openstack"){
           git branch: env.RPC_BRANCH, url: env.RPC_REPO
           sh """
+            env
             git submodule update --init
             scripts/test-upgrade.sh
           """


### PR DESCRIPTION
Previously we applied vars that improve ssh connection stability
(forks, ansible_git_repo etc) to deploy_sh, but didn't apply those to
the upgrade step. This ensures that both get the same vars.

Connects rcbops/u-suk-dev#1406