### PR TITLE
Default DELETE_OLD to false

### DIFF
--- a/rpc_jobs/jjb_setup.yml
+++ b/rpc_jobs/jjb_setup.yml
@@ -31,7 +31,7 @@
         - bool:
             name: DELETE_OLD
             description: "Remove jobs that are no longer defined."
-            default: true
+            default: false
         - rpc_gating_params
     # Variables used in the scm plugin are expanded when the job is triggered
     # by user or pr, but not on branch merge.


### PR DESCRIPTION
This is safer and may prevent the loss of existing jobs when only
building a subset of jobs.