### PR TITLE
Skip builds on doc change only PRs

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -410,5 +410,23 @@ def docker_cache_workaround(){
    sh "touch -t 201704100000 *.txt"
 }
 
+def is_doc_update_pr(git_dir) {
+  is_doc_update_pr = false
+  if (env.ghprbPullId != null) {
+    dir(git_dir) {
+      def output = sh(script: """#!/bin/bash
+      git show --stat=400,400 | awk '/\\|/{print \$1}' \
+        | egrep -v -e '.*md\$' -e '.*rst\$' -e '^releasenotes/' \
+        || echo "Skipping build as only documentation changes were detected"
+      """, returnStdout: true)
+      print output
+      is_doc_update_pr = output.contains("Skipping build as only documentation changes were detected")
+    }
+  }
+  if(!is_doc_update_pr){
+    print "Not a documentation only change or not triggered by a pull request. Continuing..."
+  }
+  return is_doc_update_pr
+}
 
 return this

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -159,6 +159,9 @@
           }} else {{
             common.prepareRpcGit("auto", env.WORKSPACE)
           }} // if
+          if(common.is_doc_update_pr("${{env.WORKSPACE}}/rpc-openstack")){{
+            return
+          }}
           pubcloud.runonpubcloud {{
             // try within pubcloud node so we can archive archive_artifacts
             // after a failure, before the node is cleaned up.

--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -138,6 +138,9 @@
         // so that we can cater for builds on the more restricted images
         // used for artifact-based builds.
         common.prepareRpcGit("auto", env.WORKSPACE)
+        if(common.is_doc_update_pr("${{env.WORKSPACE}}/rpc-openstack")){{
+          return
+        }}
         artifact_build.git()
         artifact_build.python()
         artifact_build.container()


### PR DESCRIPTION
Port of https://github.com/rcbops/jenkins-rpc/blob/master/scripts/gating_bash_lib.sh#L365-L384

Didn't run any tests against rpc-openstack because I didn't want to accidentally affect the open PRs there, but I did create a job and a test PR with rpc-gating:

Doc Change PR -> Skipping: https://rpc.jenkins.cit.rackspace.net/job/mkam-doc-pr-test/4/console
Not a Doc Change PR -> Not Skipping: https://rpc.jenkins.cit.rackspace.net/job/mkam-doc-pr-test/5/console
Doc Change, but job not triggered by a PR (like a periodic job) -> Not skipping: https://rpc.jenkins.cit.rackspace.net/job/mkam-doc-pr-test/9/console

Connects https://github.com/rcbops/u-suk-dev/issues/1633