### PR TITLE
AR-106 Do not pull apt data from rpc-repo

### DIFF
--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -18,6 +18,7 @@
       - Git
       - Apt:
           allow_concurrent: false
+          PULL_FROM_MIRROR: "NO"
       - Python
       - Container
       - Pipeline:
@@ -72,6 +73,7 @@
     branch: master
     allow_concurrent: true
     artifacts_flavor: "general1-4"
+    PULL_FROM_MIRROR: "YES"
     PUSH_TO_MIRROR: "NO"
     NUM_TO_KEEP: 30
 
@@ -98,7 +100,7 @@
           description: "Change the Ansible parameters for the playbook execution."
       - string:
           name: PULL_FROM_MIRROR
-          default: "YES"
+          default: "{PULL_FROM_MIRROR}"
           description: "Set this to NO to skip downloading existing data from rpc-repo. This may cause the loss of existing artifacts on rpc-repo. USE WITH CAUTION!"
       - string:
           name: REPLACE_ARTIFACTS


### PR DESCRIPTION
For the apt artifact creation, rpc-repo is
primarily a publishing point and a place to
store a backup of the database. We should
therefore not be pulling the data from it
every time we run a job, but instead just
execute the job on the long-running node
which has the current database.

Issue: [AR-106](https://rpc-openstack.atlassian.net/browse/AR-106)