### PR TITLE
RI-18 Modify tempest pipeline for new execution method

### DIFF
--- a/playbooks/vars/aio.yml
+++ b/playbooks/vars/aio.yml
@@ -33,3 +33,6 @@ gating_overrides:
   # UG-615 disabling for now due to upstream bug on service restarts
   # https://github.com/rcbops/rpc-openstack/issues/2258
   cinder_service_backup_program_enabled: false
+  tempest_test_sets: "scenario defcore"
+  tempest_run_tempest_opts:
+    - "--serial"

--- a/playbooks/vars/onmetal.yml
+++ b/playbooks/vars/onmetal.yml
@@ -12,3 +12,6 @@ gating_overrides:
   #              openstack-ansible-os_cinder
   cinder_service_backup_program_enabled: false
   maas_external_ip_address: "{{ ansible_default_ipv4.address }}"
+  tempest_testr_opts:
+    - '--concurrency 3'
+  tempest_run_tempest_opts: []

--- a/rpc_jobs/lem_multi_node_aio.yml
+++ b/rpc_jobs/lem_multi_node_aio.yml
@@ -51,10 +51,6 @@
           DATA_DISK_DEVICE: "mapper/lxc-aio"
       - rpc_repo_params:
           RPC_BRANCH: "{branch}"
-      - tempest_params:
-          TEMPEST_TEST_SETS: "scenario defcore cinder_backup"
-          RUN_TEMPEST_OPTS: "--serial"
-          TESTR_OPTS: ""
       - string:
           name: STAGES
           default: |
@@ -148,7 +144,7 @@
                 maas.prepare(instance_name: instance_name)
                 maas.deploy()
                 maas.verify()
-                tempest.tempest("infra1", "deploy1")
+                tempest.tempest("deploy1")
                 kibana.kibana(env.KIBANA_SELENIUM_BRANCH, "deploy1")
                 holland.holland()
               }}

--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -3,16 +3,20 @@
     series:
       - mitaka:
           branch: mitaka-13.1
-          TEST_SET: "scenario defcore api heat_api smoke"
+          USER_VARS: |
+            tempest_test_sets: 'scenario defcore api heat_api smoke'
       - newton140:
           branch: newton-14.0
-          TEST_SET: "all"
+          USER_VARS: |
+            tempest_test_sets: 'all'
       - newton141:
           branch: newton-14.1
-          TEST_SET: "all"
+          USER_VARS: |
+            tempest_test_sets: 'all'
       - master:
           branch: master
-          TEST_SET: "all"
+          USER_VARS: |
+            tempest_test_sets: 'all'
     context:
       - xenial:
           DEFAULT_IMAGE: "16.04.2"
@@ -75,10 +79,6 @@
       - kibana_selenium_params:
           KIBANA_SELENIUM_BRANCH: "{branch}"
       - rpc_gating_params
-      - tempest_params:
-          TEMPEST_TEST_SETS: "{TEST_SET}"
-          RUN_TEMPEST_OPTS: ""
-          TESTR_OPTS: "--concurrency 3"
       - single_use_slave_params:
           IMAGE: "OnMetal - Ubuntu 14.04 LTS (Trusty Tahr)"
           FLAVOR: "onmetal-io1"
@@ -88,6 +88,10 @@
       - osa_ops_params:
           DEFAULT_IMAGE: "{DEFAULT_IMAGE}"
           DATA_DISK_DEVICE: "sdb"
+      - text:
+          name: "USER_VARS"
+          default: "{USER_VARS}"
+          description: "OSA/RPC USER_VARS to inject for this build"
       - string:
           name: STAGES
           default: |
@@ -161,7 +165,7 @@
                 maas.verify("deploy1")
               }},
               "tempest": {{
-                tempest.tempest("infra1", "deploy1")
+                tempest.tempest("deploy1")
               }},
               "horizon": {{
                 horizon.horizon_integration()

--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -98,28 +98,6 @@
           default: "master"
 
 - parameter:
-    name: tempest_params
-    parameters:
-      - string:
-          name: "TEMPEST_TEST_SETS"
-          default: "{TEMPEST_TEST_SETS}"
-          description: |
-            Test sets (space seperated). Test sets are defined in
-            https://github.com/openstack/openstack-ansible-os_tempest/blob/master/templates/openstack_tempest_gate.sh.j2
-      - string:
-          name: "RUN_TEMPEST_OPTS"
-          default: "{RUN_TEMPEST_OPTS}"
-          description: |
-            Options to pass to run_tempest.sh via openstack_tempest_gate.sh. Note that both are deprecated and will be replaced in future.
-            Serial test runner format: --serial
-      - string:
-          name: "TESTR_OPTS"
-          default: "{TESTR_OPTS}"
-          description: |
-            Options to pass to run_tempest.sh via openstack_tempest_gate.sh. Note that both are deprecated and will be replaced in future.
-            Concurrent worker format: --concurrency 3
-
-- parameter:
     name: kibana_selenium_params
     parameters:
       - string:

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -161,10 +161,6 @@
          IMAGE: "{IMAGE}"
          FLAVOR: "{FLAVOR}"
          REGION: "{REGION}"
-      - tempest_params:
-         TEMPEST_TEST_SETS: "scenario defcore"
-         RUN_TEMPEST_OPTS: "--serial"
-         TESTR_OPTS: ""
       - string:
           name: STAGES
           default: "{STAGES}"


### PR DESCRIPTION
The run_tempest.yml playbook is now provided by the rpc-openstack
repository, relieving the tempest pipeline from complying and
maintaining upstream's different tempest execution mechanisms.

The new playbook is now run by ``tempest.groovy`` the same way that
``/opt/openstack_tempest_gate.sh`` was run previously.

- [x] Depends On https://github.com/rcbops/rpc-openstack/pull/2256
- [x] Depends On https://github.com/rcbops/rpc-openstack/pull/2262
- [x] Depends On https://github.com/rcbops/rpc-openstack/pull/2261
- [x] Depends On https://github.com/rcbops/rpc-openstack/pull/2260

Edit: 05/31/2017 - Currently blocked by:
- [x] https://github.com/rcbops/rpc-openstack/pull/2280
- [x] https://github.com/rcbops/rpc-openstack/pull/2281
- [x] https://github.com/rcbops/rpc-openstack/pull/2282
- [x] https://github.com/rcbops/rpc-openstack/pull/2283
- [x] https://github.com/rcbops/rpc-openstack/pull/2284

Connects https://github.com/rcbops/u-suk-dev/issues/1680