### PR TITLE
UG-625 Docker Cleanup tweak

### DIFF
--- a/scripts/docker_cleanup.sh
+++ b/scripts/docker_cleanup.sh
@@ -7,5 +7,5 @@ docker ps -a |awk '/Exited/{print $1}' |while read cid; do docker rm $cid||:; do
 echo "Remove old Images"
 # Remove any images that have been created more than a day ago, unless it is
 # the latest ubuntu image.
-diid=$(docker images -a | grep -vP "^ubuntu.*latest" | egrep "(days[s]?|week[s]?)" | awk '{print $3}')
+diid=$(docker images -a | grep -vP "^ubuntu.*latest" | egrep "[0-9]{2,} (hour|day|week)s?" | awk '{print $3}')
 for dimage in $diid; do docker rmi -f ${dimage}||:; done


### PR DESCRIPTION
Updates docker script to remove images on double digit hours. This
is needed as the `docker images -a` does not switch to include
days at 24 hours.

The `egrep` is required as the version of docker on the build node
does not include the `--format` flag in the cli that would allow
use of the `.CreatedAt` template to better filter images to delete.