### PR TITLE
Install Grafana

### DIFF
--- a/pipeline_steps/influx.groovy
+++ b/pipeline_steps/influx.groovy
@@ -43,6 +43,7 @@ def setup(){
             playbooks: [
               "rpc-gating/playbooks/slave_security.yml",
               "rpc-maas/playbooks/maas-tigkstack-influxdb.yml",
+              "rpc-maas/playbooks/maas-tigkstack-grafana.yml",
             ],
             args: [
               "-i ${env.WORKSPACE}/inventory",


### PR DESCRIPTION
When Grafana will support SQlite, we will be able to deploy
the dashboards using this PR.

Issue: https://rpc-openstack.atlassian.net/browse/LA-332

Issue: [LA-332](https://rpc-openstack.atlassian.net/browse/LA-332)