### PR TITLE
Check Groovy syntax with JJB templates

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -29,23 +29,45 @@ check_jjb(){
     || { echo "JJB Syntax fail"; rc=1; }
 }
 
+# This pulls job.dsl from jjb templates so they can be checked for groovy syntax
+extract_groovy_from_jjb(){
+  mkdir -p tmp_groovy
+  pushd rpc_jobs
+  for i in *.yml
+  do
+    python <<EOF
+import yaml
+with open("${i}",'r') as inf:
+  jjb = yaml.load(inf)
+for item in jjb:
+  key = item.keys()[0]
+  if key in ("job", "job-template") and 'dsl' in item[key]:
+    outfile="${i}".split('.')[0]
+    with open("../tmp_groovy/{outfile}-{item}.groovy".format(
+        outfile=outfile, item=item[key]['name']), "w") as outf:
+      outf.write(item[key]['dsl'])
+EOF
+  done
+  popd
+  sed -i bk -e 's/{{/{/g' -e 's/}}/}/g' tmp_groovy/*
+}
+
 check_groovy(){
   which groovy > /dev/null \
     || { echo "groovy unavailble, please install groovy (apt:groovy2 brew:groovy)"
          return
        }
-  grc=0
-  while read scriptf
-  do groovy -classpath pipeline_steps $scriptf || grc=1
-  done < <(find ${fargs[@]} -name \*.groovy \! -name NonCPS.groovy \! -name add_jenkins_cred.groovy)
+  extract_groovy_from_jjb
+  groovy scripts/syntax.groovy pipeline_steps/*.groovy tmp_groovy/*.groovy
 
-  if [[ $grc == 0 ]]
+  if [[ $? == 0 ]]
   then
     echo "Groovy syntax ok"
   else
     echo "Groovy syntax fail"
     rc=1
   fi
+  rm -rf tmp_groovy
 }
 
 check_ansible(){

--- a/rpc_jobs/lem_multi_node_aio.yml
+++ b/rpc_jobs/lem_multi_node_aio.yml
@@ -146,14 +146,15 @@
             ) // deploy_sh
             multi_node_aio_prepare.multi_node_aio_networking()
             node(){{
-            maas.prepare(instance_name: instance_name)
-            maas.deploy()
-            maas.verify()
-            tempest.tempest("infra1", "deploy1")
-            kibana.kibana("deploy1")
-            holland.holland()
-          }} // hardware node
-          ssh_slave.destroy()
-          maas.entity_cleanup(instance_name: instance_name)
-        }} // cit node
-      }} // timeout
+              maas.prepare(instance_name: instance_name)
+              maas.deploy()
+              maas.verify()
+              tempest.tempest("infra1", "deploy1")
+              kibana.kibana("deploy1")
+              holland.holland()
+            }}
+            ssh_slave.destroy()
+            maas.entity_cleanup(instance_name: instance_name)
+          }}
+        }}
+      }}

--- a/scripts/syntax.groovy
+++ b/scripts/syntax.groovy
@@ -1,0 +1,7 @@
+ClassLoader gcl = new GroovyClassLoader()
+for (scriptfile in args) {
+  print("${scriptfile} ")
+  String script = new File(scriptfile).text
+  Class c = gcl.parseClass(script)
+  print("[OK]\n")
+}


### PR DESCRIPTION
This commit extracts groovy from JJB templates so they can be
checked for syntax. Previously JJB templates were only checked for
yaml syntax and JJB semantics so groovy errors could slip in.

This commit also reduces lint time by scanning all groovy files
with a single JVM rather than starting one up for each file.