### PR TITLE
Set overrides to fix OnMetal tempest failures

### DIFF
--- a/playbooks/vars/all.yml
+++ b/playbooks/vars/all.yml
@@ -3,6 +3,7 @@ gating_overrides_file: "/etc/openstack_deploy/user_zzz_gating_variables.yml"
 
 default_gating_overrides:
   maas_notification_plan: npTechnicalContactsEmail
+  nova_virt_type: qemu
   rackspace_cloud_auth_url: "https://identity.api.rackspacecloud.com/v2.0/"
   rackspace_cloud_tenant_id: "{{lookup('env', 'PUBCLOUD_TENANT_ID')}}"
   rackspace_cloud_username: "{{lookup('env', 'PUBCLOUD_USERNAME')}}"
@@ -14,3 +15,9 @@ default_gating_overrides:
     - container_quotas
     - slo
     - tempurl
+  # NOTE(mattt): This can be removed once we drop gating osa's stable/mitaka
+  tempest_tempest_conf_overrides:
+    object-storage:
+      reseller_admin_role: ResellerAdmin
+    compute-feature-enabled:
+      personality: false


### PR DESCRIPTION
This commit sets some openstack-ansible ansible overrides to fix a
number of tempest failures we see on the OnMetal jobs.  To summarise:

- use qemu instead of kvm (running nested virt (kvm) seems unstable and
  we end up getting a number of job failures that we do not see on the
  single node AIO or hardware labs)
- set reseller_admin_role in tempest.conf to match what gets created by
  swift (this is only an issue on stable/mitaka, the default value is
  already correct on later branches)
- disable personality in tempest.conf as our nova service by default
  disallows file injection (again, only needed on stable/mitaka as
  later versions of tempest seem to detect this correctly)

Ideally, we'll want to find the root cause of the kvm failures and try
to work around this so that we can continue to use kvm, but for now
this unblocks the gate and allows us to make use of the OnMetal build.

Connects https://github.com/rcbops/u-suk-dev/issues/1312