### PR TITLE
Override ceph_stable_release

### DIFF
--- a/rpc-jobs/RPC-AIO.yml
+++ b/rpc-jobs/RPC-AIO.yml
@@ -24,6 +24,7 @@
           DEPLOY_SWIFT: "no"
           DEPLOY_CEPH: "yes"
           CONTEXT_USER_VARS: |
+            ceph_stable_release: "hammer"
             cinder_cinder_conf_overrides:
                 DEFAULT:
                     default_volume_type: ceph


### PR DESCRIPTION
This variable is on it's way to changing to jewel in RPCO,
see https://github.com/rcbops/rpc-openstack/pull/2117. However,
the newton+trusty+ceph job currently deploys hammer, and we will
like to keep it that way. This commit overrides ceph_stable_release
to hammer.

Connects https://github.com/rcbops/u-suk-dev/issues/1536