### PR TITLE
RE-46 Remove ceph scenario from minorupgrade

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -168,6 +168,12 @@
       # install on kilo.
       - action: leapfrogupgrade
         scenario: ceph
+      # Ceph builds are not tested for minor upgrades
+      # at this time due to the minor upgrades only being
+      # targeted at newton or above, which do not support
+      # the ceph scenario.
+      - action: minorupgrade
+        scenario: ceph
       # Ceph builds are not run for Xenial at this time
       # as ceph cluster deployment is not supported for
       # Xenial using RPC-O.


### PR DESCRIPTION
From a product standpoint, deploying a ceph
cluster using RPC-O in newton and above is
not a supported configuration. It is therefore
a pointless waste of time and resources to
test this configuration for minor upgrades
for newton and above.

Issue: [RE-46](https://rpc-openstack.atlassian.net/browse/RE-46)