### PR TITLE
Increase gate timeout for IRR

### DIFF
--- a/rpc_jobs/irr_role_test.yml
+++ b/rpc_jobs/irr_role_test.yml
@@ -113,7 +113,7 @@
 
     dsl: |
       // CIT Slave node
-      timeout(time: 2, unit: 'HOURS'){{
+      timeout(time: 3, unit: 'HOURS'){{
         node() {{
           try {{
             dir("rpc-gating") {{


### PR DESCRIPTION
Due to job taking longer to provision resources and the fact that the
IRR jobs are testing more things now, specifically the maas repo, it's
likley that we'll need more time for the tests. This change increases
the job timeout to 3 hours from 2.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [LA-345](https://rpc-openstack.atlassian.net/browse/LA-345)