### PR TITLE
Add Periodic Cleanup Job

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -40,6 +40,7 @@ pycparser==2.17
 pycrypto==2.6.1
 pyparsing==2.2.0
 pyrax==1.9.8
+python-dateutil==2.6.0
 python-jenkins==0.4.14
 python-keystoneclient==3.10.0
 python-novaclient==2.27.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ansible
 jenkins-job-builder
 jenkinsapi
 pyrax
+python-dateutil

--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -1,0 +1,57 @@
+- job:
+    name: 'Periodic-Cleanup'
+    project-type: workflow
+    parameters:
+      - string:
+          name: "INSTANCE_AGE_LIMIT"
+          default: "48"
+          description: |
+            Hours. Instances older than this will be removed.
+      - string:
+          name: "INSTANCE_PREFIX"
+          default: "ra"
+          description: |
+            Only instances whose names match the supplied prefix will be cleaned
+            up.
+      - string:
+          name: "REGION"
+          default: "DFW"
+          description: |
+            Only instances in the specified region will be cleaned up.
+      - rpc_gating_params
+    triggers:
+      - timed: "H * * * *"
+    properties:
+      - build-discarder:
+          days-to-keep: 3
+    dsl: |
+      node(){
+        deleteDir()
+        stage("Prepare"){
+          dir("rpc-gating") {
+              git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
+              common = load 'pipeline_steps/common.groovy'
+              common.docker_cache_workaround()
+              container = docker.build env.BUILD_TAG.toLowerCase()
+          }
+        }
+        container.inside {
+          stage("Checkout"){
+            git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
+          }
+          stage("Public Cloud Cleanup"){
+            withCredentials([
+              string(
+                credentialsId: "dev_pubcloud_username",
+                variable: "PUBCLOUD_USERNAME"
+              ),
+              string(
+                credentialsId: "dev_pubcloud_api_key",
+                variable: "PUBCLOUD_API_KEY"
+              ),
+            ]){
+              sh "python scripts/periodic_cleanup.py"
+            }
+          }
+        }
+      }

--- a/scripts/periodic_cleanup.py
+++ b/scripts/periodic_cleanup.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+# This script deletes instances whose name starts with "ra" if they are in
+# error state or older than AGE_LIMIT hours.
+
+
+import datetime
+import dateutil.parser
+from dateutil.tz import tzutc
+import os
+
+import pyrax
+
+
+def get_env_vars():
+    env_vars = {}
+
+    env_vars["age_limit"] = int(os.environ.get("INSTANCE_AGE_LIMIT", 48))
+    env_vars["instance_prefix"] = os.environ.get("INSTANCE_PREFIX", "ra")
+    if not env_vars["instance_prefix"]:
+        raise ValueError("INSTANCE_PREFIX must not be empty")
+
+    env_vars["username"] = os.environ["PUBCLOUD_USERNAME"]
+    env_vars["api_key"] = os.environ["PUBCLOUD_API_KEY"]
+    env_vars["region_name"] = os.environ["REGION"]
+
+    return env_vars
+
+
+def cleanup_instances(cs_client, age_limit, instance_prefix):
+    current_time = datetime.datetime.now(tzutc())
+    max_age = datetime.timedelta(hours=age_limit)
+
+    prefixed_servers = (
+        server for server in cs_client.servers.list()
+        if server.name.startswith(instance_prefix)
+    )
+
+    for server in prefixed_servers:
+        created_time = dateutil.parser.parse(server.created)
+        age = current_time - created_time
+        errored = server.status == "ERROR"
+        if errored or age > max_age:
+            print("Deleting {name} Errored: {error} Age: {age}".format(
+                name=server.name, error=errored, age=age))
+            server.delete()
+
+
+if __name__ == "__main__":
+    args = get_env_vars()
+
+    pyrax.set_setting("identity_type", "rackspace")
+    pyrax.set_credentials(args["username"], args["api_key"])
+    cs = pyrax.connect_to_cloudservers(args["region_name"], verify_ssl=True)
+
+    cleanup_instances(
+        cs_client=cs,
+        age_limit=args["age_limit"],
+        instance_prefix=args["instance_prefix"],
+    )


### PR DESCRIPTION
This job deletes instances that are older than a specified time (Default
48 hours). This is useful to keep us from hitting quota if an individual
job has a cleanup failure or a user forgets to remove an instance that
was kept for investigation.

Connects rcbops/u-suk-dev#1380