### PR TITLE
Revert "UG-646 Pass MaaS token+url to bootstrap"

### DIFF
--- a/pipeline_steps/aio_prepare.groovy
+++ b/pipeline_steps/aio_prepare.groovy
@@ -9,8 +9,7 @@ def prepare(){
       }
       ansiColor('xterm'){
         dir("/opt/rpc-openstack"){
-          withEnv( common.get_deploy_script_env()
-                   +  maas.get_maas_token_and_url() + [
+          withEnv( common.get_deploy_script_env() + [
             "DEPLOY_AIO=yes",
             "DEPLOY_OA=no",
             "DEPLOY_SWIFT=${env.DEPLOY_SWIFT}",


### PR DESCRIPTION
Reverts rcbops/rpc-gating#296

This doesn't work as it tried to read from rpc-gating on the wrong node. Reverting and will try another approach. 

Issue: [UG-646](https://rpc-openstack.atlassian.net/browse/UG-646)