### PR TITLE
Properly refer to prepareRpcGit

### DIFF
--- a/pipeline-steps/aio_prepare.groovy
+++ b/pipeline-steps/aio_prepare.groovy
@@ -2,7 +2,7 @@ def prepare(){
   common.conditionalStage(
     stage_name: "Prepare Deployment",
     stage: {
-      prepareRpcGit()
+      common.prepareRpcGit()
       ansiColor('xterm'){
         dir("/opt/rpc-openstack"){
           withEnv( common.get_deploy_script_env() + [

--- a/pipeline-steps/artifact_build.groovy
+++ b/pipeline-steps/artifact_build.groovy
@@ -32,7 +32,7 @@ def apt() {
     stage_name: "Build Apt Artifacts",
     stage: {
       withCredentials(get_rpc_repo_creds()) {
-        prepareRpcGit()
+        common.prepareRpcGit()
         ansiColor('xterm') {
           dir("/opt/rpc-openstack/") {
             sh """#!/bin/bash
@@ -52,7 +52,7 @@ def python() {
       pubcloud.runonpubcloud {
         try {
           withCredentials(get_rpc_repo_creds()) {
-            prepareRpcGit()
+            common.prepareRpcGit()
             ansiColor('xterm') {
               dir("/opt/rpc-openstack/") {
                 sh """#!/bin/bash
@@ -79,7 +79,7 @@ def container() {
       pubcloud.runonpubcloud {
         try {
           withCredentials(get_rpc_repo_creds()) {
-            prepareRpcGit()
+            common.prepareRpcGit()
             ansiColor('xterm') {
               dir("/opt/rpc-openstack/") {
                 sh """#!/bin/bash


### PR DESCRIPTION
In d7bbaa9aa726058290e22fa3bbf987ff8ff14a84 the namespace
for the prepareRpcGit was left out. This adds it.