### PR TITLE
UG-641 Remove addChecksumRule

### DIFF
--- a/pipeline_steps/deploy.groovy
+++ b/pipeline_steps/deploy.groovy
@@ -77,16 +77,4 @@ def upgrade_leapfrog(Map args) {
   upgrade("Leapfrog Upgrade", "leapfrog/ubuntu14-leapfrog.sh", args.environment_vars)
 }
 
-def addChecksumRule(){
-  sh """#!/bin/bash
-    cd /opt/rpc-openstack/rpcd/playbooks
-    ansible neutron_agent \
-      -m command \
-      -a '/sbin/iptables -t mangle -A POSTROUTING -p tcp --sport 80 -j CHECKSUM --checksum-fill'
-    ansible neutron_agent \
-      -m shell \
-      -a 'DEBIAN_FRONTEND=noninteractive apt-get install iptables-persistent'
-  """
-}
-
 return this;

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -312,7 +312,6 @@
                   ]
                 aio_prepare.prepare()
                 deploy.deploy_sh(environment_vars: environment_vars)
-                deploy.addChecksumRule()
                 maas.deploy()
                 maas.verify()
                 tempest.tempest()
@@ -325,7 +324,6 @@
                   deploy.upgrade_minor(environment_vars: environment_vars)
                 }} else if (env.STAGES.contains("Major Upgrade")) {{
                   deploy.upgrade_major(environment_vars: environment_vars)
-                  deploy.addChecksumRule()
                   maas.deploy()
                   maas.verify()
                   tempest.tempest()


### PR DESCRIPTION
The requirement to add the checksum in this way
is only necessary for Liberty and earlier. Also,
this should be done in the rpc-o scripts, not
the gating scripts.

This action is already present in both kilo [1] and liberty [2].

[1] https://github.com/rcbops/rpc-openstack/pull/2370
[2] https://github.com/rcbops/rpc-openstack/pull/2369

Issue: [UG-641](https://rpc-openstack.atlassian.net/browse/UG-641)