### PR TITLE
Checkout PR repository correctly

### DIFF
--- a/pipeline_steps/aio_prepare.groovy
+++ b/pipeline_steps/aio_prepare.groovy
@@ -3,9 +3,9 @@ def prepare(){
     stage_name: "Prepare Deployment",
     stage: {
       if (env.STAGES.contains("Upgrade")) {
-        common.prepareRpcGit(branch: env.UPGRADE_FROM_REF)
+        common.prepareRpcGit(env.UPGRADE_FROM_REF)
       } else {
-        common.prepareRpcGit(branch: env.RPC_BRANCH)
+        common.prepareRpcGit()
       } // if
       ansiColor('xterm'){
         dir("/opt/rpc-openstack"){

--- a/pipeline_steps/artifact_build.groovy
+++ b/pipeline_steps/artifact_build.groovy
@@ -32,7 +32,7 @@ def apt() {
     stage_name: "Build Apt Artifacts",
     stage: {
       withCredentials(get_rpc_repo_creds()) {
-        common.prepareRpcGit(branch: env.RPC_BRANCH)
+        common.prepareRpcGit()
         ansiColor('xterm') {
           dir("/opt/rpc-openstack/") {
             sh """#!/bin/bash
@@ -52,7 +52,7 @@ def git() {
       pubcloud.runonpubcloud {
         try {
           withCredentials(get_rpc_repo_creds()) {
-            common.prepareRpcGit(branch: env.RPC_BRANCH)
+            common.prepareRpcGit()
             ansiColor('xterm') {
               dir("/opt/rpc-openstack/") {
                 sh """#!/bin/bash
@@ -79,7 +79,7 @@ def python() {
       pubcloud.runonpubcloud {
         try {
           withCredentials(get_rpc_repo_creds()) {
-            common.prepareRpcGit(branch: env.RPC_BRANCH)
+            common.prepareRpcGit()
             ansiColor('xterm') {
               dir("/opt/rpc-openstack/") {
                 sh """#!/bin/bash
@@ -106,7 +106,7 @@ def container() {
       pubcloud.runonpubcloud {
         try {
           withCredentials(get_rpc_repo_creds()) {
-            common.prepareRpcGit(branch: env.RPC_BRANCH)
+            common.prepareRpcGit()
             ansiColor('xterm') {
               dir("/opt/rpc-openstack/") {
                 sh """#!/bin/bash

--- a/pipeline_steps/deploy.groovy
+++ b/pipeline_steps/deploy.groovy
@@ -43,7 +43,7 @@ def upgrade(Map args) {
         dir("/opt/rpc-openstack/openstack-ansible"){
           sh "git reset --hard"
         }
-        common.prepareRpcGit(branch: env.RPC_BRANCH)
+        common.prepareRpcGit()
         dir("/opt/rpc-openstack"){
           sh """
             scripts/test-upgrade.sh

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -142,15 +142,6 @@
       // CIT Slave node
       timeout(time: 8, unit: 'HOURS'){{
         node() {{
-          /* if job is triggered by PR, then we need to set RPC_REPO and
-            RPC_BRANCH using the env vars supplied by ghprb. Ztrigger is a
-            jjb variable so uses single braces.
-          */
-          if ("{ztrigger}" == "pr" ){{
-            env.RPC_REPO = "https://github.com/${{env.ghprbGhRepository}}.git"
-            env.RPC_BRANCH = "origin/pr/${{ghprbPullId}}/merge" //matches the refspec in aio_prepare.groovy
-            print("""Triggered by PR: ${{ghprbPullLink}} RPC_REPO: ${{RPC_REPO}} Branch: ${{RPC_BRANCH}}""")
-          }}
           dir("rpc-gating") {{
               git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
               common = load 'pipeline_steps/common.groovy'


### PR DESCRIPTION
When a job is triggered by a PR, the checkout must
universally include the change introduced by the PR.

Currently only the AIO job inherits the correct PR
checkout. This patch moves the PR resolving to the
general RPC-O repo checkout so that it becomes
universal.

Connects https://github.com/rcbops/u-suk-dev/issues/1607