### PR TITLE
Switch artifact job branch and update base images

### DIFF
--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -4,13 +4,13 @@
     #       branches is the branch pattern to match for PR Jobs.
     series:
       - artifacts:
-          branch: artifacts-14.0
-          branches: "artifacts-.*"
+          branch: artifacts
+          branches: "artifacts.*"
     image:
       - trusty:
-          IMAGE: "Ubuntu 14.04.4 LTS prepared for RPC deployment"
+          IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
       - xenial:
-          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+          IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
     context:
       - Git
       - Apt


### PR DESCRIPTION
The artifacts-14.0 branch has become dated and will be removed.
Its content was moved into a new branch in preparation for a PR
to rpc-openstack/master and some new fixes have gone into it
since then. The fixes in there haven't been applied into the
artifacts-14.0 branch and the periodics on that branch are now
interfering with the artifacts published by manual job execution
on the artifacts branch. To resolve this the jobs should be
switched over to the artifacts branch.

Also, now that we have two base images configured in the same
way for both Trusty and Xenial, switch to using them for the
jobs.

Connects https://github.com/rcbops/u-suk-dev/issues/1609