### PR TITLE
Fail if less than required num of instances booted

### DIFF
--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -20,6 +20,11 @@
       retries: 120
       delay: 60
 
+    - name: Fail if the required number of instances aren't available
+      fail:
+        msg: "At least one public cloud instance failed to start :("
+      when: rax.success|length < count
+
     - name: Write inventory
       copy:
         content: |


### PR DESCRIPTION
 It is possible for the rax module to return success despite not successfully creating instances. This commit adds a check to ensure that the requested number of instances are successfully booted.


Connects rcbops/u-suk-dev#1507