### PR TITLE
UG-646 Skip aio config if handled in repo

### DIFF
--- a/pipeline_steps/aio_prepare.groovy
+++ b/pipeline_steps/aio_prepare.groovy
@@ -6,7 +6,14 @@ def prepare(){
         common.prepareRpcGit(env.UPGRADE_FROM_REF)
       } else {
         common.prepareRpcGit()
-      } // if
+      }
+      // If this branch can prepare its own configs, skip this stage.
+      config_cap_file="${env.WORKSPACE}/rpc-openstack/gating/capabilities/aio_config"
+      if (fileExists(config_cap_file)){
+        print ("Skipping rpc-gating config prep as this is handled in repo."
+               +" Determined by the existence of ${config_cap_file}.")
+        return
+      }
       ansiColor('xterm'){
         dir("/opt/rpc-openstack"){
           withEnv( common.get_deploy_script_env() + [

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -272,6 +272,11 @@
     dsl: |
       // CIT Slave node
       currentBuild.result = 'SUCCESS'
+      // pass JJB axes through to environment
+      env.SCENARIO = "{scenario}"
+      env.TRIGGER = "{ztrigger}"
+      env.TARGET = "aio"
+      env.ACTION = "{action}"
       timeout(time: 8, unit: 'HOURS'){{
         node() {{
           try {{


### PR DESCRIPTION
This commit adds a check for a capabilities file which indicates
that the branch being tested handles its own configuration.
Once all branches contain this functionality, then the rpc-gating
functionality for configuring rpc-o can be completely removed.

This commit also ensures that the JJB axes are passed through to the
job's environment, so that in repo scripts can make configuration
choices based on the scenario being tested.

Issue: [UG-646](https://rpc-openstack.atlassian.net/browse/UG-646)