### PR TITLE
[LA-312] Make kilo tests pass

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -6,6 +6,17 @@
       - kilo:
           branch: kilo
           branches: "kilo.*"
+          STAGES: >-
+            Allocate Resources,
+            Connect Slave,
+            Prepare Deployment,
+            Deploy RPC w/ Script,
+            Setup MaaS,
+            Install Tempest,
+            Tempest Tests,
+            Holland,
+            Cleanup,
+            Destroy Slave
       - liberty:
           branch: liberty-12.2
           branches: "liberty-.*"


### PR DESCRIPTION
Kilo was never tested with new tests.

This commit ensure kilo PR will not be tested against code that
was never tested before.

By doing this, we sadly reduce the test coverage, but we are
in-line to the current deploys's testing.