### PR TITLE
Push artifacts to Cloud Files

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -49,7 +49,7 @@ rackspace-auth-openstack==1.3
 rackspace-novaclient==2.1
 rax-default-network-flags-python-novaclient-ext==0.4.0
 rax-scheduled-images-python-novaclient-ext==0.3.1
-requests==2.13.0
+requests==2.10.0
 rfc3986==0.4.1
 simplejson==3.10.0
 six==1.10.0

--- a/pipeline_steps/maas.groovy
+++ b/pipeline_steps/maas.groovy
@@ -2,20 +2,7 @@ def prepare(Map args) {
   common.conditionalStage(
     stage_name: 'Prepare MaaS',
     stage: {
-      withCredentials([
-        string(
-          credentialsId: "dev_pubcloud_username",
-          variable: "PUBCLOUD_USERNAME"
-        ),
-        string(
-          credentialsId: "dev_pubcloud_api_key",
-          variable: "PUBCLOUD_API_KEY"
-        ),
-        string(
-          credentialsId: "dev_pubcloud_tenant_id",
-          variable: "PUBCLOUD_TENANT_ID"
-        )
-      ]){
+      withCredentials(common.get_cloud_creds()){
         dir("rpc-gating/playbooks"){
           pyrax_cfg = common.writePyraxCfg(
             username: env.PUBCLOUD_USERNAME,

--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -11,20 +11,7 @@
  */
 def create(Map args){
   withEnv(["RAX_REGION=${args.region}"]){
-    withCredentials([
-      string(
-        credentialsId: "dev_pubcloud_username",
-        variable: "PUBCLOUD_USERNAME"
-      ),
-      string(
-        credentialsId: "dev_pubcloud_api_key",
-        variable: "PUBCLOUD_API_KEY"
-      ),
-      file(
-        credentialsId: 'id_rsa_cloud10_jenkins_file',
-        variable: 'JENKINS_SSH_PRIVKEY'
-      )
-    ]){
+    withCredentials(common.get_cloud_creds()){
       dir("rpc-gating/playbooks"){
         common.install_ansible()
         pyrax_cfg = common.writePyraxCfg(
@@ -53,20 +40,7 @@ def create(Map args){
  */
 def cleanup(Map args){
   withEnv(['ANSIBLE_FORCE_COLOR=true']){
-    withCredentials([
-      string(
-        credentialsId: "dev_pubcloud_username",
-        variable: "PUBCLOUD_USERNAME"
-      ),
-      string(
-        credentialsId: "dev_pubcloud_api_key",
-        variable: "PUBCLOUD_API_KEY"
-      ),
-      file(
-        credentialsId: 'id_rsa_cloud10_jenkins_file',
-        variable: 'jenkins_ssh_privkey'
-      )
-    ]){
+    withCredentials(common.get_cloud_creds()){
       dir("rpc-gating/playbooks"){
         common.install_ansible()
         pyrax_cfg = common.writePyraxCfg(
@@ -150,6 +124,33 @@ def runonpubcloud(body){
   }finally {
     delPubCloudSlave(instance_name: instance_name)
   }
+}
+
+def uploadToCloudFiles(Map args){
+  withCredentials(common.get_cloud_creds()) {
+    dir("rpc-gating"){
+      git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
+    }
+    dir("rpc-gating/playbooks") {
+      common.install_ansible()
+      pyrax_cfg = common.writePyraxCfg(
+        username: env.PUBCLOUD_USERNAME,
+        api_key: env.PUBCLOUD_API_KEY
+      )
+      withEnv(["RAX_CREDS_FILE=${pyrax_cfg}"]) {
+        common.venvPlaybook(
+          playbooks: ["upload_to_cloud_files.yml"],
+          venv: ".venv",
+          vars: [
+            container: args.container,
+            src: args.src,
+            html_report_dest: args.html_report_dest,
+            description_file: args.description_file
+          ]
+        ) // venvPlaybook
+      } // withEnv
+    } // dir
+  } // withCredentials
 }
 
 return this

--- a/playbooks/setup_jenkins_slave.yml
+++ b/playbooks/setup_jenkins_slave.yml
@@ -42,6 +42,7 @@
         - python-dev
         - python-pip
         - build-essential
+        - libssl-dev
 
     - name: Create Jenkins user
       user:

--- a/playbooks/templates/cloudfiles.html.j2
+++ b/playbooks/templates/cloudfiles.html.j2
@@ -1,0 +1,8 @@
+<html>
+<body>
+<a href="{{ public_container.container_urls.url }}/{{ src | basename }}">{{ src | basename }}</a>
+<div style="white-space: pre">
+{{ artifact_description | default("") }}
+</div>
+</body>
+</html>

--- a/playbooks/upload_to_cloud_files.yml
+++ b/playbooks/upload_to_cloud_files.yml
@@ -1,0 +1,37 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: False
+  tasks:
+    - name: Create a public Cloud Files container
+      rax_files:
+        container: "{{ container }}"
+        public: yes
+        region: "DFW"
+      register: public_container
+
+    - name: Upload file to Cloud Files
+      rax_files_objects:
+        container: "{{ container }}"
+        region: "DFW"
+        expires: 2592000
+        method: put
+        src: "{{ src }}"
+
+    - name: Read artifact description file
+      set_fact:
+        artifact_description: "{{ lookup('file', description_file) }}"
+      no_log: True
+      when:
+        - description_file is defined
+        - description_file != None
+
+    - name: Create artifact report location if doesn't exist
+      file:
+        path: "{{ html_report_dest | dirname }}"
+        state: directory
+
+    - name: Generate HTML report with file URL
+      template:
+        src: cloudfiles.html.j2
+        dest: "{{ html_report_dest }}"


### PR DESCRIPTION
- Had to pin requests because of an issue in pyrax where requests==2.11.0 throws an InvalidHeader when it sets the TTL for the file in the header 
- Moved all the cloud account credentials into a common method
- Hardcoded DFW as the upload region since the CIT nodes are in DFW and we're currently only uploading from there

Connects https://github.com/rcbops/u-suk-dev/issues/1438