### PR TITLE
Delete kilo leapfrog periodic

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -148,6 +148,12 @@
         action: leapfrogupgrade
       - series: master
         action: leapfrogupgrade
+      # This combo tests the same thing as
+      # RPC-AIO_newton141-trusty-leapfrogupgrade-swift-periodic and is not
+      # needed
+      - series: kilo
+        action: leapfrogupgrade
+        trigger: periodic
       # Leapfrog upgrades cannot be executed on
       # xenial as it is not possible to install
       # the source series (kilo-mitaka) on xenial.


### PR DESCRIPTION
The RPC-AIO_kilo-trusty-leapfrogupgrade-swift-periodic job is failing
constantly because we're not setting UPGRADE_FROM_REF appropriately for
this job.  This commit deletes this job since this job is effectively
testing the same thing as
RPC-AIO_newton141-trusty-leapfrogupgrade-swift-periodic.