### PR TITLE
Use the artifact_build.groovy file

### DIFF
--- a/rpc-jobs/RPC-Artifact-Build.yml
+++ b/rpc-jobs/RPC-Artifact-Build.yml
@@ -80,7 +80,7 @@
       node() {{
         dir("rpc-gating") {{
             git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-            artifact_build = load 'pipeline-steps/artifact-build.groovy'
+            artifact_build = load 'pipeline-steps/artifact_build.groovy'
             common = load 'pipeline-steps/common.groovy'
             pubcloud = load 'pipeline-steps/pubcloud.groovy'
         }}


### PR DESCRIPTION
In 3027b9acda764a5e38f2b77c6ca8799e68e852db I
unfortunately neglected to rename the file
name loaded for the artifact_build functions.
This fixes that.

Connects https://github.com/rcbops/u-suk-dev/issues/1432