### PR TITLE
LA-323 Add configurable resource load to leapfrog

### DIFF
--- a/rpc_jobs/defaults.yml
+++ b/rpc_jobs/defaults.yml
@@ -22,3 +22,7 @@
     JENKINS_NODE_EXECUTORS: "2"
     jenkins_node_exclusive: true
     allow_jenkins_sudo: true
+    # generate_test_params
+    GENERATE_TEST_NETWORKS: "0"
+    GENERATE_TEST_SERVERS: "0"
+    GENERATE_TEST_VOLUMES: "0"

--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -152,3 +152,16 @@
       - string:
           name: "RPC_MAAS_BRANCH"
           default: "{RPC_MAAS_BRANCH}"
+
+- parameter:
+    name: generate_test_params
+    parameters:
+      - string:
+          name: "GENERATE_TEST_NETWORKS"
+          default: "{GENERATE_TEST_NETWORKS}"
+      - string:
+          name: "GENERATE_TEST_SERVERS"
+          default: "{GENERATE_TEST_SERVERS}"
+      - string:
+          name: "GENERATE_TEST_VOLUMES"
+          default: "{GENERATE_TEST_VOLUMES}"

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -56,7 +56,11 @@
       # working well, additional stages may be added.
       - leapfrogupgrade:
           ACTION_STAGES: >-
+            Install Tempest,
             Leapfrog Upgrade
+          GENERATE_TEST_NETWORKS: "6"
+          GENERATE_TEST_SERVERS: "4"
+          GENERATE_TEST_VOLUMES: "12"
       # A minimum set of stages is chosen deliberately
       # to test the convergance of the upgrade itself
       # without additional complexity. Once this is
@@ -234,6 +238,10 @@
               Pause (use to hold instance for investigation before cleanup)
               Cleanup
               Destroy Slave
+      - generate_test_params:
+          GENERATE_TEST_NETWORKS: "{GENERATE_TEST_NETWORKS}"
+          GENERATE_TEST_SERVERS: "{GENERATE_TEST_SERVERS}"
+          GENERATE_TEST_VOLUMES: "{GENERATE_TEST_VOLUMES}"
     triggers:
       - timed: "{CRON}"
       - github-pull-request:


### PR DESCRIPTION
The function `upgrade` is modified to enable resources, e.g. compute
instances, to be created prior to a leapfrog upgrade. These resources
will be used elsewhere to monitor the end-user impact of the upgrade.

Three parameters are exposed to control the number of resources that are
created:
- LEAPFROG_TEST_NETWORKS
- LEAPFROG_TEST_SERVERS
- LEAPFROG_TEST_VOLUMES

Depends-on: https://rpc-openstack.atlassian.net/browse/LA-321

Issue: [LA-323](https://rpc-openstack.atlassian.net/browse/LA-323)