### PR TITLE
Bump percent_used_critical_threshold

### DIFF
--- a/playbooks/vars/all.yml
+++ b/playbooks/vars/all.yml
@@ -28,3 +28,7 @@ default_gating_overrides:
     volume-feature-enabled:
       snapshot: true
   cinder_service_backup_program_enabled: true
+  # This is being increased from the default of 85 as the default value may be
+  # too low for the liberty->mitaka upgrade job where more space is used by
+  # additional packages, venvs, logs, etc.
+  percent_used_critical_threshold: 95


### PR DESCRIPTION
This commit increases percent_used_critical_threshold to 95 from 85 as
the default value looks to be too low for the liberty->mitaka upgrade
job specifically.  That job runs longer (meaning more logs used, etc.)
and also has venvs for both liberty and mitaka and therefore consumes
more space than the other jobs.