### PR TITLE
Skip ARA if build succeeded to prevent false negatives

### DIFF
--- a/pipeline_steps/ssh_slave.groovy
+++ b/pipeline_steps/ssh_slave.groovy
@@ -50,7 +50,7 @@ def destroy(){
       ]){
         dir("rpc-gating/scripts"){
           sh """
-            . ../playbooks/.venv/bin/activate
+            . ${env.WORKSPACE}/.venv/bin/activate
             pip install 'pip==9.0.1'
             pip install -c ../constraints.txt jenkinsapi
             python jenkins_node.py \

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -207,9 +207,9 @@
               }}
             }} catch (e) {{
               print(e)
+              common.submit_ara()
               throw e
             }} finally {{
-              common.submit_ara()
               common.archive_artifacts()
             }}
           }} //pubcloud slave


### PR DESCRIPTION
Might not be the ideal solution for the long term, but it should at least prevent the gates from blocking PRs that had no problems.

We also adjust the path to the .venv when running jenkins_node.py, which ensures the ssh slave is torn down correctly.

Connects https://github.com/rcbops/u-suk-dev/issues/1587