### PR TITLE
Standardise tempest testing

### DIFF
--- a/playbooks/vars/aio.yml
+++ b/playbooks/vars/aio.yml
@@ -16,9 +16,6 @@ gating_overrides:
       sha256: "ec1120a9310ac3987feee4e3c5108d5d0fd0e594c4283804c17d673ebb2d3769"
     - url: "{{ '{{' }}cirros_tgz_url{{ '}}' }}"
       sha256: "95e77c7deaf0f515f959ffe329918d5dd23e417503d1d45e926a888853c90710"
-  tempest_tempest_conf_overrides:
-    volume-feature-enabled:
-      snapshot: true
 
   # Ensure raw_multi_journal is False for upgrades.
   # This is because of the way migrate-yaml.py behaves with the

--- a/playbooks/vars/all.yml
+++ b/playbooks/vars/all.yml
@@ -25,3 +25,6 @@ default_gating_overrides:
     compute-feature-enabled:
       personality: false
       attach_encrypted_volume: false
+    volume-feature-enabled:
+      snapshot: true
+  cinder_service_backup_program_enabled: true

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -29,7 +29,6 @@
                 DEFAULT:
                     default_volume_type: ceph
             cinder_service_backup_driver: cinder.backup.drivers.ceph
-            cinder_service_backup_program_enabled: true
             tempest_service_available_swift: false
       - upgrade:
           STAGES: "Allocate Resources, Connect Slave, Prepare Deployment, Deploy RPC w/ Script, Setup MaaS, Verify MaaS, Install Tempest, Tempest Tests, Upgrade, Cleanup, Destroy Slave"


### PR DESCRIPTION
Currently, we have a few options that are configured differently
between our AIO build and our multi-node build which results in tests
being run differently.  This commit moves some of the AIO overrides
out to playbooks/vars/all.yml so that tempest will test and behave in a
more standard manner.

Connects https://github.com/rcbops/u-suk-dev/issues/1490