### PR TITLE
Reduce slave executors to 2

### DIFF
--- a/scripts/jenkins_node.py
+++ b/scripts/jenkins_node.py
@@ -22,7 +22,7 @@ from jenkinsapi.jenkins import Jenkins
 def create_node(jenkins, host_ip, name, credential_description, labels=None,
                 remote_root_dir=None):
     node_dict = {
-        "num_executors": 15,
+        "num_executors": 2,
         "remote_fs": remote_root_dir or "/var/lib/jenkins",
         "labels": labels or "",
         "exclusive": True,


### PR DESCRIPTION
Currently most slaves are short-lived, so they
do not need more than 1 executor. Having 15
causes the Jenkins dashboard to be rather long
to scroll down and my finger occasionally gets
a cramp. I'd rather avoid that.

So, for a better world, we're reducing the
executors for any slave nodes created to 2.