### PR TITLE
Trigger multi-node AIO on post merge

### DIFF
--- a/rpc-jobs/multi-node-aio.yml
+++ b/rpc-jobs/multi-node-aio.yml
@@ -47,6 +47,15 @@
             build job: 'OnMetal_Multi_Node_AIO_{series}-xenial-post-merge'
           }}
         }} // stage
+        stage('Push to rpc-openstack'){{
+         sshagent (credentials:['rpc-jenkins-svc-github-ssh-key']){{
+           sh """
+             mkdir -p ~/.ssh
+             ssh-keyscan github.com >> ~/.ssh/known_hosts
+             git push -f git@github.com:rcbops/rpc-openstack HEAD:omna-approved-{series}
+             """
+         }} // sshagent
+        }} // stage
       }} // node
 
 - job-template:

--- a/rpc-jobs/multi-node-aio.yml
+++ b/rpc-jobs/multi-node-aio.yml
@@ -20,6 +20,28 @@
         context: xenial
     jobs:
       - 'OnMetal_Multi_Node_AIO_{series}-{context}'
+      - 'OnMetal_Multi_Node_AIO_Merge_Trigger_{series}'
+
+- job-template:
+    name: 'OnMetal_Multi_Node_AIO_Merge_Trigger_{series}'
+    project-type: workflow
+    properties:
+      - build-discarder:
+          days-to-keep: 7
+      - rpc-openstack-github
+    triggers:
+      - github
+    dsl: |
+      node(){{
+        stage('OnMetal Multi-Node AIO') {{
+          git branch: "{branch}", url: "https://github.com/rcbops/rpc-openstack"
+          if("{series}" == "mitaka"){{
+            build job: 'OnMetal_Multi_Node_AIO_mitaka-trusty'
+          }} else {{
+            build job: 'OnMetal_Multi_Node_AIO_{series}-xenial'
+          }}
+        }} // stage
+      }} // node
 
 - job-template:
     name: 'OnMetal_Multi_Node_AIO_{series}-{context}'
@@ -27,6 +49,7 @@
     properties:
       - build-discarder:
           days-to-keep: 7
+      - rpc-openstack-github
     concurrent: true
     triggers:
       - timed: "H H(0-8) * * 1-5"

--- a/rpc-jobs/multi-node-aio.yml
+++ b/rpc-jobs/multi-node-aio.yml
@@ -15,11 +15,16 @@
           DEFAULT_IMAGE: "16.04.2"
       - trusty:
           DEFAULT_IMAGE: "14.04.5"
+    trigger:
+      - periodic:
+          CRON: "H H(0-8) * * 1-5"
+      - post-merge:
+          CRON: ""
     exclude:
       - series: mitaka
         context: xenial
     jobs:
-      - 'OnMetal_Multi_Node_AIO_{series}-{context}'
+      - 'OnMetal_Multi_Node_AIO_{series}-{context}-{trigger}'
       - 'OnMetal_Multi_Node_AIO_Merge_Trigger_{series}'
 
 - job-template:
@@ -29,6 +34,7 @@
       - build-discarder:
           days-to-keep: 7
       - rpc-openstack-github
+    concurrent: true
     triggers:
       - github
     dsl: |
@@ -36,15 +42,15 @@
         stage('OnMetal Multi-Node AIO') {{
           git branch: "{branch}", url: "https://github.com/rcbops/rpc-openstack"
           if("{series}" == "mitaka"){{
-            build job: 'OnMetal_Multi_Node_AIO_mitaka-trusty'
+            build job: 'OnMetal_Multi_Node_AIO_mitaka-trusty-post-merge'
           }} else {{
-            build job: 'OnMetal_Multi_Node_AIO_{series}-xenial'
+            build job: 'OnMetal_Multi_Node_AIO_{series}-xenial-post-merge'
           }}
         }} // stage
       }} // node
 
 - job-template:
-    name: 'OnMetal_Multi_Node_AIO_{series}-{context}'
+    name: 'OnMetal_Multi_Node_AIO_{series}-{context}-{trigger}'
     project-type: workflow
     properties:
       - build-discarder:
@@ -52,7 +58,7 @@
       - rpc-openstack-github
     concurrent: true
     triggers:
-      - timed: "H H(0-8) * * 1-5"
+      - timed: "{CRON}"
     parameters:
       - rpc_gating_params
       - string:


### PR DESCRIPTION
Because pipeline jobs don't have an scm section where you can specify which branch and repo to watch, I made a separate trigger job to call the omna job. Pipelines use the repo and branch of the last build, so that git info is hardcoded into the trigger jobs.

Connects https://github.com/rcbops/u-suk-dev/issues/1358