### PR TITLE
Artifact job refactor

### DIFF
--- a/pipeline-steps/artifact_build.groovy
+++ b/pipeline-steps/artifact_build.groovy
@@ -1,71 +1,100 @@
-def python(Map args) {
+def get_rpc_repo_creds(){
+  return [
+    string(
+      credentialsId: "RPC_REPO_IP",
+      variable: "REPO_HOST"
+    ),
+    string(
+      credentialsId: "RPC_REPO_SSH_USERNAME_TEXT",
+      variable: "REPO_USER"
+    ),
+    file(
+      credentialsId: "RPC_REPO_SSH_USER_PRIVATE_KEY_FILE",
+      variable: "REPO_USER_KEY"
+    ),
+    file(
+      credentialsId: "RPC_REPO_SSH_HOST_PUBLIC_KEY_FILE",
+      variable: "REPO_HOST_PUBKEY"
+    ),
+    file(
+      credentialsId: "RPC_REPO_GPG_SECRET_KEY_FILE",
+      variable: "GPG_PRIVATE"
+    ),
+    file(
+      credentialsId: "RPC_REPO_GPG_PUBLIC_KEY_FILE",
+      variable: "GPG_PUBLIC"
+    )
+  ]
+}
+
+def apt() {
   common.conditionalStage(
-    stage_name: "Build Python Artifacts",
+    stage_name: "Build Apt Artifacts",
     stage: {
-      withEnv(args.environment_vars) {
-        withCredentials([
-          string(
-            credentialsId: "RPC_REPO_IP",
-            variable: "REPO_HOST"
-          ),
-          string(
-            credentialsId: "RPC_REPO_SSH_USERNAME_TEXT",
-            variable: "REPO_USER"
-          ),
-          file(
-            credentialsId: "RPC_REPO_SSH_USER_PRIVATE_KEY_FILE",
-            variable: "REPO_USER_KEY"
-          ),
-          file(
-            credentialsId: "RPC_REPO_SSH_HOST_PUBLIC_KEY_FILE",
-            variable: "REPO_HOST_PUBKEY"
-          )
-        ]){
-          ansiColor('xterm') {
-            dir("/opt/rpc-openstack/") {
-              sh """#!/bin/bash
-              scripts/artifacts-building/python/build-python-artifacts.sh
-              """
-            } // dir
-          } // ansiColor
-        } // withCredentials
-      } // withEnv
+      withCredentials(get_rpc_repo_creds()) {
+        prepareRpcGit()
+        ansiColor('xterm') {
+          dir("/opt/rpc-openstack/") {
+            sh """#!/bin/bash
+            scripts/artifacts-building/apt/build-apt-artifacts.sh
+            """
+          } // dir
+        } // ansiColor
+      } // withCredentials
     } // stage
   ) // conditionalStage
 }
 
-def container(Map args) {
+def python() {
+  common.conditionalStage(
+    stage_name: "Build Python Artifacts",
+    stage: {
+      pubcloud.runonpubcloud {
+        try {
+          withCredentials(get_rpc_repo_creds()) {
+            prepareRpcGit()
+            ansiColor('xterm') {
+              dir("/opt/rpc-openstack/") {
+                sh """#!/bin/bash
+                scripts/artifacts-building/python/build-python-artifacts.sh
+                """
+              } // dir
+            } // ansiColor
+          } // withCredentials
+        } catch (e) {
+          print(e)
+          throw e
+        } finally {
+          common.archive_artifacts()
+        }
+      } // pubcloud slave
+    } // stage
+  ) // conditionalStage
+}
+
+def container() {
   common.conditionalStage(
     stage_name: "Build Container Artifacts",
     stage: {
-      withEnv(args.environment_vars) {
-        withCredentials([
-          string(
-            credentialsId: "RPC_REPO_IP",
-            variable: "REPO_HOST"
-          ),
-          string(
-            credentialsId: "RPC_REPO_SSH_USERNAME_TEXT",
-            variable: "REPO_USER"
-          ),
-          file(
-            credentialsId: "RPC_REPO_SSH_USER_PRIVATE_KEY_FILE",
-            variable: "REPO_USER_KEY"
-          ),
-          file(
-            credentialsId: "RPC_REPO_SSH_HOST_PUBLIC_KEY_FILE",
-            variable: "REPO_HOST_PUBKEY"
-          )
-        ]){
-          ansiColor('xterm') {
-            dir("/opt/rpc-openstack/") {
-              sh """#!/bin/bash
-              scripts/artifacts-building/containers/build-process.sh
-              """
-            } // dir
-          } // ansiColor
-        } // withCredentials
-      } // withEnv
+      pubcloud.runonpubcloud {
+        try {
+          withCredentials(get_rpc_repo_creds()) {
+            prepareRpcGit()
+            ansiColor('xterm') {
+              dir("/opt/rpc-openstack/") {
+                sh """#!/bin/bash
+                scripts/artifacts-building/containers/build-process.sh
+                """
+              } // dir
+            } // ansiColor
+          } // withCredentials
+        } catch (e) {
+          print(e)
+          throw e
+        } finally {
+          common.archive_artifacts()
+        }
+      } // pubcloud slave
     } // stage
   ) // conditionalStage
 }

--- a/rpc-jobs/RPC-Artifact-Build.yml
+++ b/rpc-jobs/RPC-Artifact-Build.yml
@@ -10,18 +10,20 @@
       - trusty:
           IMAGE: "Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)"
     context:
+      - Apt
       - Python
       - Container
       - Pipeline
     ztrigger:
       - pr:
           CRON: ""
-          STAGES: "Allocate Resources, Connect Slave, Prepare Deployment, Build {context} Artifacts, Cleanup"
+          STAGES: "Allocate Resources, Connect Slave, Build {context} Artifacts, Cleanup"
       - periodic:
           branches: "do_not_build_on_pr"
-          STAGES: "Allocate Resources, Connect Slave, Prepare Deployment, Build Python Artifacts, Build Container Artifacts, Cleanup"
           PUSH_TO_MIRROR: "YES"
     exclude:
+      - context: Apt
+        ztrigger: periodic
       - context: Python
         ztrigger: periodic
       - context: Container
@@ -42,7 +44,7 @@
     TRIGGER_USER_VARS: ""
     SERIES_USER_VARS: ""
     UPGRADE_FROM_REF: ""
-    STAGES: "Allocate Resources, Connect Slave, Prepare Deployment, Build Python Artifacts, Build Container Artifacts, Cleanup"
+    STAGES: "Build Apt Artifacts, Allocate Resources, Connect Slave, Build Python Artifacts, Build Container Artifacts, Cleanup"
     branch: artifacts-14.0
     PUSH_TO_MIRROR: "NO"
 
@@ -74,7 +76,7 @@
             Options:
               Allocate Resources
               Connect Slave
-              Prepare Deployment
+              Build Apt Artifacts
               Build Python Artifacts
               Build Container Artifacts
               Pause (use to hold instance for investigation before cleanup)
@@ -92,49 +94,21 @@
           auth-id: "github_account_rpc_jenkins_svc"
           status-context: 'CIT/artifact-{image}-{context}'
     dsl: |
-      // CIT Slave node
+      node('ArtifactBuilder2') {{
+        dir("rpc-gating") {{
+            git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
+            common = load 'pipeline-steps/common.groovy'
+            artifact_build = load 'pipeline-steps/artifact_build.groovy'
+        }}
+        artifact_build.apt()
+      }} // node ArtifactBuilder2
       node() {{
         dir("rpc-gating") {{
             git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
             common = load 'pipeline-steps/common.groovy'
             pubcloud = load 'pipeline-steps/pubcloud.groovy'
-            aio_prepare = load 'pipeline-steps/aio_prepare.groovy'
             artifact_build = load 'pipeline-steps/artifact_build.groovy'
         }}
-        if (env.STAGES.contains("Build Python Artifacts")) {{
-          pubcloud.runonpubcloud {{
-            // try within pubcloud node so we can archive archive_artifacts
-            // after a failure, before the node is cleaned up.
-            try {{
-              environment_vars = [
-                "PUSH_TO_MIRROR=${{PUSH_TO_MIRROR}}",
-              ]
-              aio_prepare.prepare()
-              artifact_build.python(environment_vars: environment_vars)
-            }} catch (e) {{
-              print(e)
-              throw e
-            }} finally {{
-              common.archive_artifacts()
-            }}
-          }} // pubcloud slave
-        }} // if
-        if (env.STAGES.contains("Build Container Artifacts")) {{
-          pubcloud.runonpubcloud {{
-            // try within pubcloud node so we can archive archive_artifacts
-            // after a failure, before the node is cleaned up.
-            try {{
-              environment_vars = [
-                "PUSH_TO_MIRROR=${{PUSH_TO_MIRROR}}",
-              ]
-              aio_prepare.prepare()
-              artifact_build.container(environment_vars: environment_vars)
-            }} catch (e) {{
-              print(e)
-              throw e
-            }} finally {{
-              common.archive_artifacts()
-            }}
-          }} // pubcloud slave
-        }} // if
-      }} // cit node
+        artifact_build.python()
+        artifact_build.container()
+      }} // node


### PR DESCRIPTION
This patch aims to refactor the Artifact jobs so
that they more effectively use stages, and share
a common structure. The detailed steps are all in
the groovy file, whereas the pipeline logic is
formed into stages in the job dsl.

An additional job is also added to build apt
artifacts. This job runs on a jenkins slave rather
than a single-use node.

A common script to get the credentials into the
environment is used for all jobs.

Connects https://github.com/rcbops/u-suk-dev/issues/1451