### PR TITLE
RI-20 Add jobs for ocata-15.0 branch

### DIFF
--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -13,6 +13,9 @@
           branch: newton-14.1
           USER_VARS: |
             tempest_test_sets: 'all'
+      - ocata150:
+          branch: ocata-15.0
+          USER_VARS: ""
       - master:
           branch: master
           USER_VARS: |
@@ -30,6 +33,11 @@
     exclude:
       - series: mitaka
         context: xenial
+      # Ocata onwards does not support trusty, so these jobs are excluded
+      - series: ocata150
+        context: trusty
+      - series: master
+        context: trusty
     jobs:
       - 'OnMetal-Multi-Node-AIO_{series}-{context}-{trigger}'
       - 'OnMetal-Multi-Node-AIO-Merge-Trigger_{series}'

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -31,6 +31,9 @@
           branch: newton-14.1
           branches: "newton-14.1.*"
           UPGRADE_FROM_REF: "kilo"
+      - ocata150:
+          branch: ocata-15.0
+          branches: "ocata-15.0.*"
       - master:
           branch: master
           branches: "master"
@@ -100,6 +103,8 @@
         action: majorupgrade
       - series: master
         action: majorupgrade
+      - series: ocata
+        action: majorupgrade
       # Xenial builds are run for newton and above
       # as it is not supported distro before newton.
       - series: kilo
@@ -120,6 +125,8 @@
       - series: newton140
         action: leapfrogupgrade
       - series: master
+        action: leapfrogupgrade
+      - series: ocata
         action: leapfrogupgrade
       # Leapfrog upgrades cannot be executed on
       # xenial as it is not possible to install
@@ -146,6 +153,8 @@
       # as Trusty is not a supported distro for
       # Ocata onwards.
       - series: master
+        image: trusty
+      - series: ocata150
         image: trusty
     jobs:
       - 'RPC-AIO_{series}-{image}-{action}-{scenario}-{ztrigger}'

--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -6,6 +6,9 @@
       - master:
           branch: master
           branches: "master"
+      - ocata:
+          branch: ocata-15.0
+          branches: "ocata-15.0.*"
       - newton:
           branch: newton-14.1
           branches: "newton-14.1.*"
@@ -49,8 +52,8 @@
         ztrigger: periodic
       - context: Pipeline
         ztrigger: pr
-      # Trusty artifacts are not required after Newton
-      # as Trusty is no longer a supported distro.
+      - series: ocata
+        image: trusty
       - series: master
         image: trusty
     jobs:


### PR DESCRIPTION
This commit adds jobs for the ocata-15.0 branch in rpc-openstack.
It also adds exclusions to prevent these jobs from running any permutation that
includes the trusty image and ocata series.