### PR TITLE
Re-enable cinder-backup on RPC-AIO jobs

### DIFF
--- a/playbooks/vars/aio.yml
+++ b/playbooks/vars/aio.yml
@@ -30,3 +30,4 @@ gating_overrides:
   raw_multi_journal: false
   journal_size: 1024
   osd_directory: true
+  cinder_service_backup_program_enabled: true

--- a/playbooks/vars/all.yml
+++ b/playbooks/vars/all.yml
@@ -27,11 +27,6 @@ default_gating_overrides:
       attach_encrypted_volume: false
     volume-feature-enabled:
       snapshot: true
-  # NOTE(mattt): This functionality is currently broken on multi-node
-  #              deployments, disabling until this is addressed in
-  #              openstack-ansible-os_cinder
-  cinder_service_backup_program_enabled: false
-  #
   # This is being increased from the default of 85 as the default value may be
   # too low for the liberty->mitaka upgrade job where more space is used by
   # additional packages, venvs, logs, etc.

--- a/playbooks/vars/onmetal.yml
+++ b/playbooks/vars/onmetal.yml
@@ -6,3 +6,7 @@ gating_overrides:
   memory_used_percentage_critical_threshold: 99.5
   net_max_speed: 1000
   lb_name: "{{ lookup('env', 'NODE_NAME') }}"
+  # NOTE(mattt): This functionality is currently broken on multi-node
+  #              deployments, disabling until this is addressed in
+  #              openstack-ansible-os_cinder
+  cinder_service_backup_program_enabled: false


### PR DESCRIPTION
The RPC-AIO jobs are currently failing tempest runs because it's
attempting to test cinder-backup while cinder backup is not being
deployed.  This commit keeps cinder-backup disabled for the OnMetal
AIOs but re-enables it for the RPC-AIOs.

Side note, the OSA AIO boostrap sets tempest_volume_backup_enabled
to true, which is why disabling this service did not affect the
OnMetal AIOs.