### PR TITLE
Run on any available node

### DIFF
--- a/rpc_jobs/influx.yml
+++ b/rpc_jobs/influx.yml
@@ -51,7 +51,7 @@
             only be allowed from RAX bastions and internal Jenkins nodes.
 
     dsl: |
-      node('CentOS'){
+      node(){
         deleteDir()
         dir("rpc-gating"){
             git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO


### PR DESCRIPTION
This way we avoid issues with an old pip version.
It should be alright if no blacklist/whitelist.

Issue: [LA-356](https://rpc-openstack.atlassian.net/browse/LA-356)