### PR TITLE
Update virtualenv location for destroy slave step

### DIFF
--- a/pipeline_steps/ssh_slave.groovy
+++ b/pipeline_steps/ssh_slave.groovy
@@ -51,7 +51,7 @@ def destroy(){
         dir("rpc-gating/scripts"){
           retry(5) {
             sh """
-              . ../playbooks/.venv/bin/activate
+              . ${env.WORKSPACE}/.venv/bin/activate
               pip install 'pip==9.0.1'
               pip install -c ../constraints.txt jenkinsapi
               python jenkins_node.py \


### PR DESCRIPTION
Found that it was in the wrong location with this build: https://rpc.jenkins.cit.rackspace.net/job/mkam-RPC-AIO/22/console