### PR TITLE
UG-607 Ensure pull requests link to Jira issues

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -509,8 +509,7 @@ def get_jira_issue_key(repo_path="rpc-openstack"){
       }
     }
     throw new Exception("""
-Attempting to add a comment to the relevant JIRA issue, but a JIRA Issue key
-was not found in any of the commits introduced by ${repo_path}:${ghprbSourceBranch}""")
+No JIRA Issue key was found in any of the commits introduced by ${repo_path}:${ghprbSourceBranch}""")
   }
 }
 

--- a/pipeline_steps/github.groovy
+++ b/pipeline_steps/github.groovy
@@ -25,4 +25,44 @@ def create_issue(
   }
 }
 
+/**
+ * Add issue link to pull request description
+ *
+ * Pull request commit messages include the issue key for an issue on Jira.
+ * Update the description of the current GitHub pull request with a link to
+ * the Jira issue.
+ */
+void add_issue_url_to_pr(){
+  List org_repo = env.ghprbGhRepository.split("/")
+  String org = org_repo[0]
+  String repo = org_repo[1]
+
+  Integer pull_request_number = env.ghprbPullId as Integer
+
+  dir(repo) {
+    git branch: env.ghprbSourceBranch, url: env.ghprbAuthorRepoGitUrl
+  }
+  String issue_key = common.get_jira_issue_key(repo)
+
+  withCredentials([
+    string(
+      credentialsId: 'rpc-jenkins-svc-github-pat',
+      variable: 'pat'
+    )
+  ]){
+    sh """#!/bin/bash -xe
+      cd $env.WORKSPACE
+      . .venv/bin/activate
+      python rpc-gating/scripts/ghutils.py add_issue_url_to_pr\
+        --org '$org'\
+        --repo '$repo'\
+        --pat '$pat'\
+        --pull-request-number '$pull_request_number'\
+        --issue-key '$issue_key'
+    """
+  }
+  return null
+}
+
+
 return this;

--- a/pipeline_steps/github.groovy
+++ b/pipeline_steps/github.groovy
@@ -14,12 +14,13 @@ def create_issue(
     sh """#!/bin/bash -xe
       cd ${env.WORKSPACE}
       . .venv/bin/activate
-      python rpc-gating/scripts/ghutils.py create_issue\
-        --tag '$tag'\
-        --link '$link'\
+      python rpc-gating/scripts/ghutils.py\
         --org '$org'\
         --repo '$repo'\
         --pat '$pat'\
+        create_issue\
+        --tag '$tag'\
+        --link '$link'\
         --label '$label'
     """
   }
@@ -53,10 +54,11 @@ void add_issue_url_to_pr(){
     sh """#!/bin/bash -xe
       cd $env.WORKSPACE
       . .venv/bin/activate
-      python rpc-gating/scripts/ghutils.py add_issue_url_to_pr\
+      python rpc-gating/scripts/ghutils.py\
         --org '$org'\
         --repo '$repo'\
         --pat '$pat'\
+        add_issue_url_to_pr\
         --pull-request-number '$pull_request_number'\
         --issue-key '$issue_key'
     """

--- a/rpc_jobs/pull_request_issue_link.yml
+++ b/rpc_jobs/pull_request_issue_link.yml
@@ -1,0 +1,54 @@
+- project:
+    name: 'RPC-Pull-Request-Issue-Link-Jobs'
+    series:
+      - all_branches:
+          branches: ".*"
+    repo:
+      - rpc_openstack:
+          repo_url: "https://github.com/rcbops/rpc-openstack"
+      - rpc_gating:
+          repo_url: "https://github.com/rcbops/rpc-gating"
+    jobs:
+      - 'RPC-Pull-Request-Issue-Link_{repo}'
+
+- job-template:
+    name: 'RPC-Pull-Request-Issue-Link_{repo}'
+    project-type: workflow
+    concurrent: true
+    triggers:
+      - github-pull-request:
+          org-list:
+            - rcbops
+          github-hooks: true
+          trigger-phrase: '.*recheck_all.*|.*recheck_issue_link.*'
+          only-trigger-phrase: false
+          auth-id: "github_account_rpc_jenkins_svc"
+          status-context: 'CIT/issue-link'
+          cancel-builds-on-update: true
+    properties:
+      - github:
+          url: "{repo_url}"
+    parameters:
+      - rpc_gating_params
+      - string:
+          name: REPO
+          default: "{repo}"
+    dsl: |
+      node() {{
+        deleteDir()
+        if (REPO == "rpc_gating") {{
+          branch = env.ghprbSourceBranch
+          url = env.ghprbAuthorRepoGitUrl
+        }} else {{
+          branch = env.RPC_GATING_BRANCH
+          url = env.RPC_GATING_REPO
+        }}
+        dir("rpc-gating") {{
+          git branch: branch, url: url
+          common = load 'pipeline_steps/common.groovy'
+          github = load 'pipeline_steps/github.groovy'
+          venv = "${{env.WORKSPACE}}/.venv"
+          sh "virtualenv ${{venv}} && . ${{venv}}/bin/activate && pip install -c constraints.txt click github3.py"
+        }}
+        github.add_issue_url_to_pr()
+      }}


### PR DESCRIPTION
Add a line of the form Issue: Jira key to the
description of pull requests in tracked repositories.
This change adds a job to update pull requests. Developers only add an
issue key reference to commit messages. This job runs a script to update
the pull request description body with a link to the issue to simplify
accessing it.

Issue: [UG-607](https://rpc-openstack.atlassian.net/browse/UG-607)