### PR TITLE
Use prepareRpcGit in upgrade testing

### DIFF
--- a/pipeline-steps/aio_prepare.groovy
+++ b/pipeline-steps/aio_prepare.groovy
@@ -2,7 +2,11 @@ def prepare(){
   common.conditionalStage(
     stage_name: "Prepare Deployment",
     stage: {
-      common.prepareRpcGit()
+      if (env.STAGES.contains("Upgrade")) {
+        common.prepareRpcGit(branch: env.UPGRADE_FROM_REF)
+      } else {
+        common.prepareRpcGit(branch: env.RPC_BRANCH)
+      } // if
       ansiColor('xterm'){
         dir("/opt/rpc-openstack"){
           withEnv( common.get_deploy_script_env() + [

--- a/pipeline-steps/artifact_build.groovy
+++ b/pipeline-steps/artifact_build.groovy
@@ -32,7 +32,7 @@ def apt() {
     stage_name: "Build Apt Artifacts",
     stage: {
       withCredentials(get_rpc_repo_creds()) {
-        common.prepareRpcGit()
+        common.prepareRpcGit(branch: env.RPC_BRANCH)
         ansiColor('xterm') {
           dir("/opt/rpc-openstack/") {
             sh """#!/bin/bash
@@ -52,7 +52,7 @@ def git() {
       pubcloud.runonpubcloud {
         try {
           withCredentials(get_rpc_repo_creds()) {
-            common.prepareRpcGit()
+            common.prepareRpcGit(branch: env.RPC_BRANCH)
             ansiColor('xterm') {
               dir("/opt/rpc-openstack/") {
                 sh """#!/bin/bash
@@ -79,7 +79,7 @@ def python() {
       pubcloud.runonpubcloud {
         try {
           withCredentials(get_rpc_repo_creds()) {
-            common.prepareRpcGit()
+            common.prepareRpcGit(branch: env.RPC_BRANCH)
             ansiColor('xterm') {
               dir("/opt/rpc-openstack/") {
                 sh """#!/bin/bash
@@ -106,7 +106,7 @@ def container() {
       pubcloud.runonpubcloud {
         try {
           withCredentials(get_rpc_repo_creds()) {
-            common.prepareRpcGit()
+            common.prepareRpcGit(branch: env.RPC_BRANCH)
             ansiColor('xterm') {
               dir("/opt/rpc-openstack/") {
                 sh """#!/bin/bash

--- a/pipeline-steps/common.groovy
+++ b/pipeline-steps/common.groovy
@@ -331,17 +331,12 @@ def prepareConfigs(Map args){
   } //withCredentials
 }
 
-def prepareRpcGit(){
+def prepareRpcGit(Map args){
   dir("/opt/rpc-openstack"){
-    if (env.STAGES.contains("Upgrade")) {
-      branch = env.UPGRADE_FROM_REF
-    } else {
-      branch = env.RPC_BRANCH
-    } // if
     // checkout used instead of git as a custom refspec is required
     // to checkout pull requests
     checkout([$class: 'GitSCM',
-      branches: [[name: branch ]],
+      branches: [[name: args.branch]],
       doGenerateSubmoduleConfigurations: false,
       extensions: [[$class: 'CleanCheckout']],
       submoduleCfg: [],

--- a/pipeline-steps/deploy.groovy
+++ b/pipeline-steps/deploy.groovy
@@ -43,11 +43,9 @@ def upgrade(Map args) {
         dir("/opt/rpc-openstack/openstack-ansible"){
           sh "git reset --hard"
         }
+        common.prepareRpcGit(branch: env.RPC_BRANCH)
         dir("/opt/rpc-openstack"){
-          git branch: env.RPC_BRANCH, url: env.RPC_REPO
           sh """
-            env
-            git submodule update --init
             scripts/test-upgrade.sh
           """
         } // dir


### PR DESCRIPTION
The RPC-AIO_mitaka-upgrade-pr job is currently failing when attempting
to upgrade to RPC_BRANCH.  This commit updates deploy.upgrade() to use
prepareRpcGit and updates common.prepareRpcGit() to accept the desired
branch as an argument.  We then move out the upgrade conditional logic
into aio_prepare.prepare().

Connects https://github.com/rcbops/u-suk-dev/issues/1506