### PR TITLE
UG-599 Add Jira Issue Creation to Multinode AIO

### DIFF
--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -176,8 +176,7 @@
         }} catch (e){{
             currentBuild.result = 'FAILURE'
             if("{trigger}" == "post-merge"){{
-              github.create_issue(env.BUILD_TAG,
-                                  env.BUILD_URL)
+              common.create_jira_issue()
             }}
             throw e
         }} finally {{


### PR DESCRIPTION
Create jira issues instead of github issues when a post-merge mnaio
build fails.

- [x] Depends on #191