### PR TITLE
LA-347 Fix inventory mangling

### DIFF
--- a/rpc_jobs/influx.yml
+++ b/rpc_jobs/influx.yml
@@ -47,11 +47,12 @@
 
     dsl: |
       node('CentOS'){
-          dir("rpc-gating"){
-              git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-              common = load 'pipeline_steps/common.groovy'
-              pubCloudSlave = load 'pipeline_steps/pubcloud.groovy'
-              influx = load 'pipeline_steps/influx.groovy'
-          }
-          influx.setup()
+        deleteDir()
+        dir("rpc-gating"){
+            git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
+            common = load 'pipeline_steps/common.groovy'
+            pubCloudSlave = load 'pipeline_steps/pubcloud.groovy'
+            influx = load 'pipeline_steps/influx.groovy'
+        }
+        influx.setup()
       } // cit node


### PR DESCRIPTION
The log hosts group is added to the inventory to ensure the influx
plays run correctly. Use of unstash is removed so that override
inventory can be used in future.

Issue: [LA-347](https://rpc-openstack.atlassian.net/browse/LA-347)