### PR TITLE
Revert "UG-606: Install ansible packages without using cache"

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -22,12 +22,10 @@ def install_ansible(){
     source .venv/bin/activate
 
     # These pip commands cannot be combined into one.
-    # Using --no-cache-dir temporarily to avoid jobs from hanging during installation (UG-606)
+    pip install -U six packaging appdirs
+    pip install -U setuptools
     pip install 'pip==9.0.1'
-    pip install --no-cache-dir -U six packaging appdirs
-    pip install --no-cache-dir -U setuptools
     pip install \
-      --no-cache-dir \
       -U \
       -c rpc-gating/constraints.txt \
       -r rpc-gating/requirements.txt


### PR DESCRIPTION
We hit a similar issue previously, and this was a result of a stale lock dir in ~/.cache/pip.  I've since removed ~./pip/http/b/9/2/d/5/b92d5efeb2406de109c0263ebfbbe56d85532219b7d0aae49a57069a.lock which should hopefully resolve the hanging we were seeing.

Side note, we will need to find out what's causing this issue as this is the second time we've hit it.

Reverts rcbops/rpc-gating#194