### PR TITLE
UG-646 Supply MaaS env vars to RPC scripts

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -397,26 +397,21 @@ api_key = ${args.api_key}
 }
 
 def prepareConfigs(Map args){
-  withCredentials(get_cloud_creds()){
-      dir("rpc-gating"){
-        git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-      } //dir
-      dir("rpc-gating/playbooks"){
-        common.install_ansible()
-        withCredentials(common.get_cloud_creds()) {
-          List maas_vars = maas.get_maas_token_and_url()
-          withEnv(maas_vars) {
-            common.venvPlaybook(
-              playbooks: ["aio_config.yml"],
-              args: [
-                "-i inventory",
-                "--extra-vars \"@vars/${args.deployment_type}.yml\""
-              ]
-            )
-          }
-        }
-      } //dir
-  } //withCredentials
+  dir("rpc-gating"){
+    git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
+  }
+  dir("rpc-gating/playbooks"){
+    common.install_ansible()
+    withCredentials(common.get_cloud_creds()) {
+      common.venvPlaybook(
+        playbooks: ["aio_config.yml"],
+        args: [
+          "-i inventory",
+          "--extra-vars \"@vars/${args.deployment_type}.yml\""
+        ]
+      )
+    }
+  }
 }
 
 def prepareRpcGit(branch = "auto", dest = "/opt"){

--- a/pipeline_steps/maas.groovy
+++ b/pipeline_steps/maas.groovy
@@ -50,6 +50,17 @@ def verify(vm=null) {
   ) //conditionalStage
 }
 
+// Add MaaS vars as properties of the env object
+// This is similar to withEnv but doesn't require
+// another level of nesting.
+void add_maas_env_vars(){
+  List vars = get_maas_token_and_url()
+  for (def i=0; i<vars.size(); i++){
+    kv = vars[i].split('=')
+    env[var[0]] = kv[1]
+  }
+}
+
 List get_maas_token_and_url() {
   return maas_utils(['get_token_url']).trim().tokenize(" ")
 }

--- a/rpc_jobs/hw_multi_node_aio.yml
+++ b/rpc_jobs/hw_multi_node_aio.yml
@@ -120,6 +120,9 @@
             }}
             ssh_slave.connect()
             deploy_node = null
+            // Adds maas token and url to environment
+            // without adding another level of nesting
+            maas.add_maas_env_vars()
             node(env.INSTANCE_NAME) {{
               common.conditionalStage(
                 stage_name: 'Prepare HW AIO',

--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -143,6 +143,9 @@
           deploy_node = null
           pubCloudSlave.getPubCloudSlave(instance_name: instance_name)
 
+          // Adds maas token and url to environment
+          // without adding another level of nesting
+          maas.add_maas_env_vars()
           node(instance_name){{
             multi_node_aio_prepare.prepare()
             instance_ip = sh(script: "ip route get 1 | awk '{{print \$NF;exit}}'", returnStdout: true)

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -300,6 +300,9 @@
             if(common.is_doc_update_pr("${{env.WORKSPACE}}/rpc-openstack")){{
               return
             }}
+            // Adds maas token and url to environment
+            // without adding another level of nesting
+            maas.add_maas_env_vars()
             pubcloud.runonpubcloud {{
               // try within pubcloud node so we can archive archive_artifacts
               // after a failure, before the node is cleaned up.


### PR DESCRIPTION
Previously these vars were added to overrides via the rpc-gating
aio_config playbook. This configuration is now done in rpc-o, so we
need to ensure the token and url variables are available in the
environment for the rpc-o scripts to use.

This is the second attempt, first attempt:
  * introduction: https://github.com/rcbops/rpc-gating/pull/296
  * revert: https://github.com/rcbops/rpc-gating/pull/297

The first attempt failed because it attempted to run a script from
rpc-gating on a single use slave that didn't have a checkout of
rpc-gating. This version ensures that the the script is run on a
long-running slave that will have the appropriate checkout.

Issue: [UG-646](https://rpc-openstack.atlassian.net/browse/UG-646)