### PR TITLE
[LA-347] Escape $ in influx step

### DIFF
--- a/pipeline_steps/influx.groovy
+++ b/pipeline_steps/influx.groovy
@@ -39,9 +39,9 @@ def setup(){
             git branch: env.RPC_MAAS_BRANCH, url: env.RPC_MAAS_REPO
             sh """#!/bin/bash
               export INVENTORY="${env.WORKSPACE}/inventory/hosts"
-              if ! grep log_hosts $INVENTORY; then
-                  echo [log_hosts:children] >> $INVENTORY
-                  echo job_nodes >> $INVENTORY
+              if ! grep log_hosts \$INVENTORY; then
+                  echo [log_hosts:children] >> \$INVENTORY
+                  echo job_nodes >> \$INVENTORY
               fi
             """
             // Run playbooks


### PR DESCRIPTION
$ is parsed in the job, and $INVENTORY is undefined.
That leads to issues like [1] and [2].

[1] /var/lib/jenkins/workspace/Influx-Setup/rpc-maas@tmp/durable-3d035db5/script.sh: line 7: syntax error near unexpected token `;'
[2] /var/lib/jenkins/workspace/Influx-Setup/rpc-maas@tmp/durable-3d035db5/script.sh: line 7: `; then’