### PR TITLE
UG-621 Stage python artifacts on all infra VMs

### DIFF
--- a/playbooks/vars/onmetal.yml
+++ b/playbooks/vars/onmetal.yml
@@ -15,3 +15,4 @@ gating_overrides:
   tempest_testr_opts:
     - '--concurrency 3'
   tempest_run_tempest_opts: []
+  staging_host: repo-infra_hosts


### PR DESCRIPTION
The stage-python-artifacts.yml playbook stages the python artifacts
on localhost by default. For multi-node AIO builds, these artifacts
need to be on all of the infra VMs, which host the repo server containers.