### PR TITLE
LA-347 Supply influx creds

### DIFF
--- a/pipeline_steps/influx.groovy
+++ b/pipeline_steps/influx.groovy
@@ -1,5 +1,5 @@
 def setup(){
-  instance_name = "INFLUX"
+  instance_name = common.gen_instance_name("influx")
   pubCloudSlave.getPubCloudSlave(instance_name: instance_name)
   common.override_inventory()
   try{
@@ -14,6 +14,14 @@ def setup(){
           string(
             credentialsId: "SSH_IP_ADDRESS_WHITELIST",
             variable: "SSH_IP_ADDRESS_WHITELIST"
+          ),
+          string(
+            credentialsId: "INFLUX_METRIC_PASSWORD",
+            variable: "INFLUX_METRIC_PASSWORD"
+          ),
+          string(
+            credentialsId: "INFLUX_ROOT_PASSWORD",
+            variable: "INFLUX_ROOT_PASSWORD"
           ),
         ]){
           dir('rpc-gating'){
@@ -42,7 +50,9 @@ def setup(){
               "--private-key=\"${env.JENKINS_SSH_PRIVKEY}\""
             ],
             vars: [
-              WORKSPACE: "${env.WORKSPACE}",
+              WORKSPACE: env.WORKSPACE,
+              influxdb_db_root_password: env.INFLUX_ROOT_PASSWORD,
+              influxdb_db_metric_password: env.INFLUX_METRIC_PASSWORD
             ]
           )
         }

--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -20,6 +20,24 @@
       retries: 120
       delay: 60
 
+    - name: Display rax output on failure
+      debug:
+        var: rax
+      when:
+        - rax.success|length < count
+
+    - name: Fail on duplicate instance
+      fail:
+        msg: |
+          While nova allows multiple instances with the same name,
+          the ansible rax module will not create an instance if one
+          with the requested name already exists. Please create
+          instances with unique names, using the common.gen_instance_name
+          function
+      when:
+        - rax.success|length < count
+        - rax.instances|length == count
+
     - name: Fail if the required number of instances aren't available
       fail:
         msg: "At least one public cloud instance failed to start :("
@@ -32,7 +50,9 @@
           hosts
 
           [hosts]
-          {% for instance in rax.success %} {{instance.name}} ansible_host={{instance.accessIPv4}}{% endfor %}
+          {% for instance in rax.success %}
+          {{instance.name}} ansible_host={{instance.accessIPv4}} ansible_user=root
+          {% endfor %}
         dest: '{{lookup("env", "WORKSPACE")}}/rpc-gating/playbooks/inventory/hosts'
 
     - name: Wait for SSH to be available on all hosts

--- a/rpc_jobs/influx.yml
+++ b/rpc_jobs/influx.yml
@@ -14,7 +14,6 @@
           REGION: IAD
           FLAVOR: "general1-8"
           IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
-          INSTANCE_NAME: "INFLUX"
       - string:
           name: FIREWALL_OPEN_PORTS
           default: "8086, 8088, 8083, 8089"


### PR DESCRIPTION
As the influx db instance will be long running, it needs some
actual creds, rather than using publicly accessible defaults.

Issue: [LA-347](https://rpc-openstack.atlassian.net/browse/LA-347)