### PR TITLE
Fix execution of tempest on AIO

### DIFF
--- a/pipeline_steps/tempest.groovy
+++ b/pipeline_steps/tempest.groovy
@@ -12,9 +12,14 @@ def tempest_install(vm=null){
 }
 
 def tempest_run(wrapper="") {
+  tempest_cmd = "cd /opt/rpc-openstack/rpcd/playbooks && openstack-ansible ../../scripts/run_tempest.yml -t tempest_execute_tests -vv"
+  if (wrapper != "") {
+    tempest_cmd_wrapped = "${wrapper} '${tempest_cmd}'"
+  } else {
+    tempest_cmd_wrapped = tempest_cmd
+  }
   def output = sh (script: """#!/bin/bash
-  ${wrapper} 'cd /opt/rpc-openstack/rpcd/playbooks && openstack-ansible \
-    ../../scripts/run_tempest.yml -t tempest_execute_tests -vv'
+  ${tempest_cmd_wrapped}
   """, returnStdout: true)
   print output
   return output


### PR DESCRIPTION
AIO builds are currently failing with a "No such file or directory"
error when running tempest on the AIOs.  This appears to be a result of
running tempest unwrapped with quotes around the tempest command, which
bash does not like:

```
root@ranxp-16-8323:~# 'cd /tmp && ls -al'
-bash: cd /tmp && ls -al: No such file or directory
root@ranxp-16-8323:~#
```

This commit simply creates a temporary variable depending on whether we
are using a wrapper (and need to quote) or not.