### PR TITLE
LA-366 Re-introduce leapfrog PR.

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -151,9 +151,9 @@
       # This combo tests the same thing as
       # RPC-AIO_newton141-trusty-leapfrogupgrade-swift-periodic and is not
       # needed
-      - series: kilo
-        action: leapfrogupgrade
-        trigger: periodic
+      #- series: kilo
+      #  action: leapfrogupgrade
+      #  trigger: periodic
       # Leapfrog upgrades cannot be executed on
       # xenial as it is not possible to install
       # the source series (kilo-mitaka) on xenial.


### PR DESCRIPTION
We previously removed the PR leapfrog jobs by using a triple
axis exclude, which doesn't seem to work.

Issue: LA-366 

Issue: [LA-366](https://rpc-openstack.atlassian.net/browse/LA-366)