### PR TITLE
Clean up new RPC-IRR instances

### DIFF
--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -9,10 +9,10 @@
             Hours. Instances older than this will be removed.
       - string:
           name: "INSTANCE_PREFIX"
-          default: "ra"
+          default: "ra|ri"
           description: |
-            Only instances whose names match the supplied prefix will be cleaned
-            up.
+            Only instances whose names match the supplied prefix pattern will
+            be cleaned up.
       - string:
           name: "REGION"
           default: "DFW"

--- a/scripts/jenkins_node.py
+++ b/scripts/jenkins_node.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 import argparse
 import os
+import re
 
 from jenkinsapi.jenkins import Jenkins
 
@@ -47,9 +48,9 @@ def delete_inactive_nodes(jenkins, instance_prefix):
     for node_id, node in jenkins.get_nodes().iteritems():
         # Ignore nodes that are coming online for the first time
         # which won't have an offline cause.
-        if (node_id.startswith(instance_prefix) and not node.is_online()
+        if (re.match(instance_prefix, node_id) and not node.is_online()
             and node.poll(tree="offlineCauseReason")
-                    .get("offlineCauseReason")):
+                .get("offlineCauseReason")):
             print("Deleting inactive Jenkins node {}".format(node_id))
             jenkins.delete_node(node_id)
 

--- a/scripts/periodic_cleanup.py
+++ b/scripts/periodic_cleanup.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 
-# This script deletes instances whose name starts with "ra" if they are in
-# error state or older than AGE_LIMIT hours.
+# This script deletes instances whose name matches a supplied pattern if they
+# are in error state or older than AGE_LIMIT hours.
 
 
 import datetime
 import dateutil.parser
 from dateutil.tz import tzutc
 import os
+import re
 
 import pyrax
 import jenkins_node
@@ -17,7 +18,7 @@ def get_env_vars():
     env_vars = {}
 
     env_vars["age_limit"] = int(os.environ.get("INSTANCE_AGE_LIMIT", 48))
-    env_vars["instance_prefix"] = os.environ.get("INSTANCE_PREFIX", "ra")
+    env_vars["instance_prefix"] = os.environ.get("INSTANCE_PREFIX")
     if not env_vars["instance_prefix"]:
         raise ValueError("INSTANCE_PREFIX must not be empty")
 
@@ -34,7 +35,7 @@ def cleanup_instances(cs_client, age_limit, instance_prefix):
 
     prefixed_servers = (
         server for server in cs_client.servers.list()
-        if server.name.startswith(instance_prefix)
+        if re.match(instance_prefix, server.name)
     )
 
     for server in prefixed_servers:


### PR DESCRIPTION
This commit updates periodic_cleanup.py so we can pass a pattern to use
when cleaning up instances.  We also update the periodic cleanup job to
cleanup ra|ri instances.

Connects https://github.com/rcbops/u-suk-dev/issues/1655