### PR TITLE
UG-646 Pass MaaS token+url to bootstrap

### DIFF
--- a/pipeline_steps/aio_prepare.groovy
+++ b/pipeline_steps/aio_prepare.groovy
@@ -9,7 +9,8 @@ def prepare(){
       }
       ansiColor('xterm'){
         dir("/opt/rpc-openstack"){
-          withEnv( common.get_deploy_script_env() + [
+          withEnv( common.get_deploy_script_env()
+                   +  maas.get_maas_token_and_url() + [
             "DEPLOY_AIO=yes",
             "DEPLOY_OA=no",
             "DEPLOY_SWIFT=${env.DEPLOY_SWIFT}",


### PR DESCRIPTION
These used to be added to vars files by rpc-gating, this is now done
within rpc-o, so we need to ensure that the token is passed as an
environment variable.

Issue: [UG-646](https://rpc-openstack.atlassian.net/browse/UG-646)