### PR TITLE
Add dashboard link to MaaS Jira tickets

### DIFF
--- a/webhooktranslator/tests/MaaS_payload_example.json
+++ b/webhooktranslator/tests/MaaS_payload_example.json
@@ -1,107 +1,82 @@
 {
-   "event_id": "acOne:enOne:alOne:chOne:1326910500000:WARNING",
-   "log_entry_id": "6da55310-4200-11e1-aaaf-cd4c8801b6b1",
-   "details": {
-       "target": null,
-       "timestamp": 1326905540481,
-       "metrics": {
-           "tt_firstbyte": {
-               "type": "I",
-               "data": 2,
-               "unit": "milliseconds"
-           },
-           "duration": {
-               "type": "I",
-               "data": 2,
-               "unit": "milliseconds"
-           },
-           "bytes": {
-               "type": "i",
-               "data": 17,
-               "unit": "bytes"
-           },
-           "tt_connect": {
-               "type": "I",
-               "data": 0,
-               "unit": "milliseconds"
-           },
-           "code": {
-               "type": "s",
-               "data": "200",
-               "unit": "unknown"
-           }
-       },
-       "state": "WARNING",
-       "status": "warn.",
-       "txn_id": "sometransaction",
-       "collector_address_v4": "127.0.0.1",
-       "collector_address_v6": null,
-       "observations": [
-           {
-               "monitoring_zone_id": "mzOne",
-               "state": "WARNING",
-               "status": "warn.",
-               "timestamp": 1326905540481,
-               "collectorState": "UP"
-           }
-       ]
-   },
-   "entity": {
-       "id": "enOne",
-       "label": "entity one",
-       "ip_addresses": {
-           "default": "127.0.0.1"
-       },
-       "metadata": null,
-       "managed": false,
-       "uri": null,
-       "agent_id": null,
-       "created_at": 1326905540481,
-       "updated_at": 1326905540481
-   },
-   "check": {
-       "id": "chOne",
-       "label": "ch a",
-       "type": "remote.http",
-       "details": {
-           "url": "http://www.foo.com",
-           "body": "b",
-           "method": "GET",
-           "follow_redirects": true,
-           "include_body": false
-       },
-       "monitoring_zones_poll": [
-           "mzOne"
-       ],
-       "timeout": 30,
-       "period": 60,
-       "target_alias": "default",
-       "target_hostname": "",
-       "target_resolver": "",
-       "disabled": false,
-       "metadata": null,
-       "confd_name": null,
-       "confd_hash": null,
-       "active_suppressions": null,
-       "scheduled_suppressions": null,
-       "created_at": 1326905540481,
-       "updated_at": 1326905540481
-   },
-   "alarm": {
-       "id": "alOne",
-       "label": "Alarm 1",
-       "check_id": "chOne",
-       "entity_id": "enOne",
-       "criteria": "if (metric[\"t\"] >= 2.1) { return WARNING } return WARNING",
-       "disabled": false,
-       "notification_plan_id": "npOne",
-       "metadata": null,
-       "confd_name": null,
-       "confd_hash": null,
-       "active_suppressions": null,
-       "scheduled_suppressions": null,
-       "created_at": 1326905540481,
-       "updated_at": 1326905540481
-       },
-       "tenant_id": "91111"
+  "alarm": {
+    "active_suppressions": null,
+    "check_id": "chKzEIrCli",
+    "confd_hash": "23acb5c933bc0f8ecc7a855d7e985a2f418c913c",
+    "confd_name": "{\"alarm\":\"percentage_disk_utilisation_xvda\",\"filename\":\"disk_utilisation--lrs-2-daa6.yaml\"}",
+    "created_at": 1497445418059,
+    "criteria": ":set consecutiveCount=3\nif (metric[\"disk_utilisation_xvda\"] > 99) {\n    return new AlarmStatus(CRITICAL, \"Disk IO utilisation for xvda >= 99%\");\n}\nif (metric[\"disk_utilisation_xvda\"] > 90) {\n    return new AlarmStatus(WARNING, \"Disk IO utilisation for xvda >= 90%\");\n}\n",
+    "disabled": false,
+    "entity_id": "enxAJKN38B",
+    "id": "alL0HLZphj",
+    "label": "percentage_disk_utilisation_xvda--lrs-2-daa6",
+    "metadata": null,
+    "notification_plan_id": "np8VCT2ZLA",
+    "scheduled_suppressions": null,
+    "updated_at": 1497445418059
+  },
+  "check": {
+    "active_suppressions": null,
+    "check_version": 1,
+    "confd_hash": "bcc6a7cd4b9ea43bc18ac2f8fb628b4d626893de",
+    "confd_name": "{\"check\":\"default\",\"filename\":\"disk_utilisation--lrs-2-daa6.yaml\"}",
+    "created_at": 1497445416938,
+    "details": {
+      "args": [
+        "/usr/lib/rackspace-monitoring-agent/plugins/disk_utilisation.py"
+      ],
+      "file": "run_plugin_in_venv.sh"
+    },
+    "disabled": false,
+    "id": "chKzEIrCli",
+    "label": "disk_utilisation--lrs-2-daa6",
+    "metadata": null,
+    "monitoring_zones_poll": null,
+    "period": 60,
+    "scheduled_suppressions": null,
+    "target_alias": null,
+    "target_hostname": null,
+    "target_resolver": null,
+    "timeout": 30,
+    "type": "agent.plugin",
+    "updated_at": 1497445416938
+  },
+  "dashboard_link": "https://intelligence.rackspace.com/cloud/entities/enxAJKN38B/checks/chKzEIrCli/alarm/alL0HLZphj",
+  "details": {
+    "metrics": null,
+    "observations": [
+      {
+        "collectorState": "UP",
+        "monitoring_zone_id": null,
+        "state": "CRITICAL",
+        "status": "error [Errno 2] No such file or directory",
+        "timestamp": 1497445589102
+      }
+    ],
+    "state": "CRITICAL",
+    "status": "error [Errno 2] No such file or directory",
+    "target": "",
+    "timestamp": 1497445589102,
+    "txn_id": null
+  },
+  "entity": {
+    "agent_id": "lrs-2-daa6",
+    "created_at": 1497444783791,
+    "id": "enxAJKN38B",
+    "ip_addresses": {
+      "access_ip0_v6": "2001:4802:7805:0102:be76:4eff:fe20:7c4d",
+      "access_ip1_v4": "104.239.168.41",
+      "private0_v4": "10.209.96.167",
+      "public0_v4": "104.239.168.41",
+      "public1_v6": "2001:4802:7805:0102:be76:4eff:fe20:7c4d"
+    },
+    "label": "lrs-2-daa6",
+    "managed": false,
+    "metadata": null,
+    "updated_at": 1497445384536,
+    "uri": "https://iad.servers.api.rackspacecloud.com/976582/servers/eff11850-c5de-4cac-99d2-330010f3f10c"
+  },
+  "event_id": "acF1Ndksg8:enxAJKN38B:alL0HLZphj:chKzEIrCli:1497445560000:CRITICAL",
+  "log_entry_id": "479808e0-5102-11e7-afc6-538975e7cb8b",
+  "tenant_id": "000000"
 }

--- a/webhooktranslator/tests/test_webhooktranslator.py
+++ b/webhooktranslator/tests/test_webhooktranslator.py
@@ -56,9 +56,13 @@ class WebhooktranslatorTestCase(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         _, kwargs = mock_create_jira_issue.call_args
         self.assertIn("MaaS Alert:", kwargs['summary'])
-        self.assertIn("WARNING", kwargs['summary'])
+        self.assertIn("CRITICAL", kwargs['summary'])
         self.assertIn("Full Payload", kwargs['description'])
         self.assertIn("alert", kwargs['labels'])
+        self.assertIn(
+            "[Dashboard Link|https://intelligence.rackspace.com/cloud/"
+            "entities/enxAJKN38B/checks/chKzEIrCli/alarm/alL0HLZphj]",
+            kwargs['description'])
 
 
 if __name__ == '__main__':

--- a/webhooktranslator/webhooktranslator/webhooktranslator.py
+++ b/webhooktranslator/webhooktranslator/webhooktranslator.py
@@ -62,6 +62,7 @@ def maas():
         entity = maas_payload['entity']['label']
         check = maas_payload['check']['label']
         alarm = maas_payload['alarm']['label']
+        dash_link = maas_payload['dashboard_link']
     except KeyError as e:
         abort(400, "JSON content missing required key: {}".format(
             e.message
@@ -79,6 +80,8 @@ def maas():
 Alarm {alarm} for entity {entity} is in {state} state.
 The check is {check}.
 
+[Dashboard Link|{dash_link}]
+
 {{code:title=Full Payload from MaaS}}
 {maas_payload}
 {{code}}
@@ -87,6 +90,7 @@ The check is {check}.
             entity=entity,
             state=state,
             check=check,
+            dash_link=dash_link,
             maas_payload=json.dumps(maas_payload,
                                     sort_keys=True,
                                     indent=2,


### PR DESCRIPTION
This change adds a link to the intelligence dashboard for an alert.
This will allow a user to see historical data related to the alert.

This change also adds a real sample MaaS webhook payload as reality
doesn't quite match the sample given in the docs.

Tests are also udpated to reflect the new sample payload.