### PR TITLE
Check Groovy syntax with JJB templates

### DIFF
--- a/rpc_jobs/lem_multi_node_aio.yml
+++ b/rpc_jobs/lem_multi_node_aio.yml
@@ -146,14 +146,15 @@
             ) // deploy_sh
             multi_node_aio_prepare.multi_node_aio_networking()
             node(){{
-            maas.prepare(instance_name: instance_name)
-            maas.deploy()
-            maas.verify()
-            tempest.tempest("infra1", "deploy1")
-            kibana.kibana(env.RPC_BRANCH, "deploy1")
-            holland.holland()
-          }} // hardware node
-          ssh_slave.destroy()
-          maas.entity_cleanup(instance_name: instance_name)
-        }} // cit node
-      }} // timeout
+              maas.prepare(instance_name: instance_name)
+              maas.deploy()
+              maas.verify()
+              tempest.tempest("infra1", "deploy1")
+              kibana.kibana(env.RPC_BRANCH, "deploy1")
+              holland.holland()
+            }}
+            ssh_slave.destroy()
+            maas.entity_cleanup(instance_name: instance_name)
+          }}
+        }}
+      }}

--- a/scripts/extract_dsl.py
+++ b/scripts/extract_dsl.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+import os
+import yaml
+
+import click
+
+
+@click.command()
+@click.option(
+    "--jjbfile",
+    type=click.File('r'),
+    required=True,
+    help="Extract dsl from this JJB job")
+@click.option(
+    "--outdir",
+    type=click.Path(exists=True),
+    required=True,
+    help="Dir to write extracted groovy into"
+)
+def extract_dsl(jjbfile, outdir):
+    jjb = yaml.safe_load(jjbfile)
+    for item in jjb:
+        key = item.keys()[0]
+        if key in ("job", "job-template") and 'dsl' in item[key]:
+            dsl = item[key]['dsl'].replace('{{', '{').replace('}}', '}')
+            outfile = "{outdir}/{base}-{item}.groovy".format(
+                outdir=outdir,
+                base=os.path.basename(jjbfile.name).split('.')[0],
+                item=item[key]['name'])
+            with open(outfile, "w") as outf:
+                outf.write(dsl)
+            print("Written {outfile}".format(outfile=outfile))
+
+
+if __name__ == "__main__":
+    extract_dsl()

--- a/scripts/syntax.groovy
+++ b/scripts/syntax.groovy
@@ -1,0 +1,15 @@
+ClassLoader gcl = new GroovyClassLoader()
+rc=0
+for (scriptfile in args) {
+  try{
+    print("${scriptfile} ")
+    String script = new File(scriptfile).text
+    Class c = gcl.parseClass(script)
+  } catch (e){
+    print("[PARSE ERROR]\n${e}")
+    rc=1
+    continue
+  }
+  print("[OK]\n")
+}
+System.exit rc

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 ansible
+click
 jenkins-job-builder
 flake8


### PR DESCRIPTION
This commit extracts groovy from JJB templates so they can be
checked for syntax. Previously JJB templates were only checked for
yaml syntax and JJB semantics so groovy errors could slip in.

This commit also reduces lint time by scanning all groovy files
with a single JVM rather than starting one up for each file.

Connects rcbops/u-suk-dev#1661