### PR TITLE
[LA-347] Inventory with log_hosts not generated

### DIFF
--- a/pipeline_steps/influx.groovy
+++ b/pipeline_steps/influx.groovy
@@ -37,7 +37,7 @@ def setup(){
           }
           dir('rpc-maas'){
             git branch: env.RPC_MAAS_BRANCH, url: env.RPC_MAAS_REPO
-            sh """
+            sh """#!/bin/bash
               export INVENTORY="${env.WORKSPACE}/inventory/hosts"
               if ! grep log_hosts $INVENTORY; then
                   echo [log_hosts:children] >> $INVENTORY


### PR DESCRIPTION
Because the shell used by default isn't bash, we can't do the
smart grep and inclusion.

This should fix it.