### PR TITLE
UG-629 Temporary fix for multi-node AIO tempest vars

### DIFF
--- a/playbooks/vars/onmetal.yml
+++ b/playbooks/vars/onmetal.yml
@@ -12,6 +12,9 @@ gating_overrides:
   #              openstack-ansible-os_cinder
   cinder_service_backup_program_enabled: false
   maas_external_ip_address: "{{ ansible_default_ipv4.address }}"
+  # NOTE(mkam): Extra quotations and empty string for tempest_run_tempest_opts
+  # are a temporary fix for UG-629
   tempest_testr_opts:
-    - '--concurrency 3'
-  tempest_run_tempest_opts: []
+    - '"--concurrency 3"'
+  tempest_run_tempest_opts:
+    - '""'


### PR DESCRIPTION
Add quotations and an empty string to tempest vars
for multi-node AIO builds because they are not
surrounded by quotes in the run_tempest.yml playbook.