### PR TITLE
Tidy IRR stages

### DIFF
--- a/pipeline_steps/irr_role_tests.groovy
+++ b/pipeline_steps/irr_role_tests.groovy
@@ -1,62 +1,61 @@
 def run_irr_tests() {
-  common.conditionalStage(
-    stage_name: "Run IRR Tests",
-    stage: {
-      pubcloud.runonpubcloud {
-        currentBuild.result="SUCCESS"
-        try {
-          ansiColor('xterm') {
-            dir("${env.WORKSPACE}/${env.ghprbGhRepository}") {
-              print("Triggered by PR: ${env.ghprbPullLink}")
-              checkout([$class: 'GitSCM',
-                branches: [[name: "origin/pr/${env.ghprbPullId}/merge"]],
-                doGenerateSubmoduleConfigurations: false,
-                extensions: [[$class: 'CleanCheckout']],
-                submoduleCfg: [],
-                userRemoteConfigs: [
-                  [
-                    url: "https://github.com/${env.ghprbGhRepository}.git",
-                    refspec: '+refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*'
-                  ]
+  pubcloud.runonpubcloud {
+    currentBuild.result="SUCCESS"
+    try {
+      ansiColor('xterm') {
+        dir("${env.WORKSPACE}/${env.ghprbGhRepository}") {
+          stage('Checkout'){
+            print("Triggered by PR: ${env.ghprbPullLink}")
+            checkout([$class: 'GitSCM',
+              branches: [[name: "origin/pr/${env.ghprbPullId}/merge"]],
+              doGenerateSubmoduleConfigurations: false,
+              extensions: [[$class: 'CleanCheckout']],
+              submoduleCfg: [],
+              userRemoteConfigs: [
+                [
+                  url: "https://github.com/${env.ghprbGhRepository}.git",
+                  refspec: '+refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*'
                 ]
-              ]) // checkout
-              withCredentials(common.get_cloud_creds()) {
-                sh """#!/bin/bash
-                bash ./run_tests.sh
-                """
-              }
-            } // dir
-          } // ansiColor
-        } catch (e) {
-          print(e)
-          currentBuild.result="FAILURE"
-          throw e
-        } finally {
-          common.safe_jira_comment("${currentBuild.result}: [${env.BUILD_TAG}|${env.BUILD_URL}]")
-          irr_archive_artifacts()
+              ]
+            ])
+          }
+          stage('Execute ./run_tests.sh'){
+            withCredentials(common.get_cloud_creds()) {
+              sh """#!/bin/bash
+              bash ./run_tests.sh
+              """
+            }
+          }
         }
-      } // pubcloud slave
-    } // stage
-  ) // conditionalStage
+      }
+    } catch (e) {
+      print(e)
+      currentBuild.result="FAILURE"
+      throw e
+    } finally {
+      common.safe_jira_comment("${currentBuild.result}: [${env.BUILD_TAG}|${env.BUILD_URL}]")
+      irr_archive_artifacts()
+    }
+  } // pubcloud slave
 }
 
 def irr_archive_artifacts(){
-  print("Running Log Collection")
-  try{
-    sh """#!/bin/bash
-    d="artifacts_\${BUILD_TAG}"
-    mkdir -p "${WORKSPACE}/logs"
-    pushd "${WORKSPACE}/logs"
-      touch "\$d".marker
-    popd
-    tar -C "${WORKSPACE}/logs" -cjf "${env.WORKSPACE}/\$d".tar.bz2 .
-    """
-  } catch (e){
-    print(e)
-    throw(e)
-  } finally{
-    // still worth trying to archiveArtifacts even if some part of
-    // artifact collection failed.
+  stage('Compress and Publish Artefacts'){
+    try{
+      sh """#!/bin/bash
+      d="artifacts_\${BUILD_TAG}"
+      mkdir -p "${WORKSPACE}/logs"
+      pushd "${WORKSPACE}/logs"
+        touch "\$d".marker
+      popd
+      tar -C "${WORKSPACE}/logs" -cjf "${env.WORKSPACE}/\$d".tar.bz2 .
+      """
+    } catch (e){
+      print(e)
+      throw(e)
+    } finally{
+      // still worth trying to archiveArtifacts even if some part of
+      // artifact collection failed.
       pubcloud.uploadToCloudFiles(
         container: "jenkins_logs",
         src: "${env.WORKSPACE}/artifacts_${env.BUILD_TAG}.tar.bz2",
@@ -69,10 +68,11 @@ def irr_archive_artifacts(){
         reportFiles: 'index.html',
         reportName: 'Build Artifact Links'
       )
-    sh """
-    rm -rf "${WORKSPACE}/logs"
-    rm -f artifacts_${env.BUILD_TAG}.tar.bz2
-    """
+      sh """
+      rm -rf "${WORKSPACE}/logs"
+      rm -f artifacts_${env.BUILD_TAG}.tar.bz2
+      """
+    }
   }
 }
 


### PR DESCRIPTION
Currently the IRR jobs use a top level stage, with a few nested stages.
This doesn't display well in either UI, so isn't particularly useful.

This commit adds a run_tests.sh stage, which will allow anyone
viewing a job via blue ocean to skip passed all the Jenkins related
logs and get straight to the test execution output.

Note: Nothing has changed apart from indentation, and additional/removal of stage blocks.