### PR TITLE
LA-347 Skip host key checking

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -98,6 +98,7 @@ def venvPlaybook(Map args){
         sh """#!/bin/bash -x
           which scl && source /opt/rh/python27/enable
           . ${env.WORKSPACE}/.venv/bin/activate
+          export ANSIBLE_HOST_KEY_CHECKING=False
           ansible-playbook ${args.args.join(' ')} -e@${vars_file} ${playbook}
         """
       } //for


### PR DESCRIPTION
As gating playbooks are run from shared long running nodes, IPs will
gradually be added to the known hosts file. These IPs will be recycled
by public cloud and cause intermittent host key failures.

Issue: [LA-347](https://rpc-openstack.atlassian.net/browse/LA-347)