### PR TITLE
UG-551 Use OSA SHA defined by RPCO with multi-node

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -513,4 +513,16 @@ def create_jira_issue(project="UG", tag=env.BUILD_TAG, link=env.BUILD_URL, type=
   }
 }
 
+String get_current_git_sha(String repo_path) {
+  String sha = ""
+  dir(repo_path) {
+    sha = sh(
+      returnStdout: true,
+      script: "git rev-parse --verify HEAD",
+    ).trim()
+  }
+  print("Current SHA for '${repo_path}' is '${sha}'.")
+  return sha
+}
+
 return this

--- a/pipeline_steps/multi_node_aio_prepare.groovy
+++ b/pipeline_steps/multi_node_aio_prepare.groovy
@@ -2,6 +2,8 @@ def prepare() {
   common.conditionalStage(
     stage_name: 'Prepare Multi-Node AIO',
     stage: {
+      common.prepareRpcGit(env.RPC_BRANCH)
+      String osa_commit = common.get_current_git_sha("/opt/rpc-openstack/openstack-ansible")
       dir("openstack-ansible-ops") {
         git url: env.OSA_OPS_REPO, branch: env.OSA_OPS_BRANCH
       }
@@ -24,7 +26,7 @@ def prepare() {
               "VM_DISK_SIZE=252",
               "DEFAULT_IMAGE=${env.DEFAULT_IMAGE}",
               "DEFAULT_KERNEL=${env.DEFAULT_KERNEL}",
-              "OSA_BRANCH=${env.OPENSTACK_ANSIBLE_BRANCH}",
+              "OSA_BRANCH=${osa_commit}",
               "SETUP_HOST=true",
               "SETUP_VIRSH_NET=true",
               "VM_IMAGE_CREATE=true",
@@ -42,7 +44,6 @@ def prepare() {
   common.conditionalStage(
     stage_name: 'Prepare RPC Configs',
     stage: {
-      common.prepareRpcGit(env.RPC_BRANCH)
       common.prepareConfigs(
         deployment_type: "onmetal"
       )

--- a/rpc_jobs/lem_multi_node_aio.yml
+++ b/rpc_jobs/lem_multi_node_aio.yml
@@ -5,13 +5,10 @@
     series:
       - mitaka:
           branch: mitaka-13.1
-          OPENSTACK_ANSIBLE_BRANCH: "stable/mitaka"
       - newton:
           branch: newton-14.0
-          OPENSTACK_ANSIBLE_BRANCH: "stable/newton"
       - master:
           branch: master
-          OPENSTACK_ANSIBLE_BRANCH: "stable/newton"
     context:
       - trusty:
           DEFAULT_IMAGE: "14.04.5"
@@ -48,7 +45,6 @@
           RPC_BRANCH: "{branch}"
       - rpc_gating_params
       - osa_ops_params:
-          OPENSTACK_ANSIBLE_BRANCH: "{OPENSTACK_ANSIBLE_BRANCH}"
           DEFAULT_IMAGE: "{DEFAULT_IMAGE}"
           DATA_DISK_DEVICE: "mapper/lxc-aio"
       - rpc_repo_params:

--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -3,15 +3,12 @@
     series:
       - mitaka:
           branch: mitaka-13.1
-          OPENSTACK_ANSIBLE_BRANCH: "stable/mitaka"
           TEST_SET: "scenario defcore api heat_api smoke"
       - newton:
           branch: newton-14.0
-          OPENSTACK_ANSIBLE_BRANCH: "stable/newton"
           TEST_SET: "all"
       - master:
           branch: master
-          OPENSTACK_ANSIBLE_BRANCH: "stable/newton"
           TEST_SET: "all"
     context:
       - xenial:
@@ -84,7 +81,6 @@
       - rpc_repo_params:
           RPC_BRANCH: "{branch}"
       - osa_ops_params:
-          OPENSTACK_ANSIBLE_BRANCH: "{OPENSTACK_ANSIBLE_BRANCH}"
           DEFAULT_IMAGE: "{DEFAULT_IMAGE}"
           DATA_DISK_DEVICE: "sdb"
       - string:

--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -39,10 +39,6 @@
           name: OSA_OPS_BRANCH
           default: master
       - string:
-          name: OPENSTACK_ANSIBLE_BRANCH
-          default: "{OPENSTACK_ANSIBLE_BRANCH}"
-          description: Openstack Ansible branch to use in setup
-      - string:
           name: DEFAULT_IMAGE
           default: "{DEFAULT_IMAGE}"
           description: Version of Ubuntu image to use for VMs (14.04.5 or 16.04.2)


### PR DESCRIPTION
This change ensures the version of openstack-ansible being tested on
multi-node AIOs is the one defined by the submodule in rpc-openstack.
To override the OSA SHA, add a new commit to RPCO and then test that
version of RPCO.

This change removes the ability to specify the OSA SHA as a job
parameter. Affected jobs will now use the SHA specified by the version
of RPCO being tested instead of defaulting to the HEAD of the relevant
OSA branch, this should remove the chance of incorrect test results due
to a mismatch between what RPCO specifies the OSA SHA should be and what
Jenkins uses. This change also helps to enforce the principle that
configuration should be in code.