### PR TITLE
UG-619 Run Jenkins API operations internally

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -62,6 +62,16 @@ def install_ansible(){
   install_ansible_roles()
 }
 
+// check if a venv already exists before running create_workspace_venv
+// useful to avoid re-running venv creation and pip package installation
+def create_workspace_venv_if_doesnt_exist(){
+  dir(WORKSPACE){
+    if (!fileExists('.venv')){
+      create_workspace_venv()
+    }
+  }
+}
+
 /* Run ansible-playbooks within a venev
  * Sadly the standard ansibleplaybook step doesn't allow specifying a custom
  * ansible path. It does allow selection of an ansible tool, but those are

--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -28,11 +28,15 @@ def create(Map args){
             ],
             vars: args
           )
-        } // withEnv
-      } // directory
-    } //withCredentials
-  } // withEnv
-} //call
+        }
+        stash (
+          name: "pubcloud_inventory",
+          include: "inventory/hosts"
+        )
+      }
+    }
+  }
+}
 
 
 /* Remove public cloud instances

--- a/playbooks/setup_jenkins_slave.yml
+++ b/playbooks/setup_jenkins_slave.yml
@@ -11,8 +11,8 @@
     allow_jenkins_sudo: "{% set v=lookup('env', 'allow_jenkins_sudo') %}{% if v=='' %}True{% else %}{{v|bool}}{% endif %}"
     jenkins_node_exclusive: "{% set v=lookup('env', 'jenkins_node_exclusive') %}{% if v=='' %}True{% else %}{{v|bool}}{% endif %}"
     # These variables are not booleans so can use the standard default filter
-    jenkins_node_labels: "{% set v=lookup('env', 'JENKINS_NODE_LABELS') %}{% if v=='' %}single_use_slave{% else %}{{v}}{% endif %}"
-    jenkins_node_executors: "{% set v=lookup('env', 'JENKINS_NODE_EXECUTORS') %}{% if v=='' %}2{% else %}{{v}}{% endif %}"
+    jenkins_node_labels: "{{ lookup('env', 'JENKINS_NODE_LABELS')|default('single_use_slave', true) }}"
+    jenkins_node_executors: "{{ lookup('env', 'JENKINS_NODE_EXECUTORS')|default('2', true) }}"
   roles:
     - role: willshersystems.sshd
       sshd:


### PR DESCRIPTION
External slaves do not have access to the Jenkins API, so operations
that require that access must use a node() block that allocates
an internal slave.