### PR TITLE
UG-618 Allow manual specification of job node inventory

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -572,4 +572,31 @@ String get_current_git_sha(String repo_path) {
   return sha
 }
 
+// Create inventory file. Useful for running part of a job against
+// an existing node, where the job expects an inventory file to
+// have been created by the resource allocation step.
+void drop_inventory_file(String content,
+                         String path='rpc-gating/playbooks/inventory/hosts'){
+    dir(env.WORKSPACE){
+      writeFile file: path, text: content
+    }
+}
+
+// Conditional step to drop manually created inventory file
+void override_inventory(){
+  conditionalStep(
+    step_name: "Override Inventory",
+    step:{
+        // This is usually done by the allocate step
+        common.install_ansible()
+        if (env.OVERRIDE_INVENTORY_PATH == null){
+          inventory_path = 'rpc-gating/playbooks/inventory/hosts'
+        } else{
+          inventory_path = env.OVERRIDE_INVENTORY_PATH
+        }
+        drop_inventory_file(env.INVENTORY, inventory_path)
+    }
+  )
+}
+
 return this

--- a/pipeline_steps/webhooks.groovy
+++ b/pipeline_steps/webhooks.groovy
@@ -1,6 +1,7 @@
 def webhooks(){
   instance_name = "WEBHOOK-PROXY"
   pubCloudSlave.getPubCloudSlave(instance_name: instance_name)
+  common.override_inventory()
   try{
     common.conditionalStage(
       stage_name: "Webhooks",

--- a/playbooks/webhooks.yml
+++ b/playbooks/webhooks.yml
@@ -57,6 +57,7 @@
       pip:
         virtualenv: "{{ WHT_VENV_DIR }}"
         name: "{{ WHT_DIR }}"
+        state: forcereinstall
 
     - name: Template webhooktranslator service definition
       template:
@@ -76,6 +77,7 @@
         enabled: yes
         service: webhooktranslator.service
         daemon_reload: yes
+        state: restarted
 
     - name: Load and Enable webhooktranslator systemd socket activator
       systemd:

--- a/rpc_jobs/webhook.yml
+++ b/rpc_jobs/webhook.yml
@@ -25,14 +25,27 @@
           description: |
             Pipeline stages to run CSV. Note that this list does not influence execution order.
             Options:
+              Override Inventory
               Allocate Resources
               Connect Slave
               Webhooks
               Cleanup
               Destroy Slave
+      - text:
+          name: "INVENTORY"
+          description: |
+            Override inventory. This is useful for reconfiguring the current
+            proxy node instead of building a new one. Should be used with the
+            "Override Inventory" stage insated of Allocate Resources and
+            Connect Slave
+          default: |
+            [job_nodes:children]
+            hosts
+            [hosts]
+            node ansible_host=YOUR_IP_HERE
 
     dsl: |
-      node(){
+      node('CentOS'){
           dir("rpc-gating"){
               git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
               common = load 'pipeline_steps/common.groovy'


### PR DESCRIPTION
Useful for re-running parts of a job that usually allocates its own
resources. The first usage is for reconfiguring the long running
webhooks node.

Issue: [UG-618](https://rpc-openstack.atlassian.net/browse/UG-618)