### PR TITLE
[LA-346] Set default influxdb ports to open

### DIFF
--- a/rpc_jobs/influx.yml
+++ b/rpc_jobs/influx.yml
@@ -16,6 +16,11 @@
           IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
           INSTANCE_NAME: "INFLUX"
       - string:
+          name: FIREWALL_OPEN_PORTS
+          default: "8086, 8088, 8083, 8089"
+          description: |
+            Open Ports on the firewall
+      - string:
           name: STAGES
           default: "Allocate Resources, Connect Slave, Influx"
           description: |


### PR DESCRIPTION
InfluxDB host currently doesn't have any influx specific open
ports. This should open the influxdb ports listed in [1].

[1]: https://docs.influxdata.com/influxdb/v1.2/administration/ports/