### PR TITLE
First pass at a LEM multi-node AIO

### DIFF
--- a/pipeline_steps/multi_node_aio_prepare.groovy
+++ b/pipeline_steps/multi_node_aio_prepare.groovy
@@ -2,7 +2,7 @@ def prepare() {
   dir("openstack-ansible-ops") {
     git url: env.OSA_OPS_REPO, branch: env.OSA_OPS_BRANCH
   }
-  dir("openstack-ansible-ops/multi-node-aio") {
+  dir("openstack-ansible-ops/${env.MULTI_NODE_AIO_DIR}") {
     common.conditionalStage(
       stage_name: 'Prepare Multi-Node AIO',
       stage: {
@@ -25,7 +25,8 @@ def prepare() {
               "VM_IMAGE_CREATE=true",
               "DEPLOY_OSA=true",
               "PRE_CONFIG_OSA=true",
-              "RUN_OSA=false"]
+              "RUN_OSA=false",
+              "DATA_DISK_DEVICE=${env.DATA_DISK_DEVICE}"]
           ) //run_script
         } //timeout
       } //stage

--- a/playbooks/setup_jenkins_slave.yml
+++ b/playbooks/setup_jenkins_slave.yml
@@ -1,33 +1,4 @@
 ---
-- hosts: localhost
-  connection: local
-  gather_facts: False
-  tasks:
-    - name: Get facts about servers with a given name
-      local_action:
-          module: rax_facts
-          name: "{{ name }}"
-
-    - name: Show IP of server with given name, fail if no such server exists in region
-      debug: var=rax_accessipv4
-      failed_when: rax_accessipv4 is undefined
-
-    - name: Set ansible host to IP address of server with given name
-      set_fact:
-          ansible_host: "{{ rax_accessipv4 }}"
-
-    - name: Add servers to job_nodes host group
-      local_action:
-        module: add_host
-        hostname: "{{ name }}"
-        ansible_host: "{{ rax_accessipv4 }}"
-        ansible_user: root
-        groupname: job_nodes
-
-    - name: Wait for SSH to be available on host
-      wait_for: port=22 host="{{ ansible_host }}"
-
-
 - hosts: job_nodes
   user: root
   tasks:
@@ -81,6 +52,6 @@
         python ../scripts/jenkins_node.py \
           create \
           --name {{inventory_hostname}} \
-          --ip {{ansible_default_ipv4.address}} \
+          --ip {{ansible_host}} \
           --creds "SSH Creds for Jenkins instances in public cloud." \
           --labels single_use_slave

--- a/rpc_jobs/lem_multi_node_aio.yml
+++ b/rpc_jobs/lem_multi_node_aio.yml
@@ -1,0 +1,135 @@
+- project:
+    name: 'LEM-Multi-Node-AIO-Jobs'
+    # Note: branch is the branch for periodics to build
+    #       branches is the branch pattern to match for PR Jobs.
+    series:
+      - mitaka:
+          branch: mitaka-13.1
+          OPENSTACK_ANSIBLE_BRANCH: "stable/mitaka"
+      - newton:
+          branch: newton-14.0
+          OPENSTACK_ANSIBLE_BRANCH: "stable/newton"
+      - master:
+          branch: master
+          OPENSTACK_ANSIBLE_BRANCH: "stable/newton"
+    context:
+      - trusty:
+          DEFAULT_IMAGE: "14.04.5"
+      - xenial:
+          DEFAULT_IMAGE: "16.04.2"
+
+    # NOTE: Hugh tested this and found that ztrigger overrides series and
+    #       trigger doesn't, which is odd because both trigger and ztrigger
+    #       sort after series.
+    ztrigger:
+      - periodic
+    exclude:
+      # Xenial builds are run for newton and above.
+      - series: mitaka
+        context: xenial
+    jobs:
+      - 'LEM-Multi-Node-AIO_{series}-{context}-{ztrigger}'
+
+- job-template:
+    # DEFAULTS
+    NUM_TO_KEEP: 30
+
+    # TEMPLATE
+    name: 'LEM-Multi-Node-AIO_{series}-{context}-{ztrigger}'
+    project-type: workflow
+    concurrent: false
+    properties:
+      - build-discarder:
+          num-to-keep: "{NUM_TO_KEEP}"
+      - rpc-openstack-github
+    parameters:
+      # See params.yml
+      - rpc_repo_params:
+          RPC_BRANCH: "{branch}"
+      - rpc_gating_params
+      - osa_ops_params:
+          OPENSTACK_ANSIBLE_BRANCH: "{OPENSTACK_ANSIBLE_BRANCH}"
+          DEFAULT_IMAGE: "{DEFAULT_IMAGE}"
+          DATA_DISK_DEVICE: "mapper/lxc-aio"
+      - rpc_repo_params:
+          RPC_BRANCH: "{branch}"
+      - tempest_params:
+          TEMPEST_TEST_SETS: "scenario defcore cinder_backup"
+          RUN_TEMPEST_OPTS: "--serial"
+          TESTR_OPTS: ""
+      - string:
+          name: STAGES
+          default: "Connect Slave, Prepare Multi-Node AIO, Prepare RPC Configs, Deploy RPC w/ Script, Destroy Slave"
+          description: |
+            Pipeline stages to run CSV. Note that this list does not influence execution order.
+            Options:
+              Connect Slave
+              Prepare Deployment
+              Deploy RPC w/ Script
+              Setup MaaS
+              Verify MaaS
+              Install Tempest
+              Tempest Tests
+              Holland (test holland mysql backup)
+              Upgrade
+              Destroy Slave
+      - string:
+          name: INSTANCE_NAME
+          description: The hostname of the instance/server being deployed to
+      - string:
+          name: INSTANCE_IP
+          description: The IP address of the instance/server being deployed to
+      - string:
+          name: REGION
+          description: The public cloud region, required when creating MaaS checks/alarms
+          default: DFW
+    triggers:
+      - timed: ""
+
+    dsl: |
+      // CIT Slave node
+      timeout(time: 8, unit: 'HOURS'){{
+        node() {{
+          dir("rpc-gating") {{
+              git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
+              common = load 'pipeline_steps/common.groovy'
+              ssh_slave = load 'pipeline_steps/ssh_slave.groovy'
+              multi_node_aio_prepare = load 'pipeline_steps/multi_node_aio_prepare.groovy'
+              deploy = load 'pipeline_steps/deploy.groovy'
+              tempest = load 'pipeline_steps/tempest.groovy'
+              holland = load 'pipeline_steps/holland.groovy'
+              maas = load 'pipeline_steps/maas.groovy'
+          }}
+          dir("rpc-gating/playbooks") {{
+            writeFile file: "inventory/hosts", text: "[job_nodes]\n${{INSTANCE_NAME}} ansible_host=${{INSTANCE_IP}}\n"
+            common.install_ansible()
+          }}
+          ssh_slave.connect()
+          node(INSTANCE_NAME) {{
+            sh """
+               lvcreate -n aio -L250G lxc
+            """
+            multi_node_aio_prepare.prepare()
+            deploy.deploy_sh(
+              environment_vars: [
+                "DEPLOY_HAPROXY=yes",
+                "DEPLOY_ELK=yes",
+                "DEPLOY_TEMPEST=no",
+                "DEPLOY_AIO=no",
+                "DEPLOY_MAAS=no"
+                ]
+            ) // deploy_sh
+            node(){{
+              dir("rpc-gating"){{
+                git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
+              }}
+              maas.prepare(instance_name: instance_name)
+            }}
+            maas.deploy()
+            maas.verify()
+            tempest.tempest(vm: "infra1")
+            holland.holland()
+          }} // hardware node
+          ssh_slave.destroy()
+        }} // cit node
+      }} // timeout

--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -83,6 +83,7 @@
       - osa_ops_params:
           OPENSTACK_ANSIBLE_BRANCH: "{OPENSTACK_ANSIBLE_BRANCH}"
           DEFAULT_IMAGE: "{DEFAULT_IMAGE}"
+          DATA_DISK_DEVICE: "sdb"
       - string:
           name: STAGES
           default: |

--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -54,6 +54,18 @@
           name: PARTITION_HOST
           default: true
           description: Enable partitioning of host data disk device
+      - string:
+          name: DATA_DISK_DEVICE
+          default: "{DATA_DISK_DEVICE}"
+          description: The data disk to use for VMs (if unset the largest unpartitioned device will be used)
+      - string:
+          name: MULTI_NODE_AIO_DIR
+          default: "multi-node-aio"
+          description: |
+            The directory to trigger build.sh from
+            Options:
+              multi-node-aio
+              multi-node-aio-xenial-ansible
 
 - parameter:
     name: rpc_deploy_params


### PR DESCRIPTION
This commit does the following:

- adds MULTI_NODE_AIO_DIR and DATA_DISK_DEVICE params to osa_ops_params
  and overrides these in the respective jobs
- removes old code from setup_jenkins_slave.yml that is no longer
  used and changes a reference from ansible_default_ipv4.address to
  ansible_host (this is necessary because we may try to use a host
  behind a firewall and not wish to use the host's
  ansible_default_ipv4.address address)
- creates rpc_multi_node_aio.yml which is specifically for building the
  multi-node AIO on LEM nodes

Connects https://github.com/rcbops/u-suk-dev/issues/1368