### PR TITLE
Remove template macros from non template job

### DIFF
--- a/rpc_jobs/single_use_slave_template.yml
+++ b/rpc_jobs/single_use_slave_template.yml
@@ -7,8 +7,8 @@
       # params you want to override the defaults for.
       - single_use_slave_params:
           IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
-          FLAVOR: "{FLAVOR}"
-          REGION: "{REGION}"
+          FLAVOR: "performance2-15"
+          REGION: "DFW"
       - rpc_gating_params
       - string:
           name: STAGES


### PR DESCRIPTION
Macro expansion is only valid in job templates, not jobs.