### PR TITLE
Allow concurrent artifact PR tests

### DIFF
--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -16,10 +16,12 @@
           IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
     context:
       - Git
-      - Apt
+      - Apt:
+          allow_concurrent: false
       - Python
       - Container
-      - Pipeline
+      - Pipeline:
+          allow_concurrent: false
     ztrigger:
       - pr:
           CRON: ""
@@ -68,13 +70,14 @@
       Cleanup,
       Destroy Slave
     branch: master
+    allow_concurrent: true
     PUSH_TO_MIRROR: "NO"
     NUM_TO_KEEP: 30
 
     # TEMPLATE
     name: 'RPC-Artifact-Build_{series}-{image}-{context}-{ztrigger}'
     project-type: workflow
-    concurrent: false
+    concurrent: {allow_concurrent}
     properties:
       - build-discarder:
           num-to-keep: "{NUM_TO_KEEP}"


### PR DESCRIPTION
Only the Apt and Pipeline jobs need to not
be concurrent. All others can be done in
parallel. This should help speed up feedback
for PR's.

The pipeline jobs should not be concurrently
run because any one job will produce artifacts.