### PR TITLE
UG-651 Remove nova_cross_az_attach override

### DIFF
--- a/playbooks/vars/all.yml
+++ b/playbooks/vars/all.yml
@@ -4,9 +4,6 @@ gating_overrides_file: "/etc/openstack_deploy/user_zzz_gating_variables.yml"
 default_gating_overrides:
   maas_notification_plan: npTechnicalContactsEmail
   nova_virt_type: qemu
-  # NOTE(mkam): Setting nova_cross_az_attach to avoid volume test failures caused by:
-  # https://bugs.launchpad.net/nova/+bug/1648324
-  nova_cross_az_attach: True
   maas_auth_method: "token"
   maas_auth_token: "{{lookup('env', 'MAAS_AUTH_TOKEN')}}"
   maas_api_url: "{{lookup('env', 'MAAS_API_URL')}}"


### PR DESCRIPTION
This var is correctly set in rpc-openstack now, there should no longer
be a need to override this in rpc-gating.