### PR TITLE
UG-668 Reduce workspace retention

### DIFF
--- a/scripts/tmp_cleanup.sh
+++ b/scripts/tmp_cleanup.sh
@@ -4,5 +4,5 @@ echo "Remove old pip build directories"
 set -xe
 mkdir -p /var/lib/jenkins/tmp
 cd /var/lib/jenkins/tmp \
-  && find . -maxdepth 1 -mtime +2 -type d -name "pip*" \
+  && find . -maxdepth 1 -mtime +2 -type d -iregex ".*\(pip\|tmp\|easy\|get\).*" \
     -exec rm -rf {} \;

--- a/scripts/workspace_cleanup.sh
+++ b/scripts/workspace_cleanup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-echo "Removing Workspaces that haven't been modified in the last 7 days"
+echo "Removing Workspaces that haven't been modified in the last 2 days"
 set -xe
 cd /var/lib/jenkins/workspace \
-  && find . -maxdepth 1 -ctime +7 \
+  && find . -maxdepth 1 -ctime +2 \
     |while read old; do rm -rf "$old"; done


### PR DESCRIPTION
To reduce disk usage on restricted CIT slaves, we reduce the workspace
retention period.

Added regex to pip cleanup to ensure tmp dirs aren't missed.

Issue: [UG-668](https://rpc-openstack.atlassian.net/browse/UG-668)