### PR TITLE
Use the 14.04.4 Trusty image for artifacting jobs

### DIFF
--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -7,7 +7,8 @@
           branch: artifacts-14.0
           branches: "artifacts-.*"
     image:
-      - trusty
+      - trusty:
+          IMAGE: "Ubuntu 14.04.4 LTS prepared for RPC deployment"
     context:
       - Git
       - Apt


### PR DESCRIPTION
In order to be able to use apt artifacts successfully
to build the same tag in the same way today and next
year we need to fix the starting point to ensure that
the host OS does not have packages installed which are
later than the packages in the artifacted apt repo.

A 14.04.4 image has been prepared for Trusty and serves
as that starting point.

Connects https://github.com/rcbops/u-suk-dev/issues/1606