### PR TITLE
LA-356 Allow SSH Whitelist to be disabled

### DIFF
--- a/pipeline_steps/influx.groovy
+++ b/pipeline_steps/influx.groovy
@@ -6,14 +6,10 @@ def setup(){
     common.conditionalStage(
       stage_name: "Influx",
       stage:{
-        withCredentials([
+        creds = [
           file(
             credentialsId: 'id_rsa_cloud10_jenkins_file',
             variable: 'jenkins_ssh_privkey'
-          ),
-          string(
-            credentialsId: "SSH_IP_ADDRESS_WHITELIST",
-            variable: "SSH_IP_ADDRESS_WHITELIST"
           ),
           string(
             credentialsId: "INFLUX_METRIC_PASSWORD",
@@ -27,7 +23,14 @@ def setup(){
             credentialsId: "GRAFANA_ADMIN_PASSWORD",
             variable: "GRAFANA_ADMIN_PASSWORD"
           ),
-        ]){
+        ]
+        if (env.USE_SSH_WHITELIST == "true"){
+          creds += string(
+            credentialsId: "SSH_IP_ADDRESS_WHITELIST",
+            variable: "SSH_IP_ADDRESS_WHITELIST"
+          )
+        }
+        withCredentials([creds]){
           dir('rpc-gating'){
             git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
           }

--- a/rpc_jobs/influx.yml
+++ b/rpc_jobs/influx.yml
@@ -43,6 +43,12 @@
             hosts
             [log_hosts]
             node ansible_host=YOUR_IP_HERE
+      - bool:
+          name: "USE_SSH_WHITELIST"
+          description: |
+            Enable src restriction on SSH connections. Disabling allows
+            connections from anywhere. When enabled SSH connections will
+            only be allowed from RAX bastions and internal Jenkins nodes.
 
     dsl: |
       node('CentOS'){


### PR DESCRIPTION
This allows SSH logins from anywhere, which will be useful for debugging
during the early stages of influxdb setup.

Issue: [LA-356](https://rpc-openstack.atlassian.net/browse/LA-356)