### PR TITLE
Make sure PUSH_TO_MIRROR is a string

### DIFF
--- a/rpc-jobs/RPC-Artifact-Build.yml
+++ b/rpc-jobs/RPC-Artifact-Build.yml
@@ -20,7 +20,7 @@
       - periodic:
           branches: "do_not_build_on_pr"
           STAGES: "Allocate Resources, Connect Slave, Prepare Deployment, Build Python Artifacts, Build Container Artifacts, Cleanup"
-          PUSH_TO_MIRROR: yes
+          PUSH_TO_MIRROR: "YES"
     exclude:
       - context: Python
         ztrigger: periodic


### PR DESCRIPTION
Currently it's evaluated by JJB as a boolean which
is not properly catered for in the scripts. This
patch ensures that the value is always set to a
string for all jobs.

Connects https://github.com/rcbops/u-suk-dev/issues/1413