### PR TITLE
Simply pass in cloud creds into the IRR job

### DIFF
--- a/pipeline_steps/irr_role_tests.groovy
+++ b/pipeline_steps/irr_role_tests.groovy
@@ -20,8 +20,7 @@ def run_irr_tests() {
                   ]
                 ]
               ]) // checkout
-              List maas_vars = maas.get_maas_token_and_url()
-              withEnv(maas_vars) {
+              withCredentials(common.get_cloud_creds()) {
                 sh """#!/bin/bash
                 bash ./run_tests.sh
                 """

--- a/rpc_jobs/irr_role_test.yml
+++ b/rpc_jobs/irr_role_test.yml
@@ -119,7 +119,6 @@
             dir("rpc-gating") {{
               git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
               common = load 'pipeline_steps/common.groovy'
-              maas = load 'pipeline_steps/maas.groovy'
               pubcloud = load 'pipeline_steps/pubcloud.groovy'
               irr_role_tests = load 'pipeline_steps/irr_role_tests.groovy'
             }}


### PR DESCRIPTION
The IRR jobs may need the basic cloud credentials available to them for
varying reasons. This change ensures the cloud creds are passed in and
allowing the job to do what it needs within the test itself.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [UG-618](https://rpc-openstack.atlassian.net/browse/UG-618)