### PR TITLE
LA-356 Rename target nodes for influx

### DIFF
--- a/pipeline_steps/influx.groovy
+++ b/pipeline_steps/influx.groovy
@@ -40,8 +40,8 @@ def setup(){
               export INVENTORY="${env.WORKSPACE}/inventory/hosts"
               mkdir -p \$(dirname \$INVENTORY)
               cp ${env.WORKSPACE}/rpc-gating/playbooks/inventory/hosts \$INVENTORY
-              if ! grep log_hosts \$INVENTORY; then
-                  echo [log_hosts:children] >> \$INVENTORY
+              if ! grep influx_hosts \$INVENTORY; then
+                  echo [influx_hosts:children] >> \$INVENTORY
                   echo job_nodes >> \$INVENTORY
               fi
             """


### PR DESCRIPTION
Target nodes should now be named influx_hosts, due to the latest
changes in rpc-maas.

Issue: [LA-356](https://rpc-openstack.atlassian.net/browse/LA-356)