### PR TITLE
fixed flavor

### DIFF
--- a/rpc_jobs/irr_role_test.yml
+++ b/rpc_jobs/irr_role_test.yml
@@ -18,7 +18,7 @@
     # NOTE(cloudnull): Context are used to set the OpenStack series used in the gate.
     context:
       - master:
-          irr_flavor: "general2-15"
+          irr_flavor: "performance2-15"
       - ocata
       - newton
       - mitaka


### PR DESCRIPTION
The flavor used in the irr gates was wrong, its now been fixed.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>