### PR TITLE
Fix JJB issue

### DIFF
--- a/rpc-jobs/RPC-AIO.yml
+++ b/rpc-jobs/RPC-AIO.yml
@@ -89,7 +89,7 @@
     concurrent: true
     properties:
       - build-discarder:
-          num-to-keep: {NUM_TO_KEEP}
+          num-to-keep: "{NUM_TO_KEEP}"
       - rpc-openstack-github
     parameters:
       # See params.yml

--- a/rpc-jobs/RPC-Artifact-Build.yml
+++ b/rpc-jobs/RPC-Artifact-Build.yml
@@ -56,7 +56,7 @@
     concurrent: false
     properties:
       - build-discarder:
-          num-to-keep: {NUM_TO_KEEP}
+          num-to-keep: "{NUM_TO_KEEP}"
     parameters:
       # See params.yml
       - rpc_repo_params:


### PR DESCRIPTION
The jobs in Jenkins are currently displaying the following error:

Not a positive integer

This commit wraps {NUM_TO_BUILD} in quotes which seems to resolve
this issue.