### PR TITLE
Include creds for maas testing

### DIFF
--- a/pipeline_steps/irr_role_tests.groovy
+++ b/pipeline_steps/irr_role_tests.groovy
@@ -20,9 +20,12 @@ def run_irr_tests() {
                   ]
                 ]
               ]) // checkout
-              sh """#!/bin/bash
-              bash ./run_tests.sh
-              """
+              List maas_vars = maas.get_maas_token_and_url()
+              withEnv(maas_vars) {
+                sh """#!/bin/bash
+                bash ./run_tests.sh
+                """
+              }
             } // dir
           } // ansiColor
         } catch (e) {

--- a/rpc_jobs/irr_role_test.yml
+++ b/rpc_jobs/irr_role_test.yml
@@ -119,6 +119,7 @@
             dir("rpc-gating") {{
               git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
               common = load 'pipeline_steps/common.groovy'
+              maas = load 'pipeline_steps/maas.groovy'
               pubcloud = load 'pipeline_steps/pubcloud.groovy'
               irr_role_tests = load 'pipeline_steps/irr_role_tests.groovy'
             }}


### PR DESCRIPTION
At present the IRR tests do not include API tests becuase the creds used
for maas were passed into the the job. This change allows the job to pass
in environment variables which contain the needed credentials and will
enable us to test additional API interactions from within any IRR test.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [UG-618](https://rpc-openstack.atlassian.net/browse/UG-618)