### PR TITLE
Removing the hard coded cinder backup option

### DIFF
--- a/playbooks/vars/aio.yml
+++ b/playbooks/vars/aio.yml
@@ -30,9 +30,6 @@ gating_overrides:
   raw_multi_journal: false
   journal_size: 1024
   osd_directory: true
-  # UG-615 disabling for now due to upstream bug on service restarts
-  # https://github.com/rcbops/rpc-openstack/issues/2258
-  cinder_service_backup_program_enabled: false
   tempest_test_sets: "scenario defcore"
   tempest_run_tempest_opts:
     - "--serial"

--- a/playbooks/vars/onmetal.yml
+++ b/playbooks/vars/onmetal.yml
@@ -7,10 +7,6 @@ gating_overrides:
   memory_used_percentage_critical_threshold: 99.5
   net_max_speed: 1000
   lb_name: "{{ lookup('env', 'NODE_NAME') }}"
-  # NOTE(mattt): This functionality is currently broken on multi-node
-  #              deployments, disabling until this is addressed in
-  #              openstack-ansible-os_cinder
-  cinder_service_backup_program_enabled: false
   maas_external_ip_address: "{{ ansible_default_ipv4.address }}"
   tempest_testr_opts:
     - '--concurrency 3'


### PR DESCRIPTION
This option should be set within the RPC-O project should we need to
have the service disabled. Hard coding it here makes it next to
impossible to test changes that may use this feature within the gate.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>