### PR TITLE
UG-666 Updates tempest results location

### DIFF
--- a/pipeline_steps/tempest.groovy
+++ b/pipeline_steps/tempest.groovy
@@ -1,9 +1,8 @@
-def tempest_install(vm=null){
+def tempest_install(){
   // NOTE(mkam): Can remove ANSIBLE_CACHE_PLUGIN when we no longer gate stable/mitaka
   // NOTE(alextricity25): --skip-tags needs to be used here because tags cannot be used
   // with included roles in earlier versions of Ansible. Such that used in Mitaka
   common.openstack_ansible(
-    vm: vm,
     playbook: "../../scripts/run_tempest.yml",
     args: "--skip-tags tempest_execute_tests",
     path: "/opt/rpc-openstack/rpcd/playbooks",
@@ -11,15 +10,9 @@ def tempest_install(vm=null){
   )
 }
 
-def tempest_run(wrapper="") {
-  tempest_cmd = "cd /opt/rpc-openstack/rpcd/playbooks && openstack-ansible ../../scripts/run_tempest.yml -t tempest_execute_tests -vv"
-  if (wrapper != "") {
-    tempest_cmd_wrapped = "${wrapper} '${tempest_cmd}'"
-  } else {
-    tempest_cmd_wrapped = tempest_cmd
-  }
+def tempest_run() {
   def output = sh (script: """#!/bin/bash
-  ${tempest_cmd_wrapped}
+  cd /opt/rpc-openstack/rpcd/playbooks && openstack-ansible ../../scripts/run_tempest.yml -t tempest_execute_tests -vv
   """, returnStdout: true)
   print output
   return output
@@ -29,28 +22,21 @@ def tempest_run(wrapper="") {
 /* if tempest install fails, don't bother trying to run or collect test results
  * however if running fails, we should still collect the failed results
  */
-def tempest(deploy_vm=null){
-  if (deploy_vm != null) {
-    wrapper = "sudo ssh -T -oStrictHostKeyChecking=no ${deploy_vm}"
-    copy_cmd = "scp -o StrictHostKeyChecking=no -p  -r \$(${wrapper} \"cd /opt/rpc-openstack/openstack-ansible/playbooks && ansible utility[0] -m command -a 'echo {{ physical_host }}' | grep -Ev 'Variable files|utility'\"):"
-  } else{
-    wrapper = ""
-    copy_cmd = "cp -p "
-  }
+def tempest(){
   common.conditionalStage(
     stage_name: "Install Tempest",
     stage: {
-      tempest_install(deploy_vm)
+      tempest_install()
     }
   )
   common.conditionalStage(
     stage_name: "Tempest Tests",
     stage: {
       try{
-        def result = tempest_run(wrapper)
+        def result = tempest_run()
         def second_result = ""
         if(result.contains("Race in testr accounting.")){
-          second_result = tempest_run(wrapper)
+          second_result = tempest_run()
         }
         if(second_result.contains("Race in testr accounting.")) {
           currentBuild.result = 'FAILURE'
@@ -59,10 +45,18 @@ def tempest(deploy_vm=null){
         print(e)
         throw(e)
       } finally{
-        sh """
-        rm -f *tempest*.xml
-        ${copy_cmd}/openstack/log/*utility*/**/*tempest*.xml . ||:
-        ${copy_cmd}/openstack/log/*utility*/*tempest*.xml . ||:
+        sh """#!/bin/bash -x
+          # Set up variables for copy
+          find_tempest_results_cmd=\"find /var/lib/lxc/*utility*/ -type f -name \"tempest_results.xml\"\"
+          tempest_server=\$(cd /opt/rpc-openstack/openstack-ansible/playbooks && ansible utility[0] -m command -a 'echo {{ physical_host }}' | grep -Ev 'Variable files|utility')
+          copy_cmd=\"scp -o StrictHostKeyChecking=no -p  -r \${tempest_server}:\"
+
+          rm -f *tempest*.xml
+          # Following used for pre-Ocata, will fail post-Newton
+          \${copy_cmd}/openstack/log/*utility*/**/*tempest*.xml . ||:
+          \${copy_cmd}/openstack/log/*utility*/*tempest*.xml . ||:
+          # Following used for Ocata and up, will fail pre-Ocata
+          \${copy_cmd}\$(ssh -o StrictHostKeyChecking=no \${tempest_server} \"\${find_tempest_results_cmd}\") . ||:
         """
         junit allowEmptyResults: true, testResults: '*tempest*.xml'
       } //finally


### PR DESCRIPTION
Master/Ocata places tempests result in a different path than pre-
Ocata. This updates command to attempt to find the location of
the >=Ocata `tempest_results.xml` file if exists and includes that
in path of results files that are attempted to be copied.

Issue: [UG-666](https://rpc-openstack.atlassian.net/browse/UG-666)