### PR TITLE
RE-51 Remove extraneous deleteDir

### DIFF
--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -173,7 +173,6 @@
             }} // stage
           ) // conditionalStage
           // continuing on CIT slave
-          deleteDir()
           artifact_build.git()
           artifact_build.python()
           artifact_build.container()


### PR DESCRIPTION
The extraneous deleteDir was a mistake
left behind in the previous commit, and
it causes the git checkout to be deleted
when it's still required.

Issue: [RE-51](https://rpc-openstack.atlassian.net/browse/RE-51)