### PR TITLE
UG-612 Install pip using get-pip.py

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -39,6 +39,7 @@ oslo.utils==3.25.0
 packaging==16.8
 paramiko==2.1.2
 pbr==1.10.0
+pip==9.0.1
 positional==1.1.1
 prettytable==0.7.2
 pyasn1==0.2.3
@@ -60,6 +61,7 @@ rax-default-network-flags-python-novaclient-ext==0.4.0
 rax-scheduled-images-python-novaclient-ext==0.3.1
 requests==2.10.0
 rfc3986==0.4.1
+setuptools==33.1.1
 simplejson==3.10.0
 six==1.10.0
 stevedore==1.19.1

--- a/playbooks/setup_jenkins_slave.yml
+++ b/playbooks/setup_jenkins_slave.yml
@@ -9,11 +9,11 @@
         state: installed
         update_cache: yes
       with_items:
-        - git
+        - git-core
         - default-jre-headless
         - python-dev
-        - python-pip
-        - build-essential
+        - gcc
+        - libffi-dev
         - libssl-dev
 
     - name: Create Jenkins user
@@ -41,6 +41,57 @@
         state: present
         regexp: 'jenkins'
         line: 'jenkins ALL=(ALL) NOPASSWD: ALL'
+
+    - name: Copy constraints file over to cloud server
+      copy:
+        src: "{{ lookup('env', 'WORKSPACE') ~ '/rpc-gating/constraints.txt' }}"
+        dest: "/opt/rpc_gating_constraints.txt"
+
+    - block:
+        - name: Get Modern PIP
+          get_url:
+            url: "https://bootstrap.pypa.io/get-pip.py"
+            dest: "/opt/get-pip.py"
+            force: "yes"
+          register: get_pip
+          until: get_pip | success
+          retries: 5
+          delay: 2
+          tags:
+            - pip-install-script
+
+      rescue:
+        - name: Get Modern PIP using fallback URL
+          get_url:
+            url: "https://raw.githubusercontent.com/pypa/get-pip/master/get-pip.py"
+            dest: "/opt/get-pip.py"
+            force: "yes"
+          when: get_pip | failed
+          register: get_pip_fallback
+          until: get_pip_fallback | success
+          retries: 5
+          delay: 2
+          tags:
+            - pip-install-script
+
+    - block:
+        - name: Install PIP
+          shell: |
+            python /opt/get-pip.py -c /opt/rpc_gating_constraints.txt
+          register: pip_install
+          until: pip_install | success
+          retries: 3
+          delay: 2
+
+      rescue:
+        - name: Install PIP (fall back mode)
+          shell: |
+            python /opt/get-pip.py --isolated -c /opt/rpc_gating_constraints.txt
+          register: pip_install_fall_back
+          until: pip_install_fall_back | success
+          retries: 3
+          delay: 2
+
 
       # pip module didn't work here as it couldn't locate the virtualenv binary
     - name: Start slave

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ python-dateutil
 click
 github3.py
 jira
+six
+packaging
+appdirs


### PR DESCRIPTION
This commit installs pip and setuptools using the ``get-pip.py`` script,
instead of using the distro's pip version.