### PR TITLE
LA-376 Remove use of deleteDir in multi_node_aio

### DIFF
--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -256,9 +256,6 @@
 
     dsl: |
       common.shared_slave(){{
-        dir(env.WORKSPACE) {{
-          deleteDir()
-        }}
         try {{
           instance_name = common.gen_instance_name()
           deploy_node = null
@@ -325,6 +322,5 @@
             if(deploy_node != null){{
               ssh_slave.destroy(deploy_node)
             }}
-            common.delete_workspace()
         }}
       }} // cit node


### PR DESCRIPTION
The commit 3be71623803ccd1d69f46e183f9750ab134f34f5 refactored the
management of nodes and now handles the clean up of workspaces. Work on
multi_node_aio.yml, that was in progress when the commit merged, has
re-introduced the use of deleteDir in the template and is causing
failures.

Given that the function `common.use_node` ensures the workspace is
deleted at the beginning and end of the job, this commit removes that
functionality from multi_node_aio.yml.

Issue: [LA-376](https://rpc-openstack.atlassian.net/browse/LA-376)