### PR TITLE
Process apt artifact stage before using node

### DIFF
--- a/pipeline_steps/artifact_build.groovy
+++ b/pipeline_steps/artifact_build.groovy
@@ -28,24 +28,19 @@ def get_rpc_repo_creds(){
 }
 
 def apt() {
-  common.conditionalStage(
-    stage_name: "Build Apt Artifacts",
-    stage: {
-      withCredentials(get_rpc_repo_creds()) {
-        common.prepareRpcGit()
-        if(common.is_doc_update_pr("${env.WORKSPACE}/rpc-openstack")){
-          return
-        }
-        ansiColor('xterm') {
-          dir("/opt/rpc-openstack/") {
-            sh """#!/bin/bash
-            scripts/artifacts-building/apt/build-apt-artifacts.sh
-            """
-          } // dir
-        } // ansiColor
-      } // withCredentials
-    } // stage
-  ) // conditionalStage
+  withCredentials(get_rpc_repo_creds()) {
+    common.prepareRpcGit()
+    if(common.is_doc_update_pr("${env.WORKSPACE}/rpc-openstack")){
+      return
+    }
+    ansiColor('xterm') {
+      dir("/opt/rpc-openstack/") {
+        sh """#!/bin/bash
+        scripts/artifacts-building/apt/build-apt-artifacts.sh
+        """
+      } // dir
+    } // ansiColor
+  } // withCredentials
 }
 
 def git() {

--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -135,14 +135,19 @@
         }}
         common.prepareRpcGit("auto", env.WORKSPACE)
         try {{
-          node('ArtifactBuilder2') {{
-            dir("rpc-gating") {{
-              git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-              common = load 'pipeline_steps/common.groovy'
-              artifact_build = load 'pipeline_steps/artifact_build.groovy'
-            }}
-            artifact_build.apt()
-          }} // node ArtifactBuilder2
+          common.conditionalStage(
+            stage_name: "Build Apt Artifacts",
+            stage: {{
+              node('ArtifactBuilder2') {{
+                dir("rpc-gating") {{
+                  git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
+                  common = load 'pipeline_steps/common.groovy'
+                  artifact_build = load 'pipeline_steps/artifact_build.groovy'
+                }}
+                artifact_build.apt()
+              }} // node ArtifactBuilder2
+            }} // stage
+          ) // conditionalStage
           // continuing on CIT slave
           artifact_build.git()
           artifact_build.python()


### PR DESCRIPTION
The node used for apt artifact builds only has one
executor. The job currently requires access to the
node before determining whether the stage is
necessary or not, resulting in any other jobs in
the pipeline waiting for a free executor.

This moves the stage check ahead of the node use
so that the node never needs to be used if the
stage is not included.