### PR TITLE
UG-606: Install ansible packages without using cache

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -22,10 +22,12 @@ def install_ansible(){
     source .venv/bin/activate
 
     # These pip commands cannot be combined into one.
-    pip install -U six packaging appdirs
-    pip install -U setuptools
+    # Using --no-cache-dir temporarily to avoid jobs from hanging during installation (UG-606)
     pip install 'pip==9.0.1'
+    pip install --no-cache-dir -U six packaging appdirs
+    pip install --no-cache-dir -U setuptools
     pip install \
+      --no-cache-dir \
       -U \
       -c rpc-gating/constraints.txt \
       -r rpc-gating/requirements.txt


### PR DESCRIPTION
Jobs have been hanging due to issues with the pip cache on the CIT node. This is a temporary fix to avoid this.

https://rpc.jenkins.cit.rackspace.net/view/IRR/job/RPC-IRR_rpc_maas-master-trusty-base/147/console
https://rpc.jenkins.cit.rackspace.net/job/mkam-OnMetal-Multi-Node-AIO/12/console