### PR TITLE
RE-49 Ensure the required version of virtualenv

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -9,9 +9,9 @@ def void create_workspace_venv(){
 
     # Create venv
     if [[ ! -d ".venv" ]]; then
-      if ! which virtualenv; then
-        pip install virtualenv
-      fi
+      requirements="virtualenv==15.1.0"
+      pip install -U "${requirements}" \
+        || pip install --isolated -U "${requirements}"
       if which scl
       then
         # redhat/centos


### PR DESCRIPTION
If virtualenv is old, it will create a venv containing an old
version of pip, which may not have the isolated flag, which we make
use of.

Issue: [RE-49](https://rpc-openstack.atlassian.net/browse/RE-49)