### PR TITLE
Make openstack-ansible-ops parameters re-usable

### DIFF
--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -77,23 +77,15 @@
           name: "RPC_BRANCH"
           default: "{branch}"
       - tempest_params:
-         TEMPEST_TEST_SETS: "scenario defcore api"
-         RUN_TEMPEST_OPTS: ""
-         TESTR_OPTS: "--concurrency 3"
+          TEMPEST_TEST_SETS: "scenario defcore api"
+          RUN_TEMPEST_OPTS: ""
+          TESTR_OPTS: "--concurrency 3"
       - single_use_slave_params:
-         IMAGE: "OnMetal - Ubuntu 14.04 LTS (Trusty Tahr)"
-         FLAVOR: "onmetal-io1"
-         REGION: "IAD"
-      - string:
-          name: OSA_OPS_REPO
-          default: https://github.com/openstack/openstack-ansible-ops
-      - string:
-          name: OSA_OPS_BRANCH
-          default: master
-      - string:
-          name: OPENSTACK_ANSIBLE_BRANCH
-          default: "{OPENSTACK_ANSIBLE_BRANCH}"
-          description: Openstack Ansible branch to use in setup
+          IMAGE: "OnMetal - Ubuntu 14.04 LTS (Trusty Tahr)"
+          FLAVOR: "onmetal-io1"
+          REGION: "IAD"
+      - osa_ops_params:
+          OPENSTACK_ANSIBLE_BRANCH: "{OPENSTACK_ANSIBLE_BRANCH}"
       - string:
           name: DEFAULT_IMAGE
           default: "{DEFAULT_IMAGE}"

--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -30,6 +30,20 @@
           default: "{RPC_BRANCH}"
 
 - parameter:
+    name: osa_ops_params
+    parameters:
+      - string:
+          name: OSA_OPS_REPO
+          default: https://github.com/openstack/openstack-ansible-ops
+      - string:
+          name: OSA_OPS_BRANCH
+          default: master
+      - string:
+          name: OPENSTACK_ANSIBLE_BRANCH
+          default: "{OPENSTACK_ANSIBLE_BRANCH}"
+          description: Openstack Ansible branch to use in setup
+
+- parameter:
     name: rpc_deploy_params
     parameters:
       - string:


### PR DESCRIPTION
This commit makes the openstack-ansible-ops params into the params.yml
file so we can re-use these by other jobs.  We also fix some incorrect
indenting in multi_node_aio.yml.