### PR TITLE
UG-640 Add Jira Issue to linting

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -468,7 +468,7 @@ def is_doc_update_pr(git_dir) {
       def rc = sh(
         script: """#!/bin/bash
           set -xeu
-          git status 
+          git status
           git show --stat=400,400 | awk '/\\|/{print \$1}' \
             | egrep -v -e '.*md\$' -e '.*rst\$' -e '^releasenotes/'
         """,
@@ -493,23 +493,21 @@ def is_doc_update_pr(git_dir) {
  * builder and so can only be used for PR triggered jobs
  */
 def get_jira_issue_key(repo_path="rpc-openstack"){
-  def key_regex = "^[a-zA-Z][a-zA-Z0-9_]+-[1-9][0-9]*"
+  def key_regex = "[a-zA-Z][a-zA-Z0-9_]+-[1-9][0-9]*"
   dir(repo_path){
-    commit_titles = sh(
+    commits = sh(
       returnStdout: true,
-      script: "git log --pretty=%s origin/${ghprbTargetBranch}..${ghprbSourceBranch}").split('\n')
-    print("looking for Jira issue keys in the following commits: ${commit_titles}")
-    for (def i=0; i<=commit_titles.size(); i++){
-      try{
-        key = (commit_titles[i] =~ key_regex)[0]
-        print ("Found Jira Issue Key: ${key}")
-        return key
-      } catch (e){
-        continue
-      }
+      script: """
+        git log --pretty=%B upstream/${ghprbTargetBranch}..${ghprbSourceBranch}""")
+    print("looking for Jira issue keys in the following commits: ${commits}")
+    try{
+      key = (commits =~ key_regex)[0]
+      print ("First Found Jira Issue Key: ${key}")
+      return key
+    } catch (e){
+      throw new Exception("""
+  No JIRA Issue key were found in commits ${repo_path}:${ghprbSourceBranch}""")
     }
-    throw new Exception("""
-No JIRA Issue key was found in any of the commits introduced by ${repo_path}:${ghprbSourceBranch}""")
   }
 }
 

--- a/pipeline_steps/github.groovy
+++ b/pipeline_steps/github.groovy
@@ -33,7 +33,7 @@ def create_issue(
  * Update the description of the current GitHub pull request with a link to
  * the Jira issue.
  */
-void add_issue_url_to_pr(){
+void add_issue_url_to_pr(upstream="upstream"){
   List org_repo = env.ghprbGhRepository.split("/")
   String org = org_repo[0]
   String repo = org_repo[1]
@@ -42,6 +42,11 @@ void add_issue_url_to_pr(){
 
   dir(repo) {
     git branch: env.ghprbSourceBranch, url: env.ghprbAuthorRepoGitUrl
+    sh """#!/bin/bash
+      set -x
+      git remote add ${upstream} https://github.com/${org}/${repo}.git
+      git remote update
+    """
   }
   String issue_key = common.get_jira_issue_key(repo)
 


### PR DESCRIPTION
Adds lint step to verify Jira Issue included in commit. Required to
verify that commit attached to an existing Jira Issue.

Updates get_jira_issue_key function to only view last commit for
Jira issue key which can be included in either subject or body.

Adds git to Dockerfile which is required for new linter function.

Issue: [UG-640](https://rpc-openstack.atlassian.net/browse/UG-640)

Issue: [LA-320](https://rpc-openstack.atlassian.net/browse/LA-320)