### PR TITLE
Retain logs for 7 days

### DIFF
--- a/rpc-jobs/RPC-AIO.yml
+++ b/rpc-jobs/RPC-AIO.yml
@@ -87,7 +87,7 @@
     concurrent: true
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 7
     parameters:
       # See params.yml
       - rpc_params:


### PR DESCRIPTION
This is not ideal, but we need to keep this number low until we have
more storage allocated to the CIT instance or figure out a way to
send logs elsewhere.