### PR TITLE
Add functional testing to the rpc-role-logstash repo

### DIFF
--- a/rpc_jobs/irr_role_test.yml
+++ b/rpc_jobs/irr_role_test.yml
@@ -4,6 +4,8 @@
       # IRR REPOS ARE ADDED HERE
       - rpc_maas:
           irr_repo_url: https://github.com/rcbops/rpc-maas
+      - rpc-role-logstash:
+          irr_repo_url: https://github.com/rcbops/rpc-role-logstash
     series:
       # Note: branches is the branch pattern to match for PR Jobs.
       - master:


### PR DESCRIPTION
We have seperated out the logstash role to allow changes for
log aggregation.  The role will eventually be moved upstream,
but will need a local role and functional testing until then.

Connected to issue/942