### PR TITLE
UG-586 fix artefact build ordering

### DIFF
--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -127,6 +127,12 @@
         // We need to checkout the rpc-openstack repo on the CIT Slave
         // so that we can cater for builds on the more restricted images
         // used for artifact-based builds.
+        dir("rpc-gating") {{
+          git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
+          common = load 'pipeline_steps/common.groovy'
+          pubcloud = load 'pipeline_steps/pubcloud.groovy'
+          artifact_build = load 'pipeline_steps/artifact_build.groovy'
+        }}
         common.prepareRpcGit("auto", env.WORKSPACE)
         try {{
           node('ArtifactBuilder2') {{
@@ -138,12 +144,6 @@
             artifact_build.apt()
           }} // node ArtifactBuilder2
           // continuing on CIT slave
-          dir("rpc-gating") {{
-            git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-            common = load 'pipeline_steps/common.groovy'
-            pubcloud = load 'pipeline_steps/pubcloud.groovy'
-            artifact_build = load 'pipeline_steps/artifact_build.groovy'
-          }}
           artifact_build.git()
           artifact_build.python()
           artifact_build.container()


### PR DESCRIPTION
3c952fb introduced a bug where the common library was used before
being imported. This commit fixes that.