### PR TITLE
Fix how kibana_branch is determined

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -270,7 +270,7 @@
                 maas.deploy()
                 maas.verify()
                 tempest.tempest()
-                kibana_branch = env.UPGRADE_FROM_REF ?: env.KIBANA_SELENIUM_BRANCH
+                kibana_branch = env.STAGES.contains("Major Upgrade") ? env.UPGRADE_FROM_REF : env.KIBANA_SELENIUM_BRANCH
                 kibana.kibana(kibana_branch)
                 holland.holland()
                 if (env.STAGES.contains("Major Upgrade")) {{


### PR DESCRIPTION
Previously, we only set UPGRADE_FROM_REF on upgrade context, however
it is now set in the series and this is breaking the kibana tests.

This commit only uses UPGRADE_FROM_REF when we're on the first step of
a major upgrade.