### PR TITLE
Install gating python packages in isolated mode

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -22,10 +22,10 @@ def install_ansible(){
     source .venv/bin/activate
 
     # These pip commands cannot be combined into one.
-    pip install -U six packaging appdirs
-    pip install -U setuptools
-    pip install 'pip==9.0.1'
+    pip install --index-url https://pypi.python.org/simple pip==9.0.1 setuptools==33.1.1
+    pip install --isolated -c rpc-gating/constraints.txt six packaging appdirs
     pip install \
+      --isolated \
       -U \
       -c rpc-gating/constraints.txt \
       -r rpc-gating/requirements.txt


### PR DESCRIPTION
The packages that are installed for gating purposes should not use the pip configuration set for RPC deployments.

AIO partial build: https://rpc.jenkins.cit.rackspace.net/job/mkam-RPC-AIO/2/console