### PR TITLE
Use MaaS token and API URL

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -340,14 +340,20 @@ def prepareConfigs(Map args){
       } //dir
       dir("rpc-gating/playbooks"){
         common.install_ansible()
-        common.venvPlaybook(
-          playbooks: ["aio_config.yml"],
-          venv: ".venv",
-          args: [
-            "-i inventory",
-            "--extra-vars \"@vars/${args.deployment_type}.yml\""
-          ]
-        )
+        withCredentials(common.get_cloud_creds()) {
+          String venv = "${env.WORKSPACE}/rpc-gating/playbooks/.venv"
+          List maas_vars = maas.get_maas_token_and_url(env.PUBCLOUD_USERNAME, env.PUBCLOUD_API_KEY, env.REGION, venv)
+          withEnv(maas_vars) {
+            common.venvPlaybook(
+              playbooks: ["aio_config.yml"],
+              venv: ".venv",
+              args: [
+                "-i inventory",
+                "--extra-vars \"@vars/${args.deployment_type}.yml\""
+              ]
+            )
+          }
+        }
       } //dir
   } //withCredentials
 }

--- a/pipeline_steps/maas.groovy
+++ b/pipeline_steps/maas.groovy
@@ -49,4 +49,16 @@ def verify() {
   ) //conditionalStage
 }
 
+List get_maas_token_and_url(String username, String api_key, String region, String venv) {
+  def token_url = sh (
+    script: """#!/bin/bash
+cd ${env.WORKSPACE}/rpc-gating/scripts
+. ${venv}/bin/activate
+./get_maas_token_and_url.py --username ${username} --api-key ${api_key} --region ${region}
+""",
+    returnStdout: true,
+  )
+  return token_url.trim().tokenize(" ")
+}
+
 return this;

--- a/playbooks/vars/all.yml
+++ b/playbooks/vars/all.yml
@@ -7,10 +7,9 @@ default_gating_overrides:
   # NOTE(mkam): Setting nova_cross_az_attach to avoid volume test failures caused by:
   # https://bugs.launchpad.net/nova/+bug/1648324
   nova_cross_az_attach: True
-  rackspace_cloud_auth_url: "https://identity.api.rackspacecloud.com/v2.0/"
-  rackspace_cloud_tenant_id: "{{lookup('env', 'PUBCLOUD_TENANT_ID')}}"
-  rackspace_cloud_username: "{{lookup('env', 'PUBCLOUD_USERNAME')}}"
-  rackspace_cloud_api_key: "{{lookup('env', 'PUBCLOUD_API_KEY')}}"
+  maas_auth_method: "token"
+  maas_auth_token: "{{lookup('env', 'MAAS_AUTH_TOKEN')}}"
+  maas_api_url: "{{lookup('env', 'MAAS_API_URL')}}"
   tempest_swift_container_sync: False
   tempest_swift_discoverable_apis:
     - bulk

--- a/rpc_jobs/lem_multi_node_aio.yml
+++ b/rpc_jobs/lem_multi_node_aio.yml
@@ -59,7 +59,21 @@
           TESTR_OPTS: ""
       - string:
           name: STAGES
-          default: "Connect Slave, Prepare LEM AIO, Prepare Multi-Node AIO, Prepare RPC Configs, Deploy RPC w/ Script, Install Tempest, Tempest Tests, Prepare Kibana Selenium, Kibana Tests, Holland, Destroy Slave"
+          default: |
+            Connect Slave,
+            Prepare LEM AIO,
+            Prepare Multi-Node AIO,
+            Prepare RPC Configs,
+            Deploy RPC w/ Script,
+            Prepare MaaS,
+            Setup MaaS,
+            Verify MaaS,
+            Install Tempest,
+            Tempest Tests,
+            Prepare Kibana Selenium,
+            Kibana Tests,
+            Holland,
+            Destroy Slave
           description: |
             Pipeline stages to run CSV. Note that this list does not influence execution order.
             Options:
@@ -68,6 +82,7 @@
               Prepare Multi-Node AIO
               Prepare RPC Configs
               Deploy RPC w/ Script
+              Prepare MaaS
               Setup MaaS
               Verify MaaS
               Install Tempest

--- a/scripts/get_maas_token_and_url.py
+++ b/scripts/get_maas_token_and_url.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+import argparse
+import pyrax
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--username", required=True)
+parser.add_argument("--api-key", required=True)
+parser.add_argument("--region", required=True)
+
+args = parser.parse_args()
+
+pyrax.set_setting("identity_type", "rackspace")
+pyrax.set_credentials(
+    args.username,
+    args.api_key,
+    region=args.region,
+)
+
+token = pyrax.identity.token
+
+monitoring_service = next(
+    b for b in pyrax.identity.service_catalog if b["type"] == "rax:monitor"
+)
+url = monitoring_service["endpoints"][0]["publicURL"]
+
+print "MAAS_AUTH_TOKEN={} MAAS_API_URL={}".format(token, url)


### PR DESCRIPTION
The MaaS playbooks can either use a set of public cloud credentials or a
token and API URL. Customer deployments always require a token and API
URL. This commit adjusts how MaaS is deployed so that the existing
public cloud credentials are used to generate a token and API URL which
are then used by the playbooks instead.

This changes applies to all jobs deploying MaaS. Given that the use of
public cloud credentials in the playbooks is only for the benefit of
developers it makes sense for that to be the untested path.

This change does not directly address multi-physical-node deployments
using LEM however that can build on this work when it becomes a reality.

Connected https://github.com/rcbops/u-suk-dev/issues/1370