### PR TITLE
Configure apt artifact source when necessary

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -352,8 +352,8 @@ def prepareConfigs(Map args){
   } //withCredentials
 }
 
-def prepareRpcGit(branch = "auto"){
-  dir("/opt/rpc-openstack"){
+def prepareRpcGit(branch = "auto", dest = "/opt"){
+  dir("${dest}/rpc-openstack"){
 
     if (branch == "auto"){
       /* if job is triggered by PR, then we need to set RPC_REPO and

--- a/playbooks/setup_jenkins_slave.yml
+++ b/playbooks/setup_jenkins_slave.yml
@@ -1,7 +1,74 @@
 ---
 - hosts: job_nodes
   user: root
+  vars:
+    rpc_release_file_name: "{{ lookup('env', 'WORKSPACE') ~ '/rpc-openstack/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml' }}"
+    rpco_mirror_base_url: "http://rpc-repo.rackspace.com"
+    rpco_mirror_apt_filename: "rpco"
+    rpco_gpg_key_location: "{{ rpco_mirror_base_url }}/apt-mirror/"
+    rpco_gpg_key_name: "rcbops-release-signing-key.asc"
+    rpco_gpg_key_id: 52AA252F
   tasks:
+
+    # Check whether a file exists to help determine the
+    # rpc_release, as the job may not include a checkout
+    # of rpc-openstack.
+    - name: Check if release file name exists
+      stat:
+        path: "{{ rpc_release_file_name }}"
+      register: _release_file
+      delegate_to: localhost
+
+    # We then want to check the value of the rpc_release
+    # variable in the file. It may be a bit of jinja, or
+    # not exist, or be a real value. These edge cases are
+    # needed to protect against due to the many releases
+    # tested by the gate and the varied approaches across
+    # them all.
+    # If the value is of the form r<major>.<minor>.<patch>
+    # and optionally including a release candidate suffix
+    # then we have a valid version.
+    - name: Determine rpc_release value
+      shell: |
+        RPC_RELEASE=$(awk '/^rpc_release/ { print $2; }' {{ rpc_release_file_name }} | sed 's/"//g')
+        if [[ ! ${RPC_RELEASE} =~ ^r[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$ ]]; then
+          RPC_RELEASE="none"
+        fi
+        echo ${RPC_RELEASE}
+      args:
+        executable: "/bin/bash"
+      register: _release_value
+      delegate_to: localhost
+      when:
+        - _release_file.stat.exists
+
+    # If the release file exists, and we have a valid value
+    # then add an apt key & source for the artifacts repo for
+    # that version.
+    # This ensures that builds using the restricted starting
+    # apt configuration for an artifacted build are able to
+    # install the JRE package below which is only available
+    # in the ubuntu-updates repo.
+    - name: Configure the apt artifact repo key
+      apt_key:
+        id:  "{{ rpco_gpg_key_id }}"
+        url: "{{ rpco_gpg_key_location }}{{ rpco_gpg_key_name }}"
+        state: present
+      when:
+        - _release_file.stat.exists
+        - _release_value.stdout != "none"
+
+    - name: Configure the apt artifact source
+      apt_repository:
+        repo: |-
+          deb {{ rpco_mirror_base_url }}/apt-mirror/integrated {{ _release_value.stdout }}-{{ ansible_distribution_release }} main
+        state: present
+        update_cache: yes
+        filename: "{{ rpco_mirror_apt_filename }}"
+      when:
+        - _release_file.stat.exists
+        - _release_value.stdout != "none"
+
     - name: Install apt packages
       apt:
         pkg: "{{ item }}"

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -151,6 +151,14 @@
               holland = load 'pipeline_steps/holland.groovy'
               maas = load 'pipeline_steps/maas.groovy'
           }}
+          // We need to checkout the rpc-openstack repo on the CIT Slave
+          // so that we can cater for builds on the more restricted images
+          // used for artifact-based builds.
+          if (env.STAGES.contains("Upgrade")) {{
+            common.prepareRpcGit(env.UPGRADE_FROM_REF, env.WORKSPACE)
+          }} else {{
+            common.prepareRpcGit("auto", env.WORKSPACE)
+          }} // if
           pubcloud.runonpubcloud {{
             // try within pubcloud node so we can archive archive_artifacts
             // after a failure, before the node is cleaned up.

--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -134,6 +134,10 @@
             pubcloud = load 'pipeline_steps/pubcloud.groovy'
             artifact_build = load 'pipeline_steps/artifact_build.groovy'
         }}
+        // We need to checkout the rpc-openstack repo on the CIT Slave
+        // so that we can cater for builds on the more restricted images
+        // used for artifact-based builds.
+        common.prepareRpcGit("auto", env.WORKSPACE)
         artifact_build.git()
         artifact_build.python()
         artifact_build.container()


### PR DESCRIPTION
When a more restricted setup is used to ensure
that an artifacted deployment only uses the
prepared artifacts, the jobs fail as the jenkins
slave cannot install the JRE which comes from
the ubuntu updates repo.

This patch ensures that the slave is prepared
with the apt artifact repo source prior to
trying to install anything.

For the ``artifacts-14.0`` branch, this should
setup the artifacted apt repo and key. Without
doing so the job will fail to install the apt
packages. For any other branches (currently)
it should skip those tasks.

Connects https://github.com/rcbops/u-suk-dev/issues/1627