### PR TITLE
LA-347 Pass variables to influxdb

### DIFF
--- a/pipeline_steps/influx.groovy
+++ b/pipeline_steps/influx.groovy
@@ -39,7 +39,8 @@ def setup(){
             args: [
               "-i ${env.WORKSPACE}/inventory",
               "--limit job_nodes",
-              "--private-key=\"${env.JENKINS_SSH_PRIVKEY}\""
+              "--private-key=\"${env.JENKINS_SSH_PRIVKEY}\"",
+              "-e @rpc-maas/tests/user_rpcm_secrets.yml"
             ],
             vars: [
               WORKSPACE: "${env.WORKSPACE}",


### PR DESCRIPTION
Influxdb deploy playbook needs variables to properly run.
One necessary variable is "influxdb_db_metric_password", which
is already included in rpc maas repo tests.

Issue: [LA-347](https://rpc-openstack.atlassian.net/browse/LA-347)