### PR TITLE
UG-619 fix maas utils function

### DIFF
--- a/pipeline_steps/maas.groovy
+++ b/pipeline_steps/maas.groovy
@@ -60,7 +60,7 @@ def maas_utils(List args){
       script: """#!/bin/bash
         cd ${env.WORKSPACE}/rpc-gating/scripts
         . ${env.WORKSPACE}/.venv/bin/activate
-        ./maasutils.py --username ${username} --api-key ${api_key} ${args.join(" ")}
+        ./maasutils.py --username ${env.PUBCLOUD_USERNAME} --api-key ${env.PUBCLOUD_API_KEY} ${args.join(" ")}
       """,
       returnStdout: true
     )


### PR DESCRIPTION
This function was converted from one that takes user name and api key
argument to one that supplies its own creds via a with_credentials
block. However the code that used those creds was not updated to read
the env rather than supplied args. This commit fixes that.