### PR TITLE
Add github pull request builder to webhook proxy

### DIFF
--- a/playbooks/webhooks.yml
+++ b/playbooks/webhooks.yml
@@ -15,6 +15,8 @@
           line: "GatewayPorts no"
         - regexp: "PasswordAuthentication"
           line: "PasswordAuthentication no"
+        - regexp: "ClientAliveInterval"
+          line: "ClientAliveInterval 15"
 
     - name: Install apt packages
       apt:
@@ -70,7 +72,7 @@
           server_name: "webhookproxy"
           root: "/dev/null"
           extra_parameters: |
-            location /github-webhook/ {
+            location ~ /(ghprb|github-webhook) {
               auth_basic "RPC Github Webhooks";
               auth_basic_user_file /var/lib/jenkins/.htpasswd;
               proxy_bind 127.0.0.1;


### PR DESCRIPTION
The webhook proxy was originally setup for use with the jenkins
github organisation folder plugin. Github pull request builder uses
a different hook target url which this commit adds to the proxy
configuration

connects rcbops/u-suk-dev#1313