### PR TITLE
UG-646 Common node allocation

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -70,5 +70,6 @@ stevedore==1.19.1
 tox==2.7.0
 uritemplate.py==3.0.2
 uritemplate==3.0.0
+urllib3==1.18.1
 wheel==0.29.0
 wrapt==1.10.10

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -382,27 +382,21 @@ api_key = ${args.api_key}
 }
 
 def prepareConfigs(Map args){
-  withCredentials(get_cloud_creds()){
-      dir("rpc-gating"){
-        git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-        maas = load 'pipeline_steps/maas.groovy'
-      } //dir
-      dir("rpc-gating/playbooks"){
-        common.install_ansible()
-        withCredentials(common.get_cloud_creds()) {
-          List maas_vars = maas.get_maas_token_and_url()
-          withEnv(maas_vars) {
-            common.venvPlaybook(
-              playbooks: ["aio_config.yml"],
-              args: [
-                "-i inventory",
-                "--extra-vars \"@vars/${args.deployment_type}.yml\""
-              ]
-            )
-          }
-        }
-      } //dir
-  } //withCredentials
+  dir("rpc-gating"){
+    git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
+  }
+  dir("rpc-gating/playbooks"){
+    common.install_ansible()
+    withCredentials(common.get_cloud_creds()) {
+      common.venvPlaybook(
+        playbooks: ["aio_config.yml"],
+        args: [
+          "-i inventory",
+          "--extra-vars \"@vars/${args.deployment_type}.yml\""
+        ]
+      )
+    }
+  }
 }
 
 def prepareRpcGit(branch = "auto", dest = "/opt"){

--- a/pipeline_steps/holland.groovy
+++ b/pipeline_steps/holland.groovy
@@ -2,11 +2,6 @@ def holland(){
   common.conditionalStage(
     stage_name: "Holland",
     stage: {
-      //TODO: move test_holland into RPC to avoid this mess.
-      dir("rpc-gating"){
-        // only needed to pull the test_holland from the repo.
-        git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-      }
       / * recent versions of openstack-ansible allow execution of playbooks
         * from any directory, but that doesn't work all the way back to liberty
         */

--- a/pipeline_steps/influx.groovy
+++ b/pipeline_steps/influx.groovy
@@ -1,6 +1,6 @@
 def setup(){
   instance_name = common.gen_instance_name("influx")
-  pubCloudSlave.getPubCloudSlave(instance_name: instance_name)
+  pubcloud.getPubCloudSlave(instance_name: instance_name)
   common.override_inventory()
   try{
     common.conditionalStage(
@@ -31,9 +31,6 @@ def setup(){
           )
         }
         withCredentials(creds){
-          dir('rpc-gating'){
-            git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-          }
           dir('rpc-maas'){
             git branch: env.RPC_MAAS_BRANCH, url: env.RPC_MAAS_REPO
             sh """#!/bin/bash
@@ -70,7 +67,7 @@ def setup(){
     print(e)
     throw e
   }finally{
-    pubCloudSlave.delPubCloudSlave()
+    pubcloud.delPubCloudSlave()
   }
 } //func
 return this

--- a/pipeline_steps/maas.groovy
+++ b/pipeline_steps/maas.groovy
@@ -48,6 +48,17 @@ def verify() {
   ) //conditionalStage
 }
 
+// Add MaaS vars as properties of the env object
+// This is similar to withEnv but doesn't require
+// another level of nesting.
+void add_maas_env_vars(){
+  List vars = get_maas_token_and_url()
+  for (def i=0; i<vars.size(); i++){
+    kv = vars[i].split('=')
+    env[kv[0]] = kv[1]
+  }
+}
+
 List get_maas_token_and_url() {
   return maas_utils(['get_token_url']).trim().tokenize(" ")
 }

--- a/pipeline_steps/maas.groovy
+++ b/pipeline_steps/maas.groovy
@@ -8,7 +8,6 @@ def prepare(Map args) {
             username: env.PUBCLOUD_USERNAME,
             api_key: env.PUBCLOUD_API_KEY
           )
-          common.install_ansible()
           withEnv(["RAX_CREDS_FILE=${pyrax_cfg}"]){
             common.venvPlaybook(
               playbooks: ['multi_node_aio_maas_entities.yml'],
@@ -82,7 +81,6 @@ def entity_cleanup(Map args){
     step: {
       withCredentials(common.get_cloud_creds()) {
         dir("rpc-gating/playbooks") {
-          common.install_ansible()
           pyrax_cfg = common.writePyraxCfg(
             username: env.PUBCLOUD_USERNAME,
             api_key: env.PUBCLOUD_API_KEY

--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -13,7 +13,6 @@ def create(Map args){
   withEnv(["RAX_REGION=${args.region}"]){
     withCredentials(common.get_cloud_creds()){
       dir("rpc-gating/playbooks"){
-        common.install_ansible()
         pyrax_cfg = common.writePyraxCfg(
           username: env.PUBCLOUD_USERNAME,
           api_key: env.PUBCLOUD_API_KEY
@@ -45,7 +44,6 @@ def cleanup(Map args){
   withEnv(['ANSIBLE_FORCE_COLOR=true']){
     withCredentials(common.get_cloud_creds()){
       dir("rpc-gating/playbooks"){
-        common.install_ansible()
         pyrax_cfg = common.writePyraxCfg(
           username: env.PUBCLOUD_USERNAME,
           api_key: env.PUBCLOUD_API_KEY
@@ -70,7 +68,6 @@ def cleanup(Map args){
 
 
 def getPubCloudSlave(Map args){
-  ssh_slave = load 'rpc-gating/pipeline_steps/ssh_slave.groovy'
   common.conditionalStage(
     stage_name: 'Allocate Resources',
     stage: {
@@ -87,7 +84,6 @@ def getPubCloudSlave(Map args){
   ssh_slave.connect()
 }
 def delPubCloudSlave(Map args){
-  ssh_slave = load 'rpc-gating/pipeline_steps/ssh_slave.groovy'
   common.conditionalStep(
     step_name: "Pause",
     step: {
@@ -112,7 +108,7 @@ def runonpubcloud(body){
   instance_name = common.gen_instance_name()
   try{
     getPubCloudSlave(instance_name: instance_name)
-    node(instance_name){
+    common.use_node(instance_name){
       body()
     }
   }catch (e){
@@ -125,11 +121,7 @@ def runonpubcloud(body){
 
 def uploadToCloudFiles(Map args){
   withCredentials(common.get_cloud_creds()) {
-    dir("rpc-gating"){
-      git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-    }
     dir("rpc-gating/playbooks") {
-      common.install_ansible()
       pyrax_cfg = common.writePyraxCfg(
         username: env.PUBCLOUD_USERNAME,
         api_key: env.PUBCLOUD_API_KEY

--- a/pipeline_steps/ssh_slave.groovy
+++ b/pipeline_steps/ssh_slave.groovy
@@ -20,12 +20,7 @@ def connect(port=22){
   common.conditionalStage(
     stage_name: "Connect Slave",
     stage: {
-      node('CentOS'){
-        deleteDir()
-        dir('rpc-gating'){
-          git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-        }
-        common.create_workspace_venv()
+      common.internal_slave(){
         withCredentials([
           file(
             credentialsId: 'id_rsa_cloud10_jenkins_file',
@@ -61,12 +56,7 @@ def destroy(slave_name){
   common.conditionalStep(
     step_name: 'Destroy Slave',
     step: {
-      node('CentOS'){
-        deleteDir()
-        dir('rpc-gating'){
-          git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-        }
-        common.create_workspace_venv()
+      common.internal_slave(){
         withCredentials([
           usernamePassword(
             credentialsId: "service_account_jenkins_api_creds",

--- a/pipeline_steps/webhooks.groovy
+++ b/pipeline_steps/webhooks.groovy
@@ -1,6 +1,6 @@
 def webhooks(){
   instance_name = "WEBHOOK-PROXY"
-  pubCloudSlave.getPubCloudSlave(instance_name: instance_name)
+  pubcloud.getPubCloudSlave(instance_name: instance_name)
   common.override_inventory()
   try{
     common.conditionalStage(
@@ -49,7 +49,7 @@ def webhooks(){
           } //dir
         } //withCredentials
         ip = readFile file: "instance_address"
-        node("master"){
+       common.use_node("master"){
           withCredentials([
             file(
               credentialsId: 'id_rsa_cloud10_jenkins_file',
@@ -90,7 +90,7 @@ EOF
     print(e)
     throw e
   }finally{
-    pubCloudSlave.delPubCloudSlave()
+    pubcloud.delPubCloudSlave()
   }
 } //func
 return this

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pyrax
 python-dateutil
 rackspace_monitoring
 six
+urllib3

--- a/rpc_jobs/hardening.yml
+++ b/rpc_jobs/hardening.yml
@@ -68,20 +68,9 @@
               Destroy Slave
 
     dsl: |
-      node(){{
+      common.shared_slave(){{
         try {{
-          dir("rpc-gating"){{
-            git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-            pubCloudSlave = load 'pipeline_steps/pubcloud.groovy'
-            ssh_slave = load 'pipeline_steps/ssh_slave.groovy'
-            common = load 'pipeline_steps/common.groovy'
-            multi_node_aio_prepare = load 'pipeline_steps/multi_node_aio_prepare.groovy'
-            deploy = load 'pipeline_steps/deploy.groovy'
-            tempest = load 'pipeline_steps/tempest.groovy'
-            maas = load 'pipeline_steps/maas.groovy'
-          }} // dir
-
-          node("CentOS") {{
+          common.internal_slave(){{
             withCredentials([
               string(
                 credentialsId: 'hardening_repo_url',
@@ -97,9 +86,9 @@
 
           instance_name = common.gen_instance_name()
           deploy_node = null
-          pubCloudSlave.getPubCloudSlave(instance_name: instance_name)
+          pubcloud.getPubCloudSlave(instance_name: instance_name)
 
-          node(instance_name){{
+          common.use_node(instance_name){{
             multi_node_aio_prepare.prepare()
             instance_ip = sh(script: "ip route get 1 | awk '{{print \$NF;exit}}'", returnStdout: true)
           }} // public cloud node
@@ -107,7 +96,7 @@
           deploy_node = "${{instance_name}}-deploy-vm"
           multi_node_aio_prepare.connect_deploy_node(deploy_node, instance_ip)
 
-          node(deploy_node){{
+          common.use_node(deploy_node){{
             deploy.deploy_sh(
               environment_vars: [
                 "DEPLOY_HAPROXY=yes",
@@ -132,10 +121,9 @@
             currentBuild.result = 'FAILURE'
             throw e
         }} finally {{
-            pubCloudSlave.delPubCloudSlave(instance_name: instance_name)
+            pubcloud.delPubCloudSlave(instance_name: instance_name)
             if(deploy_node != null){{
               ssh_slave.destroy(deploy_node)
             }}
-            common.delete_workspace()
         }}
       }} // cit node

--- a/rpc_jobs/hw_multi_node_aio.yml
+++ b/rpc_jobs/hw_multi_node_aio.yml
@@ -120,6 +120,9 @@
             }}
             ssh_slave.connect()
             deploy_node = null
+            // Adds maas token and url to environment
+            // without adding another level of nesting
+            maas.add_maas_env_vars()
             node(env.INSTANCE_NAME) {{
               common.conditionalStage(
                 stage_name: 'Prepare HW AIO',

--- a/rpc_jobs/hw_multi_node_aio.yml
+++ b/rpc_jobs/hw_multi_node_aio.yml
@@ -101,29 +101,17 @@
     dsl: |
       // CIT Slave node
       timeout(time: 8, unit: 'HOURS'){{
-        node() {{
+        common.shared_slave() {{
           try {{
-            dir("rpc-gating") {{
-              git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-              common = load 'pipeline_steps/common.groovy'
-              ssh_slave = load 'pipeline_steps/ssh_slave.groovy'
-              multi_node_aio_prepare = load 'pipeline_steps/multi_node_aio_prepare.groovy'
-              deploy = load 'pipeline_steps/deploy.groovy'
-              tempest = load 'pipeline_steps/tempest.groovy'
-              holland = load 'pipeline_steps/holland.groovy'
-              maas = load 'pipeline_steps/maas.groovy'
-              kibana = load 'pipeline_steps/kibana.groovy'
-            }}
             dir("rpc-gating/playbooks") {{
               writeFile file: "inventory/hosts", text: "[job_nodes]\n${{env.INSTANCE_NAME}} ansible_host=${{env.INSTANCE_IP}}\n"
-              common.install_ansible()
             }}
             ssh_slave.connect()
             deploy_node = null
             // Adds maas token and url to environment
             // without adding another level of nesting
             maas.add_maas_env_vars()
-            node(env.INSTANCE_NAME) {{
+            common.use_node(env.INSTANCE_NAME) {{
               common.conditionalStage(
                 stage_name: 'Prepare HW AIO',
                 stage: {{
@@ -138,7 +126,7 @@
             deploy_node = "${{INSTANCE_NAME}}-deploy-vm"
             multi_node_aio_prepare.connect_deploy_node(deploy_node, instance_ip)
 
-            node(deploy_node) {{
+           common.use_node(deploy_node) {{
               deploy.deploy_sh(
                 environment_vars: [
                   "DEPLOY_HAPROXY=yes",

--- a/rpc_jobs/influx.yml
+++ b/rpc_jobs/influx.yml
@@ -51,13 +51,6 @@
             only be allowed from RAX bastions and internal Jenkins nodes.
 
     dsl: |
-      node(){
-        deleteDir()
-        dir("rpc-gating"){
-            git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-            common = load 'pipeline_steps/common.groovy'
-            pubCloudSlave = load 'pipeline_steps/pubcloud.groovy'
-            influx = load 'pipeline_steps/influx.groovy'
-        }
+      common.internal_slave(){
         influx.setup()
       } // cit node

--- a/rpc_jobs/install_jenkins_plugins.yml
+++ b/rpc_jobs/install_jenkins_plugins.yml
@@ -6,7 +6,7 @@
       # See params.yml
       - rpc_gating_params
     dsl: |
-      node(){ // CIT slave node
+      common.shared_slave(){ // CIT slave node
         withCredentials([
           usernamePassword(
             credentialsId: "service_account_jenkins_api_creds",
@@ -15,13 +15,6 @@
           )
         ]){
           dir("rpc-gating"){
-            git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-            common = load 'pipeline_steps/common.groovy'
-            common.install_ansible()
-            sh """#!/bin/bash
-              . ../.venv/bin/activate
-              pip install urllib3==1.18.1
-            """
             common.venvPlaybook(
               playbooks: ["playbooks/install_jenkins_plugins.yml"],
               args: [ "-i inventory" ]

--- a/rpc_jobs/irr_role_test.yml
+++ b/rpc_jobs/irr_role_test.yml
@@ -114,14 +114,8 @@
     dsl: |
       // CIT Slave node
       timeout(time: 3, unit: 'HOURS'){{
-        node() {{
+        common.shared_slave() {{
           try {{
-            dir("rpc-gating") {{
-              git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-              common = load 'pipeline_steps/common.groovy'
-              pubcloud = load 'pipeline_steps/pubcloud.groovy'
-              irr_role_tests = load 'pipeline_steps/irr_role_tests.groovy'
-            }}
             irr_role_tests.run_irr_tests()
           }} finally {{
             common.delete_workspace()

--- a/rpc_jobs/jjb_setup.yml
+++ b/rpc_jobs/jjb_setup.yml
@@ -14,7 +14,7 @@
     triggers:
       - github # triggered post merge, not on PR
     dsl: |
-      node(){
+      common.shared_slave(){
         stage('Run Jenkins Job Builder') {
           git branch: "master", url: "https://github.com/rcbops/rpc-gating"
           build job: "Jenkins-Job-Builder"
@@ -43,13 +43,8 @@
             default: false
         - rpc_gating_params
     dsl: |
-      node("CentOS"){
+      common.internal_slave(){
         dir("rpc-gating"){
-          stage('Prepare'){
-            git branch: params.RPC_GATING_BRANCH, url: params.RPC_GATING_REPO
-            common = load 'pipeline_steps/common.groovy'
-            common.create_workspace_venv()
-          }
           stage('Run JJB'){
             withCredentials([
               usernamePassword(

--- a/rpc_jobs/long_running_slave.yml
+++ b/rpc_jobs/long_running_slave.yml
@@ -31,18 +31,12 @@
               Destroy Slave
 
     dsl: |
-      node(){
-          dir("rpc-gating"){
-            git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-            common = load 'pipeline_steps/common.groovy'
-            pubCloudSlave = load 'pipeline_steps/pubcloud.groovy'
-            maas = load 'pipeline_steps/maas.groovy'
-          }
+      common.shared_slave(){
           dir("rpc-maas"){
             git branch: env.RPC_MAAS_BRANCH, url: env.RPC_MAAS_REPO
           }
           String instance_name = common.gen_instance_name("long-running-slave")
-          pubCloudSlave.getPubCloudSlave(instance_name: instance_name)
+          pubcloud.getPubCloudSlave(instance_name: instance_name)
           try{
             withCredentials([
               file(
@@ -97,6 +91,6 @@
             throw(e)
           } finally {
             // this doesn't run by default as cleanup isn't included in stages
-            pubCloudSlave.delPubCloudSlave(instance_name: instance_name)
+            pubcloud.delPubCloudSlave(instance_name: instance_name)
           }
       } // cit node

--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -143,6 +143,9 @@
           deploy_node = null
           pubCloudSlave.getPubCloudSlave(instance_name: instance_name)
 
+          // Adds maas token and url to environment
+          // without adding another level of nesting
+          maas.add_maas_env_vars()
           node(instance_name){{
             multi_node_aio_prepare.prepare()
             instance_ip = sh(script: "ip route get 1 | awk '{{print \$NF;exit}}'", returnStdout: true)

--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -45,7 +45,7 @@
     triggers:
       - github
     dsl: |
-      node(){{
+      common.shared_slave(){{
         stage('OnMetal Multi-Node AIO') {{
           git branch: "{branch}", url: "https://github.com/rcbops/rpc-openstack"
           if("{series}" == "mitaka"){{
@@ -123,30 +123,16 @@
               Destroy Slave
 
     dsl: |
-      node(){{
+      common.shared_slave(){{
         try {{
-          dir("rpc-gating"){{
-            git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-            pubCloudSlave = load 'pipeline_steps/pubcloud.groovy'
-            ssh_slave = load 'pipeline_steps/ssh_slave.groovy'
-            common = load 'pipeline_steps/common.groovy'
-            multi_node_aio_prepare = load 'pipeline_steps/multi_node_aio_prepare.groovy'
-            deploy = load 'pipeline_steps/deploy.groovy'
-            maas = load 'pipeline_steps/maas.groovy'
-            tempest = load 'pipeline_steps/tempest.groovy'
-            horizon = load 'pipeline_steps/horizon.groovy'
-            kibana = load 'pipeline_steps/kibana.groovy'
-            holland = load 'pipeline_steps/holland.groovy'
-            github = load 'pipeline_steps/github.groovy'
-          }}
           instance_name = common.gen_instance_name()
           deploy_node = null
-          pubCloudSlave.getPubCloudSlave(instance_name: instance_name)
+          pubcloud.getPubCloudSlave(instance_name: instance_name)
 
           // Adds maas token and url to environment
           // without adding another level of nesting
           maas.add_maas_env_vars()
-          node(instance_name){{
+          common.use_node(instance_name){{
             multi_node_aio_prepare.prepare()
             instance_ip = sh(script: "ip route get 1 | awk '{{print \$NF;exit}}'", returnStdout: true)
           }} // public cloud node
@@ -154,7 +140,7 @@
           deploy_node = "${{instance_name}}-deploy-vm"
           multi_node_aio_prepare.connect_deploy_node(deploy_node, instance_ip)
 
-          node(deploy_node){{
+          common.use_node(deploy_node){{
             deploy.deploy_sh(
               environment_vars: [
                 "DEPLOY_HAPROXY=yes",
@@ -165,10 +151,6 @@
                 "DEPLOY_SUPPORT_ROLE=yes"
                 ]
             ) // deploy_sh
-            dir("rpc-gating"){{
-              // Checkout rpc-gating repo to avoid race conditions in parallel steps
-              git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-            }}
             parallel(
               "maas": {{
                 maas.prepare(instance_name: instance_name)
@@ -196,7 +178,7 @@
             }}
             throw e
         }} finally {{
-            pubCloudSlave.delPubCloudSlave(instance_name: instance_name)
+            pubcloud.delPubCloudSlave(instance_name: instance_name)
             maas.entity_cleanup(instance_name: instance_name)
             if(deploy_node != null){{
               ssh_slave.destroy(deploy_node)

--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -40,7 +40,7 @@
             Create slave in exclusive mode?
             An exclusive slave will only be used for jobs that specify its
             name or labels. A non exclusive node will run jobs that don't
-            specify a name or label. eg node(){{}} blocks. Single use slaves
+            specify a name or label. eg common.shared_slave(){{}} blocks. Single use slaves
             should be exclusive, multi use slaves should not.
       - bool:
           name: allow_jenkins_sudo

--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -46,12 +46,9 @@
       for (int i=0; i<nodes.size(); i++){
         nodeName = nodes[i]
         parallel_steps['node_'+nodeName] = {
-          node(nodeName){
+          common.use_node(nodeName){
             stage("Cleanup "+nodeName){
-              deleteDir()
               dir("rpc-gating") {
-                git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-                common = load 'pipeline_steps/common.groovy'
                 sh "scripts/workspace_cleanup.sh"
                 sh "scripts/tmp_cleanup.sh"
                 sh "scripts/docker_cleanup.sh"
@@ -63,18 +60,16 @@
       parallel parallel_steps
 
       // run the pubcloud and jenkins node cleanup only on an internal slave
-      node('CentOS'){
-          deleteDir()
-          dir("rpc-gating") {
-            stage("Prepare"){
-              git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-              common = load 'pipeline_steps/common.groovy'
-            }
+      common.internal_slave(){
+        dir("rpc-gating") {
           stage("Docker Build"){
               common.docker_cache_workaround()
               container = docker.build env.BUILD_TAG.toLowerCase()
           }
         }
+        // container.inside is a docker function that does
+        // not run the same initialisaiton steps as
+        // common.use_node/shared_slave/internal_slave.
         container.inside {
           stage("Docker Checkout"){
             git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO

--- a/rpc_jobs/pull_request_issue_link.yml
+++ b/rpc_jobs/pull_request_issue_link.yml
@@ -34,21 +34,6 @@
           name: REPO
           default: "{repo}"
     dsl: |
-      node() {{
-        deleteDir()
-        if (REPO == "rpc_gating") {{
-          branch = env.ghprbSourceBranch
-          url = env.ghprbAuthorRepoGitUrl
-        }} else {{
-          branch = env.RPC_GATING_BRANCH
-          url = env.RPC_GATING_REPO
-        }}
-        dir("rpc-gating") {{
-          git branch: branch, url: url
-          common = load 'pipeline_steps/common.groovy'
-          github = load 'pipeline_steps/github.groovy'
-          venv = "${{env.WORKSPACE}}/.venv"
-          sh "virtualenv ${{venv}} && . ${{venv}}/bin/activate && pip install -c constraints.txt click github3.py"
-        }}
+      common.shared_slave() {{
         github.add_issue_url_to_pr()
       }}

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -336,6 +336,9 @@
             if(common.is_doc_update_pr("${{env.WORKSPACE}}/rpc-openstack")){{
               return
             }}
+            // Adds maas token and url to environment
+            // without adding another level of nesting
+            maas.add_maas_env_vars()
             pubcloud.runonpubcloud {{
               // try within pubcloud node so we can archive archive_artifacts
               // after a failure, before the node is cleaned up.

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -291,18 +291,8 @@
       env.ACTION = "{action}"
       env.SERIES = "{series}"
       timeout(time: 8, unit: 'HOURS'){{
-        node() {{
+        common.shared_slave() {{
           try {{
-            dir("rpc-gating") {{
-              git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-              common = load 'pipeline_steps/common.groovy'
-              pubcloud = load 'pipeline_steps/pubcloud.groovy'
-              aio_prepare = load 'pipeline_steps/aio_prepare.groovy'
-              deploy = load 'pipeline_steps/deploy.groovy'
-              tempest = load 'pipeline_steps/tempest.groovy'
-              holland = load 'pipeline_steps/holland.groovy'
-              kibana = load 'pipeline_steps/kibana.groovy'
-            }}
             // This sets kibana_branch based on STAGES
             // Note that we do this before the block below since
             // env.UPGRADE_FROM_ENV gets overwritten

--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -140,15 +140,8 @@
           cancel-builds-on-update: true
     dsl: |
       // CIT slave
-      node() {{
-        deleteDir()
+      common.shared_slave() {{
         currentBuild.result = "SUCCESS"
-        dir("rpc-gating") {{
-          git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-          common = load 'pipeline_steps/common.groovy'
-          pubcloud = load 'pipeline_steps/pubcloud.groovy'
-          artifact_build = load 'pipeline_steps/artifact_build.groovy'
-        }}
         // We need to checkout the rpc-openstack repo on the CIT Slave
         // so that we can check whether the patch is a docs-only patch
         // before allocating resources unnecessarily.
@@ -160,15 +153,8 @@
           common.conditionalStage(
             stage_name: "Build Apt Artifacts",
             stage: {{
-              node('ArtifactBuilder2') {{
-                deleteDir()
-                dir("rpc-gating") {{
-                  git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-                  common = load 'pipeline_steps/common.groovy'
-                  artifact_build = load 'pipeline_steps/artifact_build.groovy'
-                }}
+              common.use_node('ArtifactBuilder2') {{
                 artifact_build.apt()
-                deleteDir()
               }} // node ArtifactBuilder2
             }} // stage
           ) // conditionalStage
@@ -184,5 +170,4 @@
           common.safe_jira_comment("${{currentBuild.result}}: [${{env.BUILD_TAG}}|${{env.BUILD_URL}}]")
           common.delete_workspace()
         }}
-        deleteDir()
       }} // node

--- a/rpc_jobs/rpc_gating_lint.yml
+++ b/rpc_jobs/rpc_gating_lint.yml
@@ -16,14 +16,13 @@
       - rpc-gating-github
     dsl: |
       currentBuild.result = 'SUCCESS'
-      node(){
+      common.shared_slave(){
         try{
-          deleteDir()
           stage("Prepare"){
-            git url: env.ghprbAuthorRepoGitUrl, branch: ghprbSourceBranch
-            common = load 'pipeline_steps/common.groovy'
             common.docker_cache_workaround()
-            lint_container = docker.build env.BUILD_TAG.toLowerCase()
+            dir ('rpc-gating'){
+              lint_container = docker.build env.BUILD_TAG.toLowerCase()
+            }
           }
           lint_container.inside {
             stage("Checkout"){

--- a/rpc_jobs/single_use_slave_template.yml
+++ b/rpc_jobs/single_use_slave_template.yml
@@ -23,12 +23,7 @@
               Destroy Slave
     dsl: |
       // CIT Slave node
-      node(){
-        dir("rpc-gating"){
-          git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-          pubcloud = load 'pipeline_steps/pubcloud.groovy'
-          common = load 'pipeline_steps/common.groovy'
-        }
+      common.shared_slave(){
         pubcloud.runonpubcloud {
           sh """
             hostname; date

--- a/rpc_jobs/sync_credential_store.yml
+++ b/rpc_jobs/sync_credential_store.yml
@@ -23,46 +23,43 @@
             eg. git+ssh://git@repo_url/user/pwsafe.git
 
     dsl: |
-      node(){ // CIT slave node
+      common.internal_slave(){ // CIT slave node
         withCredentials([
           file(
             credentialsId: 'service_account_jenkins_ssh_key',
             variable: 'JENKINS_SSH_KEY'
           )
         ]){
-          dir("rpc-gating"){
-            git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-            dir("scripts"){
-              TMP_DIR = pwd(tmp:true)
-              withEnv([
-                "TMP_DIR=${TMP_DIR}",
-                "PWSAFE_PROJECT_ID=${PWSAFE_PROJECT_ID}",
-                "JENKINS_URL=${JENKINS_URL}",
-                "JENKINS_SSH_KEY=${JENKINS_SSH_KEY}",
-                "SSO_USERNAME=${SSO_USERNAME}",
-                "SSO_PASSWORD=${SSO_PASSWORD}"])
-              {
-                sshagent (credentials: ['rpc-jenkins-svc-github-key']) {
-                  sh """#!/bin/bash
-                    scl enable python27 bash
+          dir("rpc-gating/scripts"){
+            TMP_DIR = pwd(tmp:true)
+            withEnv([
+              "TMP_DIR=${TMP_DIR}",
+              "PWSAFE_PROJECT_ID=${PWSAFE_PROJECT_ID}",
+              "JENKINS_URL=${JENKINS_URL}",
+              "JENKINS_SSH_KEY=${JENKINS_SSH_KEY}",
+              "SSO_USERNAME=${SSO_USERNAME}",
+              "SSO_PASSWORD=${SSO_PASSWORD}"])
+            {
+              sshagent (credentials: ['rpc-jenkins-svc-github-key']) {
+                sh """#!/bin/bash
+                  scl enable python27 bash
 
-                    if [[ ! -d ".venv" ]]; then
-                        virtualenv -p /opt/rh/python27/root/usr/bin/python .venv
-                    fi
-                    source .venv/bin/activate
+                  if [[ ! -d ".venv" ]]; then
+                      virtualenv -p /opt/rh/python27/root/usr/bin/python .venv
+                  fi
+                  source .venv/bin/activate
 
-                    pip install ${PIP_PWSAFE_LOCATION}
-                    pip install functools32
+                  pip install ${PIP_PWSAFE_LOCATION}
+                  pip install functools32
 
-                    if [[ ! -f "jenkins-cli.jar" ]]; then
-                        wget ${JENKINS_URL}/jnlpJars/jenkins-cli.jar
-                    fi
+                  if [[ ! -f "jenkins-cli.jar" ]]; then
+                      wget ${JENKINS_URL}/jnlpJars/jenkins-cli.jar
+                  fi
 
-                    python pull_passwords.py
-                  """
-                } // sshagent
-              } // withEnv
-            } // dir
+                  python pull_passwords.py
+                """
+              } // sshagent
+            } // withEnv
           } // dir
         } // withCred
       } // CIT slave node

--- a/rpc_jobs/webhook.yml
+++ b/rpc_jobs/webhook.yml
@@ -45,12 +45,6 @@
             node ansible_host=YOUR_IP_HERE
 
     dsl: |
-      node('CentOS'){
-          dir("rpc-gating"){
-              git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
-              common = load 'pipeline_steps/common.groovy'
-              pubCloudSlave = load 'pipeline_steps/pubcloud.groovy'
-              webhooks = load 'pipeline_steps/webhooks.groovy'
-          }
+      common.internal_slave(){
           webhooks.webhooks()
       } // cit node

--- a/vars
+++ b/vars
@@ -1,0 +1,1 @@
+pipeline_steps/


### PR DESCRIPTION
This pull request ensures that MaaS variables are supplied to the rpc deploy process, so that it can configure MaaS for the deployment.

The majority of this change is dedicated to moving node allocation to a common function. This ensures that nodes are allocated in a consistent way, and that the gating utility virtualenv is build exactly once per node.

This PR also prepares rpc-gating for use as a Jenkins shared library, so that we can use implicitly library loading, rather than having to explicitly load every groovy script in every job.

Issue: [UG-646](https://rpc-openstack.atlassian.net/browse/UG-646)