### PR TITLE
Create defaults file

### DIFF
--- a/rpc-jobs/RPC-AIO.yml
+++ b/rpc-jobs/RPC-AIO.yml
@@ -70,15 +70,6 @@
 
 - job-template:
     # DEFAULTS
-    IMAGE: "Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)"
-    DEPLOY_SWIFT: "yes"
-    DEPLOY_CEPH: "no"
-    DEPLOY_ELK: "yes"
-    CRON: "H H(9-21) * * 1-5"
-    CONTEXT_USER_VARS: ""
-    TRIGGER_USER_VARS: ""
-    SERIES_USER_VARS: ""
-    UPGRADE_FROM_REF: "liberty-12.2"
     STAGES: "Allocate Resources, Connect Slave, Prepare Deployment, Deploy RPC w/ Script, Setup MaaS, Verify MaaS, Install Tempest, Tempest Tests, Cleanup"
     branch: master
     NUM_TO_KEEP: 30
@@ -107,8 +98,8 @@
       - rpc_gating_params
       - single_use_slave_params:
          IMAGE: "{IMAGE}"
-         FLAVOR: "performance2-15"
-         REGION: "DFW"
+         FLAVOR: "{FLAVOR}"
+         REGION: "{REGION}"
       - tempest_params:
          TEMPEST_TEST_SETS: "scenario defcore cinder_backup"
          RUN_TEMPEST_OPTS: "--serial"

--- a/rpc-jobs/RPC-Artifact-Build.yml
+++ b/rpc-jobs/RPC-Artifact-Build.yml
@@ -7,8 +7,7 @@
           branch: artifacts-14.0
           branches: "artifacts-.*"
     image:
-      - trusty:
-          IMAGE: "Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)"
+      - trusty
     context:
       - Git
       - Apt
@@ -43,15 +42,6 @@
 
 - job-template:
     # DEFAULTS
-    IMAGE: "Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)"
-    DEPLOY_SWIFT: "yes"
-    DEPLOY_CEPH: "yes"
-    DEPLOY_ELK: "yes"
-    CRON: "H H(9-21) * * 1-5"
-    CONTEXT_USER_VARS: ""
-    TRIGGER_USER_VARS: ""
-    SERIES_USER_VARS: ""
-    UPGRADE_FROM_REF: ""
     STAGES: >-
       Build Apt Artifacts,
       Build Git Artifacts,
@@ -79,8 +69,8 @@
       - rpc_gating_params
       - single_use_slave_params:
          IMAGE: "{IMAGE}"
-         FLAVOR: "performance2-15"
-         REGION: "DFW"
+         FLAVOR: "{FLAVOR}"
+         REGION: "{REGION}"
       - string:
           name: ANSIBLE_PARAMETERS
           default: "-v"

--- a/rpc-jobs/defaults.yml
+++ b/rpc-jobs/defaults.yml
@@ -1,0 +1,16 @@
+- defaults:
+    # single_use_slave_params
+    name: global
+    IMAGE: "Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)"
+    FLAVOR: "performance2-15"
+    REGION: "dfw"
+    # rpc_params
+    DEPLOY_SWIFT: "yes"
+    DEPLOY_CEPH: "no"
+    DEPLOY_ELK: "yes"
+    # Misc
+    CRON: "H H(9-21) * * 1-5"
+    CONTEXT_USER_VARS: ""
+    TRIGGER_USER_VARS: ""
+    SERIES_USER_VARS: ""
+    UPGRADE_FROM_REF: "liberty-12.2"

--- a/rpc-jobs/single_use_slave_template.yml
+++ b/rpc-jobs/single_use_slave_template.yml
@@ -7,8 +7,8 @@
       # params you want to override the defaults for.
       - single_use_slave_params:
           IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
-          FLAVOR: "performance2-15"
-          REGION: "DFW"
+          FLAVOR: "{FLAVOR}"
+          REGION: "{REGION}"
       - rpc_gating_params
       - string:
           name: STAGES


### PR DESCRIPTION
This PR moves a bunch of job defaults to global defaults.

There is a huge net benefit of doing this, however it does mean we can
remove the raft of default variables set in RPC-AIO.yml and
RPC-Artifact-Build.yml and should we need to change REGION quickly, for
example, we can do it on place versus 3.

This needs to be re-tested once the lint job is triggering again.

Connects https://github.com/rcbops/u-suk-dev/issues/1493