### PR TITLE
Use COPY instead of ADD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu
 RUN apt-get update && apt-get install -y groovy2 python-pip build-essential python-dev libssl-dev
 RUN apt-get install -y libffi-dev
 RUN apt-get install -y sudo
-ADD requirements.txt /requirements.txt
-ADD constraints.txt /constraints.txt
+COPY requirements.txt /requirements.txt
+COPY constraints.txt /constraints.txt
 RUN pip install -c /constraints.txt -r /requirements.txt
 RUN useradd jenkins --shell /bin/bash --create-home --uid 500
 RUN echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -352,4 +352,12 @@ def prepareRpcGit(Map args){
   } // dir
 }
 
+/* Set mtime to a constant value as git doesn't track mtimes but
+ * docker 1.7 does, this causes cache invalidation when files are
+ * added.
+ */
+def docker_cache_workaround(){
+   sh "touch -t 201704100000 *.txt"
+}
+
 return this

--- a/rpc_jobs/rpc_gating_lint.yml
+++ b/rpc_jobs/rpc_gating_lint.yml
@@ -19,6 +19,8 @@
         deleteDir()
         stage("Prepare"){
           git url: env.ghprbAuthorRepoGitUrl, branch: ghprbSourceBranch
+          common = load 'pipeline_steps/common.groovy'
+          common.docker_cache_workaround()
           lint_container = docker.build env.BUILD_TAG.toLowerCase()
         }
         lint_container.inside {

--- a/rpc_jobs/rpc_gating_lint.yml
+++ b/rpc_jobs/rpc_gating_lint.yml
@@ -1,6 +1,7 @@
 - job:
     name: 'RPC-Gating-Lint'
     project-type: workflow
+    concurrent: true
     triggers:
       - github-pull-request:
           org-list:


### PR DESCRIPTION
I forgot to use COPY instead of ADD. ADD is more likely to cause cache invalidations, so that's why Docker kept having to reinstall the python packages.

https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#add-or-copy

Connects https://github.com/rcbops/u-suk-dev/issues/1539