### PR TITLE
RE-51 Force known pkg version in workspace venv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,10 +7,7 @@ jenkins-job-builder
 jenkinsapi
 jira
 packaging
-pip
 pyrax
 python-dateutil
 rackspace_monitoring
-setuptools
 six
-wheel


### PR DESCRIPTION
When we setup the venv, we set it up without
the host's versions of pip, setuptools and wheel
(if possible) so that we can independently set
the version we want.

In order to ensure that we do not try to upgrade
or downgrade pip/setuptools/wheel in an existing
venv, we remove it from the requirements.

We only force a re-installation of pip, setuptools
and wheel into the venv if the pip version is not
available or incorrect.

This patch does a revert of some of the changes
in 73ad014

Issue: [RE-51](https://rpc-openstack.atlassian.net/browse/RE-51)