### PR TITLE
UG-660 Increase consecutive count for slave alerts

### DIFF
--- a/rpc_jobs/long_running_slave.yml
+++ b/rpc_jobs/long_running_slave.yml
@@ -81,7 +81,13 @@
                     maas_use_api: true,
                     maas_entity_name: instance_name,
                     entity_name: instance_name,
-                    maas_excluded_checks_regex: "disk_utilisation.*"
+                    maas_excluded_checks_regex: "disk_utilisation",
+                    // 5 is the maximum allowed consecutive count
+                    maas_alarm_local_consecutive_count: 5,
+                    maas_memory_used_percentage_warning_threshold: 99.0,
+                    maas_memory_used_percentage_critical_threshold: 99.0,
+                    maas_cpu_idle_percent_avg_warning_threshold: 1.0,
+                    maas_cpu_idle_percent_avg_critical_threshold: 1.0
                   ]
                 ) //venvPlaybook
               } //dir


### PR DESCRIPTION
We don't care about small blips in cpu utilisation, but if cpu is
pinned for an extended period (30 minutes) then that may indicate
a stuck job/process which needs investigating.

Issue: [UG-660](https://rpc-openstack.atlassian.net/browse/UG-660)