### PR TITLE
Ensure cleanup when using runonpubcloud

### DIFF
--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -109,8 +109,8 @@ def delPubCloudSlave(Map args){
 /* One func entrypoint to run a script on a single use slave */
 def runonpubcloud(body){
   instance_name = common.gen_instance_name()
-  getPubCloudSlave(instance_name: instance_name)
   try{
+    getPubCloudSlave(instance_name: instance_name)
     node(instance_name){
       body()
     }


### PR DESCRIPTION
The runOnPubCloud function didn't catch failures in the instance
creation stage, this commit ensures they are caught.

Connects rcbops/u-suk-dev#1650