### PR TITLE
Revert "UG-646 Supply MaaS env vars to RPC scripts"

### DIFF
--- a/pipeline_steps/maas.groovy
+++ b/pipeline_steps/maas.groovy
@@ -50,17 +50,6 @@ def verify(vm=null) {
   ) //conditionalStage
 }
 
-// Add MaaS vars as properties of the env object
-// This is similar to withEnv but doesn't require
-// another level of nesting.
-void add_maas_env_vars(){
-  List vars = get_maas_token_and_url()
-  for (def i=0; i<vars.size(); i++){
-    kv = vars[i].split('=')
-    env[var[0]] = kv[1]
-  }
-}
-
 List get_maas_token_and_url() {
   return maas_utils(['get_token_url']).trim().tokenize(" ")
 }

--- a/rpc_jobs/hw_multi_node_aio.yml
+++ b/rpc_jobs/hw_multi_node_aio.yml
@@ -120,9 +120,6 @@
             }}
             ssh_slave.connect()
             deploy_node = null
-            // Adds maas token and url to environment
-            // without adding another level of nesting
-            maas.add_maas_env_vars()
             node(env.INSTANCE_NAME) {{
               common.conditionalStage(
                 stage_name: 'Prepare HW AIO',

--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -143,9 +143,6 @@
           deploy_node = null
           pubCloudSlave.getPubCloudSlave(instance_name: instance_name)
 
-          // Adds maas token and url to environment
-          // without adding another level of nesting
-          maas.add_maas_env_vars()
           node(instance_name){{
             multi_node_aio_prepare.prepare()
             instance_ip = sh(script: "ip route get 1 | awk '{{print \$NF;exit}}'", returnStdout: true)

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -300,9 +300,6 @@
             if(common.is_doc_update_pr("${{env.WORKSPACE}}/rpc-openstack")){{
               return
             }}
-            // Adds maas token and url to environment
-            // without adding another level of nesting
-            maas.add_maas_env_vars()
             pubcloud.runonpubcloud {{
               // try within pubcloud node so we can archive archive_artifacts
               // after a failure, before the node is cleaned up.


### PR DESCRIPTION
Reverts rcbops/rpc-gating#298

Fails because install_ansible hasn't been called so deps aren't available. 

Issue: [UG-646](https://rpc-openstack.atlassian.net/browse/UG-646)