### PR TITLE
Make the recheck trigger phrase more sensible

### DIFF
--- a/rpc_jobs/irr_role_test.yml
+++ b/rpc_jobs/irr_role_test.yml
@@ -103,7 +103,7 @@
           org-list:
             - rcbops
           github-hooks: true
-          trigger-phrase: '.*recheck_cit_{repo}_all.*|.*recheck_cit_{repo}_{series}_{image}_{context}.*'
+          trigger-phrase: '.*recheck_cit_all.*|.*recheck_cit_{image}_{context}.*'
           only-trigger-phrase: false
           white-list-target-branches:
             - "{branches}"


### PR DESCRIPTION
Currently the trigger phrase and the status
context do not match, making it very hard to
figure out the trigger phrase.

This patch makes them match so that it is
more intuitive.

'repo' is removed from the trigger phrase
as the web hooks will not accept triggers
from any repo other than the originating
one anyway.