### PR TITLE
AR-191 Do docs check without resource allocation

### DIFF
--- a/pipeline_steps/artifact_build.groovy
+++ b/pipeline_steps/artifact_build.groovy
@@ -30,9 +30,6 @@ def get_rpc_repo_creds(){
 def apt() {
   withCredentials(get_rpc_repo_creds()) {
     common.prepareRpcGit()
-    if(common.is_doc_update_pr("${env.WORKSPACE}/rpc-openstack")){
-      return
-    }
     ansiColor('xterm') {
       dir("/opt/rpc-openstack/") {
         sh """#!/bin/bash
@@ -51,9 +48,6 @@ def git() {
         try {
           withCredentials(get_rpc_repo_creds()) {
             common.prepareRpcGit()
-            if(common.is_doc_update_pr("${env.WORKSPACE}/rpc-openstack")){
-              return
-            }
             ansiColor('xterm') {
               dir("/opt/rpc-openstack/") {
                 sh """#!/bin/bash
@@ -81,9 +75,6 @@ def python() {
         try {
           withCredentials(get_rpc_repo_creds()) {
             common.prepareRpcGit()
-            if(common.is_doc_update_pr("${env.WORKSPACE}/rpc-openstack")){
-              return
-            }
             ansiColor('xterm') {
               dir("/opt/rpc-openstack/") {
                 sh """#!/bin/bash
@@ -111,9 +102,6 @@ def container() {
         try {
           withCredentials(get_rpc_repo_creds()) {
             common.prepareRpcGit()
-            if(common.is_doc_update_pr("${env.WORKSPACE}/rpc-openstack")){
-              return
-            }
             ansiColor('xterm') {
               dir("/opt/rpc-openstack/") {
                 sh """#!/bin/bash

--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -67,7 +67,7 @@
       Connect Slave,
       Cleanup,
       Destroy Slave
-    branch: artifacts-14.0
+    branch: master
     PUSH_TO_MIRROR: "NO"
     NUM_TO_KEEP: 30
 
@@ -141,6 +141,13 @@
           common = load 'pipeline_steps/common.groovy'
           pubcloud = load 'pipeline_steps/pubcloud.groovy'
           artifact_build = load 'pipeline_steps/artifact_build.groovy'
+        }}
+        // We need to checkout the rpc-openstack repo on the CIT Slave
+        // so that we can check whether the patch is a docs-only patch
+        // before allocating resources unnecessarily.
+        common.prepareRpcGit("auto", env.WORKSPACE)
+        if(common.is_doc_update_pr("${{env.WORKSPACE}}/rpc-openstack")){{
+          return
         }}
         try {{
           common.conditionalStage(


### PR DESCRIPTION
Currently all the artifact jobs do the resource
allocation prior to checking whether the patch
is a docs-only check. This wastes resources
unnecessarily.

Also, the docs check is currently trying to
check the wrong place, resulting in the tests
not being executed.

This ensures that the docs check is done on the
CIT slave prior to processing any stages. It
also ensures that the check is executed in the
right folder.