### PR TITLE
UG-648 Reduce multi-node AIO setup steps

### DIFF
--- a/rpc_jobs/hw_multi_node_aio.yml
+++ b/rpc_jobs/hw_multi_node_aio.yml
@@ -139,7 +139,6 @@
                   "DEPLOY_MAAS=no"
                   ]
               ) // deploy_sh
-              multi_node_aio_prepare.multi_node_aio_networking()
               node(){{
                 maas.prepare(instance_name: instance_name)
                 maas.deploy()

--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -153,7 +153,6 @@
                 "DEPLOY_MAAS=no"
                 ]
             ) // deploy_sh
-            multi_node_aio_prepare.multi_node_aio_networking()
             dir("rpc-gating"){{
               // Checkout rpc-gating repo to avoid race conditions in parallel steps
               git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO


### PR DESCRIPTION
Took out some of the no longer necessary prepare steps so that there is less to port over to rpc-openstack.


- Run networking configuration before deployment

Previously, the prerouting configuration had to occur
after deployments to prevent the rules from
interfering with the setup. This is no longer the case,
so it can run with the multi-node setup.

- Remove deploy node increases

The default memory and vcpu has been increased
in the templates.

Issue: [UG-648](https://rpc-openstack.atlassian.net/browse/UG-648)