### PR TITLE
AR-197 Set flavor for artifact jobs

### DIFF
--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -71,6 +71,7 @@
       Destroy Slave
     branch: master
     allow_concurrent: true
+    artifacts_flavor: "general1-4"
     PUSH_TO_MIRROR: "NO"
     NUM_TO_KEEP: 30
 
@@ -89,7 +90,7 @@
       - rpc_gating_params
       - instance_params:
          IMAGE: "{IMAGE}"
-         FLAVOR: "{FLAVOR}"
+         FLAVOR: "{artifacts_flavor}"
          REGION: "{REGION}"
       - string:
           name: ANSIBLE_PARAMETERS


### PR DESCRIPTION
The artifact build jobs do not need more than
a general1-8 for doing the builds, so set this
to the flavor used in order to free up
additional quota for other jobs.

Issue: [AR-197](https://rpc-openstack.atlassian.net/browse/AR-197)