### PR TITLE
UG-615 Disable cinder-backup

### DIFF
--- a/playbooks/vars/aio.yml
+++ b/playbooks/vars/aio.yml
@@ -30,4 +30,6 @@ gating_overrides:
   raw_multi_journal: false
   journal_size: 1024
   osd_directory: true
-  cinder_service_backup_program_enabled: true
+  # UG-615 disabling for now due to upstream bug on service restarts
+  # https://github.com/rcbops/rpc-openstack/issues/2258
+  cinder_service_backup_program_enabled: false

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -129,7 +129,7 @@
          FLAVOR: "{FLAVOR}"
          REGION: "{REGION}"
       - tempest_params:
-         TEMPEST_TEST_SETS: "scenario defcore cinder_backup"
+         TEMPEST_TEST_SETS: "scenario defcore"
          RUN_TEMPEST_OPTS: "--serial"
          TESTR_OPTS: ""
       - string:


### PR DESCRIPTION
Disables cinder-backup on AIO as L->M has upstream bug that is
causing gating failures.

https://github.com/rcbops/rpc-openstack/issues/2258

Connects https://rpc-openstack.atlassian.net/browse/UG-615