### PR TITLE
UG-625 Adjust Docker cleanup

### DIFF
--- a/scripts/docker_cleanup.sh
+++ b/scripts/docker_cleanup.sh
@@ -4,9 +4,8 @@ set -xe
 echo "Remove exited containers"
 docker ps -a |awk '/Exited/{print $1}' |while read cid; do docker rm $cid||:; done
 
-echo "Remove Images"
-# If the image is in use, rmi (remove image) will fail even with force.
-# Only images that aren't in use will be removed. Images that aren't in use
-# but are used will be rebuild or downloaded. Force is required to remove tagged
-# images and all the images created by the jenkins docker plugin are tagged.
-docker images -q |while read diid; do docker rmi -f $diid ||:;  done
+echo "Remove old Images"
+# Remove any images that have been created more than a day ago, unless it is
+# the latest ubuntu image.
+diid=$(docker images -a | grep -vP "^ubuntu.*latest" | egrep "(days[s]?|week[s]?)" | awk '{print $3}')
+for dimage in $diid; do docker rmi -f ${dimage}||:; done


### PR DESCRIPTION
Removes images that are not the latest ubuntu that are more
than a day old.

This change is to resolve a found race condition in which the
cleanup job could run at a time and remove a newly created image
before the job it was created for ran the image.