### PR TITLE
LA-373 Deploy Maas with an env var

### DIFF
--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -114,6 +114,10 @@
           name: "DEPLOY_SUPPORT_ROLE"
           default: "{DEPLOY_SUPPORT_ROLE}"
           description: "Deploy support role? yes/no"
+      - string:
+          name: "DEPLOY_MAAS"
+          default: "{DEPLOY_MAAS}"
+          description: "Deploy and verify maas? yes/no"
       - text:
           name: "USER_VARS"
           default: "{USER_VARS}"

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -35,16 +35,12 @@
     action:
       - deploy:
           ACTION_STAGES: >-
-            Setup MaaS,
-            Verify MaaS,
             Install Tempest,
             Tempest Tests,
             Prepare Kibana Selenium,
             Kibana Tests
       - majorupgrade:
           ACTION_STAGES: >-
-            Setup MaaS,
-            Verify MaaS,
             Install Tempest,
             Tempest Tests,
             Prepare Kibana Selenium,
@@ -57,8 +53,6 @@
       - leapfrogupgrade:
           ACTION_STAGES: >-
             Leapfrog Upgrade,
-            Setup MaaS,
-            Verify MaaS,
             Install Tempest,
             Tempest Tests,
             Prepare Kibana Selenium,
@@ -212,6 +206,7 @@
     branch: master
     NUM_TO_KEEP: 30
     IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+    DEPLOY_MAAS: "YES"
     DEPLOY_TELEGRAF: "NO"
     DEPLOY_INFLUX: "NO"
     # TEMPLATE
@@ -233,6 +228,7 @@
           DEPLOY_CEPH: "{DEPLOY_CEPH}"
           DEPLOY_ELK: "{DEPLOY_ELK}"
           DEPLOY_SUPPORT_ROLE: "{DEPLOY_SUPPORT_ROLE}"
+          DEPLOY_MAAS: "{DEPLOY_MAAS}"
           USER_VARS: |
             {CONTEXT_USER_VARS}
             {SERIES_USER_VARS}


### PR DESCRIPTION
Maas deploy or not should be defined with a single env var.
We shouldn't have steps for maas, the orchestration inside the
project (for example rpc-o leapfrog, or rpc-o deploy) should
handle its deploy.
Gating should only be aware of what to do in a job, not handling
the job's work itself.

Issue: [LA-373](https://rpc-openstack.atlassian.net/browse/LA-373)