### PR TITLE
 [DO NOT MERGE]Prepare the jobs built off master for Ocata

### DIFF
--- a/rpc_jobs/lem_multi_node_aio.yml
+++ b/rpc_jobs/lem_multi_node_aio.yml
@@ -27,6 +27,9 @@
       # Xenial builds are run for newton and above.
       - series: mitaka
         context: xenial
+      # The master+trusty must be exlucded in preperation for Ocata
+      - series: master
+        context: trusty
     jobs:
       - 'LEM-Multi-Node-AIO_{series}-{context}-{ztrigger}'
 

--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -26,6 +26,9 @@
     exclude:
       - series: mitaka
         context: xenial
+      # The master+trusty must be exlucded in preperation for Ocata
+      - series: master
+        context: trusty
     jobs:
       - 'OnMetal-Multi-Node-AIO_{series}-{context}-{trigger}'
       - 'OnMetal-Multi-Node-AIO-Merge-Trigger_{series}'

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -80,6 +80,12 @@
       # An artifacted ceph deployment is not yet supported
       - series: artifacts
         context: ceph
+      # We must exclude all jobs that run on trusty from running off
+      # the master branch. Ocata does not support trusty.
+      - series: master
+        context: ceph
+      - series: master
+        context: swift
     jobs:
       - 'RPC-AIO_{series}-{context}-{ztrigger}'
 


### PR DESCRIPTION
Ocata doesn't support trusty, and therefore all trusty jobs can be
excluded from the master+<context> matrix. This will leave only
the Xenial job to run off the master branch, which deploys swift.

NOTE: There is still work to be done to figure out how we are going
to be testing external Ceph deployments Ocata onwards. That work is
being tracked here:
https://github.com/rcbops/u-suk-dev/issues/1640

Connects https://github.com/rcbops/u-suk-dev/issues/1639