### PR TITLE
Clean up all slaves

### DIFF
--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -25,29 +25,53 @@
       - build-discarder:
           days-to-keep: 3
     dsl: |
-      node(){
-        deleteDir()
-        dir("rpc-gating") {
-          stage("Prepare"){
-            git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-            common = load 'pipeline_steps/common.groovy'
+      // Get list of jenkins slaves
+      @NonCPS
+      def getNodes() {
+        return jenkins.model.Jenkins.instance.nodes.grep {
+          node -> node.name =~ /^(long-|master|rpc-jenkins-n)/
+        }.collect {
+          node -> node.name
+        }
+      }
+
+      // run node cleanups on all nodes
+      def nodes = getNodes()
+      def branches = [:]
+      for (int i=0; i<nodes.size(); i++){
+        nodeName = nodes[i]
+        branches['node_'+nodeName] = {
+          node(nodeName){
+            stage("Cleanup "+nodeName){
+              deleteDir()
+              dir("rpc-gating") {
+                git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
+                common = load 'pipeline_steps/common.groovy'
+                sh "scripts/workspace_cleanup.sh"
+                sh "scripts/tmp_cleanup.sh"
+                sh "scripts/docker_cleanup.sh"
+              }
+            }
           }
-          stage("Cleanup Jenkins Workspaces"){
-            sh "scripts/workspace_cleanup.sh"
-          }
-          stage("Cleanup Jenkins TMP Dir"){
-            sh "scripts/tmp_cleanup.sh"
-          }
-          stage("Cleanup Docker Objects"){
-            sh "scripts/docker_cleanup.sh"
-          }
+        }
+      }
+      parallel branches
+
+      // run the pubcloud and jenkins node cleanup only on an internal slave
+      node('CentOS'){
+          deleteDir()
+          dir("rpc-gating") {
+            stage("Prepare"){
+              git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
+              common = load 'pipeline_steps/common.groovy'
+            }
           stage("Docker Build"){
               common.docker_cache_workaround()
               container = docker.build env.BUILD_TAG.toLowerCase()
           }
         }
         container.inside {
-          stage("Checkout"){
+          stage("Docker Checkout"){
             git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
           }
           stage("Public Cloud Cleanup"){


### PR DESCRIPTION
This commit addresses a problem where the Jenkins section of the
periodic cleanup job fails because its running on a slave that doesn't
have access to the Jenkins API.

When fixing this I realised that most of the cleanups are node
specific, so we actually need to run them against every node.
This job introduces a parallel stage to clean up various objects on
all slaves, then a second stage to run public cloud and Jenkins node
cleanups on a single internal slave.

[Example job viewed in blue ocean](https://rpc.jenkins.cit.rackspace.net/blue/organizations/jenkins/Periodic-Cleanup-testing/detail/Periodic-Cleanup-testing/3/pipeline/10):

![screen shot 2017-06-26 at 10 18 13](https://user-images.githubusercontent.com/253506/27532667-ee01e0de-5a58-11e7-838d-04bab6eb7f61.png)
