### PR TITLE
Temporarily disable cinder-backup from being tested

### DIFF
--- a/playbooks/vars/all.yml
+++ b/playbooks/vars/all.yml
@@ -27,7 +27,11 @@ default_gating_overrides:
       attach_encrypted_volume: false
     volume-feature-enabled:
       snapshot: true
-  cinder_service_backup_program_enabled: true
+  # NOTE(mattt): This functionality is currently broken on multi-node
+  #              deployments, disabling until this is addressed in
+  #              openstack-ansible-os_cinder
+  cinder_service_backup_program_enabled: false
+  #
   # This is being increased from the default of 85 as the default value may be
   # too low for the liberty->mitaka upgrade job where more space is used by
   # additional packages, venvs, logs, etc.


### PR DESCRIPTION
The cinder-backup service is usable on an AIO deployment, but
deploying on a multi-node deployment seems to result in the service not
working.  I'm not a storage expert, but from looking briefly it appears
that the open-iscsi package is missing on the storage nodes, which
prevents the service from backing up a volume.  The package open-iscsi
gets installed by nova on the compute nodes, and since an AIO deploys
nova-compute, cinder-volume, and cinder-backup to the host itself this
explains why cinder-backup is functional there.

I will create an upstream bug and fix for this but in the mean time
it's probably best to just disable this from being tested.

Connects https://github.com/rcbops/u-suk-dev/issues/1643