### PR TITLE
RE-46 Remove ceph scenario from newton

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -154,14 +154,23 @@
       # kilo builds is for the leapfrog upgrade tests.
       - series: kilo
         scenario: ceph
+      # Ceph cluster builds are not supported for
+      # newton. In the future ceph will be a supported
+      # scenario for newton onwards, but it will only
+      # consume the cluster, not deploy it. At that
+      # time the scenario can be added back again.
+      - series: newton140
+        scenario: ceph
+      - series: newton141
+        scenario: ceph
       # Ceph builds are not tested for leapfrog upgrades
       # at this time due to the failure for ceph to
       # install on kilo.
       - action: leapfrogupgrade
         scenario: ceph
       # Ceph builds are not run for Xenial at this time
-      # as ceph deployment is not supported for
-      # newton (yet).
+      # as ceph cluster deployment is not supported for
+      # Xenial using RPC-O.
       - image: xenial
         scenario: ceph
       # Trusty builds are not executed for master


### PR DESCRIPTION
From a product standpoint, deploying a ceph
cluster using RPC-O is not a supported
configuration. It is therefore a pointless
waste of time and resources to test this
configuration.

Issue: [RE-46](https://rpc-openstack.atlassian.net/browse/RE-46)