### PR TITLE
UG-634 Enable DEPLOY_SUPPORT_ROLE on multi-node builds

### DIFF
--- a/rpc_jobs/hw_multi_node_aio.yml
+++ b/rpc_jobs/hw_multi_node_aio.yml
@@ -142,7 +142,8 @@
                   "DEPLOY_ELK=yes",
                   "DEPLOY_TEMPEST=no",
                   "DEPLOY_AIO=no",
-                  "DEPLOY_MAAS=no"
+                  "DEPLOY_MAAS=no",
+                  "DEPLOY_SUPPORT_ROLE=yes"
                   ]
               ) // deploy_sh
               maas.prepare(instance_name: instance_name)

--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -158,7 +158,8 @@
                 "DEPLOY_ELK=yes",
                 "DEPLOY_TEMPEST=no",
                 "DEPLOY_AIO=no",
-                "DEPLOY_MAAS=no"
+                "DEPLOY_MAAS=no",
+                "DEPLOY_SUPPORT_ROLE=yes"
                 ]
             ) // deploy_sh
             dir("rpc-gating"){{


### PR DESCRIPTION
Some mnaio builds are failing because we're attempting to test holland,
but we're not deploying the rpc support role.  This commit flips on
DEPLOY_SUPPORT_ROLE so that holland is deployed for testing.