### PR TITLE
RE-102 Use only find command for copying tempest results

### DIFF
--- a/pipeline_steps/tempest.groovy
+++ b/pipeline_steps/tempest.groovy
@@ -50,12 +50,7 @@ def tempest(){
           find_tempest_results_cmd=\"find /var/lib/lxc/*utility*/ -type f -name \"tempest_results.xml\"\"
           tempest_server=\$(cd /opt/rpc-openstack/openstack-ansible/playbooks && ansible utility[0] -m command -a 'echo {{ physical_host }}' | grep -Ev 'Variable files|utility')
           copy_cmd=\"scp -o StrictHostKeyChecking=no -p  -r \${tempest_server}:\"
-
           rm -f *tempest*.xml
-          # Following used for pre-Ocata, will fail post-Newton
-          \${copy_cmd}/openstack/log/*utility*/**/*tempest*.xml . ||:
-          \${copy_cmd}/openstack/log/*utility*/*tempest*.xml . ||:
-          # Following used for Ocata and up, will fail pre-Ocata
           \${copy_cmd}\$(ssh -o StrictHostKeyChecking=no \${tempest_server} \"\${find_tempest_results_cmd}\") . ||:
         """
         junit allowEmptyResults: true, testResults: '*tempest*.xml'


### PR DESCRIPTION
Command to find the tempest results file works for
versions older than ocata as well, so running
multiple attempts to copy the file results in
duplicate results published to Jenkins.

Issue: [RE-102](https://rpc-openstack.atlassian.net/browse/RE-102)