### PR TITLE
Use SSL for artefact link

### DIFF
--- a/playbooks/templates/cloudfiles.html.j2
+++ b/playbooks/templates/cloudfiles.html.j2
@@ -1,6 +1,6 @@
 <html>
 <body>
-<a href="{{ public_container.container_urls.url }}/{{ src | basename }}">{{ src | basename }}</a>
+<a href="{{ public_container.container_urls.ssl_url }}/{{ src | basename }}">{{ src | basename }}</a>
 <div style="white-space: pre">
 {{ artifact_description | default("") }}
 </div>


### PR DESCRIPTION
This will prevent insecure script/resource warning is modern browsers.

`ssl_url` is provided by the rax_files module:
https://github.com/ansible/ansible-modules-core/blob/devel/cloud/rackspace/rax_files.py#L280