### PR TITLE
UG-599 Add JIRA issue creation

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -18,6 +18,7 @@ iso8601==0.1.11
 jenkins-job-builder==2.0.0.0b1
 jenkinsapi==0.3.3
 Jinja2==2.9.6
+jira==1.0.10
 keyring==10.3.1
 keystoneauth1==2.19.0
 MarkupSafe==1.0

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -493,4 +493,26 @@ def delete_workspace() {
   }
 }
 
+def create_jira_issue(project="UG", tag=env.BUILD_TAG, link=env.BUILD_URL, type="Task"){
+  withCredentials([
+    usernamePassword(
+      credentialsId: "jira_user_pass",
+      usernameVariable: "JIRA_USER",
+      passwordVariable: "JIRA_PASS"
+    )
+  ]){
+    sh """#!/bin/bash -xe
+      cd ${env.WORKSPACE}
+      . .venv/bin/activate
+      python rpc-gating/scripts/jirautils.py create_issue\
+        --tag '$tag'\
+        --link '$link'\
+        --project '$project'\
+        --user '$JIRA_USER' \
+        --password '$JIRA_PASS' \
+        --type '$type'
+    """
+  }
+}
+
 return this

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyrax
 python-dateutil
 click
 github3.py
+jira

--- a/scripts/jirautils.py
+++ b/scripts/jirautils.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+# This script contains jira related utilties for Jenkins.
+
+
+import click
+from jira import JIRA
+
+
+@click.command()
+@click.option('--tag',
+              help='Jenkins build tag',
+              required=True)
+@click.option('--link',
+              help='Link to related build in Jenkins UI',
+              required=True)
+@click.option('--project',
+              help='Jira Project Key',
+              required=True)
+@click.option('--user',
+              help="Jira User",
+              required=True)
+@click.option('--password',
+              help="Jira Password",
+              required=True)
+@click.option('--type',
+              help="Jira issue type",
+              default="Task")
+@click.option('--instance',
+              help="Jira instance url",
+              default="https://rpc-openstack.atlassian.net")
+@click.option('--label',
+              'labels',
+              help="Add label to issue, can be specified multiple times",
+              multiple=True,
+              default=["jenkins-build-failure"])
+def create_issue(tag, link, project, user, password, type, instance, labels):
+    authed_jira = JIRA(instance, basic_auth=(user, password))
+    authed_jira.create_issue(
+        project=project,
+        summary="JBF: {tag}".format(tag=tag),
+        description="Jenkins Build Failed :( [{tag}|{url}]".format(
+            url=link,
+            tag=tag
+        ),
+        issuetype={'name': type},
+        labels=labels
+    )
+
+
+@click.group()
+def cli():
+    pass
+
+
+cli.add_command(create_issue)
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
This adds the functionality to create JIRA issues for failed builds
but doesn't integrate it with any jobs, that will be added in a
subsequent PR.

Test job: https://rpc.jenkins.cit.rackspace.net/job/scratchpipeline/176/
Issue created by test job: https://rpc-openstack.atlassian.net/browse/UG-603