### PR TITLE
Add github property for rpc-openstack

### DIFF
--- a/rpc-jobs/RPC-AIO.yml
+++ b/rpc-jobs/RPC-AIO.yml
@@ -88,6 +88,7 @@
     properties:
       - build-discarder:
           num-to-keep: 30
+      - rpc-openstack-github
     parameters:
       # See params.yml
       - rpc_params:

--- a/rpc-jobs/properties.yml
+++ b/rpc-jobs/properties.yml
@@ -1,0 +1,5 @@
+- property:
+    name: rpc-openstack-github
+    properties:
+      - github:
+          url: https://github.com/rcbops/rpc-openstack


### PR DESCRIPTION
Triggering is currently failing with the following:

Mar 23, 2017 5:41:28 PM org.jenkinsci.plugins.ghprb.GhprbRootAction getTriggers
SEVERE: Failed to match signature for trigger on project: RPC-AIO_master-xenial-pr
java.lang.IllegalStateException: A GitHub project url is required.
...

This is a futile attempt at fixing.