### PR TITLE
RE-49 Fix dollar escapes in create_workspace_venv

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -10,8 +10,8 @@ def void create_workspace_venv(){
     # Create venv
     if [[ ! -d ".venv" ]]; then
       requirements="virtualenv==15.1.0"
-      pip install -U "${requirements}" \
-        || pip install --isolated -U "${requirements}"
+      pip install -U "\${requirements}" \
+        || pip install --isolated -U "\${requirements}"
       if which scl
       then
         # redhat/centos


### PR DESCRIPTION
Requirements is  bash variable so should be escaped to avoid being interpolated by groovy.

Issue: [RE-49](https://rpc-openstack.atlassian.net/browse/RE-49)