### PR TITLE
Reduce Timeout Age

### DIFF
--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -4,7 +4,7 @@
     parameters:
       - string:
           name: "INSTANCE_AGE_LIMIT"
-          default: "48"
+          default: "12"
           description: |
             Hours. Instances older than this will be removed.
       - string:


### PR DESCRIPTION
Some jobs are still failing on quota, so we need to reduce the amount
of time that instances can idle before they are cleaned up.