### PR TITLE
La-366 Ensure kibana branches make sense

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -322,6 +322,8 @@
                 && env.TRIGGER == "pr"
                 && env.ACTION == "leapfrogupgrade" ){{
                 env.UPGRADE_FROM_REF="origin/pr/${{env.ghprbPullId}}/merge"
+                kibana_branch = "kilo"
+                env.KIBANA_SELENIUM_BRANCH="newton-14.1"
             }}
             // We need to checkout the rpc-openstack repo on the CIT Slave
             // so that we can check whether the patch is a docs-only patch


### PR DESCRIPTION
Most of the upgrade jobs use the target branch as the trigger branch,
for exmaple changes to newton-14.1 have an upgrade test from kilo
to ensure the changes don't break upgrades.

However the kilo leapfrog job tests changes to kilo with a leapfrog
to newton-14.1 This alternate dirction upgrade requires some variable
changes to succeed.

In this commit the kibana branch variables are set to sensible
values for the kilo-newton leap job, as the defaults do not work.
Mostly because UPGRADE_FROM_REF is not set for kilo.

Issue: [La-366](https://rpc-openstack.atlassian.net/browse/La-366)