### PR TITLE
UG-646 add library statement to every job

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1,7 +1,6 @@
 import groovy.json.JsonSlurperClassic
 import groovy.json.JsonOutput
 
-
 def void create_workspace_venv(){
   print "create_workspace_venv"
   sh """#!/bin/bash -xe
@@ -578,13 +577,10 @@ void use_node(label=null, body){
     try {
       deleteDir()
       dir("rpc-gating"){
-        if (! env.RPC_GATING_REPO){
-          env.RPC_GATING_REPO="https://github.com/rcbops/rpc-gating"
-        }
         if (! env.RPC_GATING_BRANCH){
           env.RPC_GATING_BRANCH="master"
         }
-        git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
+        git branch: env.RPC_GATING_BRANCH, url: "https://github.com/rcbops/rpc-gating"
       }
       install_ansible()
       body()

--- a/playbooks/webhooks.yml
+++ b/playbooks/webhooks.yml
@@ -19,7 +19,7 @@
     GITHUB_CIDR: "192.30.252.0/22"
     GITHUB_HOOK_PORT: 80
 
-    RPC_GATING_REPO: "{{ lookup('env', 'RPC_GATING_REPO') }}"
+    RPC_GATING_REPO: "https://github.com/rcbops/rpc-gating"
     RPC_GATING_BRANCH: "{{ lookup('env', 'RPC_GATING_BRANCH') }}"
     RPC_GATING_DIR: /opt/rpc-gating
 

--- a/rpc_jobs/hardening.yml
+++ b/rpc_jobs/hardening.yml
@@ -68,6 +68,7 @@
               Destroy Slave
 
     dsl: |
+      library "rpc-gating@${{RPC_GATING_BRANCH}}"
       common.shared_slave(){{
         try {{
           common.internal_slave(){{

--- a/rpc_jobs/hw_multi_node_aio.yml
+++ b/rpc_jobs/hw_multi_node_aio.yml
@@ -99,7 +99,7 @@
       - timed: ""
 
     dsl: |
-      // CIT Slave node
+      library "rpc-gating@${{RPC_GATING_BRANCH}}"
       timeout(time: 8, unit: 'HOURS'){{
         common.shared_slave() {{
           try {{

--- a/rpc_jobs/influx.yml
+++ b/rpc_jobs/influx.yml
@@ -51,6 +51,7 @@
             only be allowed from RAX bastions and internal Jenkins nodes.
 
     dsl: |
+      library "rpc-gating@${{RPC_GATING_BRANCH}}"
       common.internal_slave(){
         influx.setup()
       } // cit node

--- a/rpc_jobs/install_jenkins_plugins.yml
+++ b/rpc_jobs/install_jenkins_plugins.yml
@@ -6,6 +6,7 @@
       # See params.yml
       - rpc_gating_params
     dsl: |
+      library "rpc-gating@${{RPC_GATING_BRANCH}}"
       common.shared_slave(){ // CIT slave node
         withCredentials([
           usernamePassword(

--- a/rpc_jobs/irr_role_test.yml
+++ b/rpc_jobs/irr_role_test.yml
@@ -112,7 +112,7 @@
           cancel-builds-on-update: true
 
     dsl: |
-      // CIT Slave node
+      library "rpc-gating@${{RPC_GATING_BRANCH}}"
       timeout(time: 3, unit: 'HOURS'){{
         common.shared_slave() {{
           try {{

--- a/rpc_jobs/jjb_setup.yml
+++ b/rpc_jobs/jjb_setup.yml
@@ -14,6 +14,7 @@
     triggers:
       - github # triggered post merge, not on PR
     dsl: |
+      library "rpc-gating@${{RPC_GATING_BRANCH}}"
       common.shared_slave(){
         stage('Run Jenkins Job Builder') {
           git branch: "master", url: "https://github.com/rcbops/rpc-gating"
@@ -43,6 +44,7 @@
             default: false
         - rpc_gating_params
     dsl: |
+      library "rpc-gating@${{RPC_GATING_BRANCH}}"
       common.internal_slave(){
         dir("rpc-gating"){
           stage('Run JJB'){

--- a/rpc_jobs/long_running_slave.yml
+++ b/rpc_jobs/long_running_slave.yml
@@ -31,6 +31,7 @@
               Destroy Slave
 
     dsl: |
+      library "rpc-gating@${{RPC_GATING_BRANCH}}"
       common.shared_slave(){
           dir("rpc-maas"){
             git branch: env.RPC_MAAS_BRANCH, url: env.RPC_MAAS_REPO

--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -146,6 +146,7 @@
     triggers:
       - github
     dsl: |
+      library "rpc-gating@${{RPC_GATING_BRANCH}}"
       common.shared_slave(){{
         stage('OnMetal Multi-Node AIO') {{
           git branch: "{branch}", url: "https://github.com/rcbops/rpc-openstack"
@@ -255,6 +256,7 @@
           description: "The number of volume nodes to deploy."
 
     dsl: |
+      library "rpc-gating@${{RPC_GATING_BRANCH}}"
       common.shared_slave(){{
         try {{
           instance_name = common.gen_instance_name()

--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -131,11 +131,12 @@
     name: rpc_gating_params
     parameters:
       - string:
-          name: RPC_GATING_REPO
-          default: "https://github.com/rcbops/rpc-gating"
-      - string:
           name: RPC_GATING_BRANCH
           default: "master"
+          description: |
+            Version of rpc-gating. This is used when loading the rpc-gating
+            groovy library, and when cloning RPC_GATING_REPO into each
+            workspace. The clone source is always rcbops/rpc-gating.
 
 - parameter:
     name: kibana_selenium_params

--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -73,7 +73,7 @@
         // common.use_node/shared_slave/internal_slave.
         container.inside {
           stage("Docker Checkout"){
-            git branch: env.RPC_GATING_BRANCH, url: env.RPC_GATING_REPO
+            git branch: env.RPC_GATING_BRANCH, url: "https://github.com/rcbops/rpc-gating"
           }
           stage("Public Cloud Cleanup"){
             withCredentials([

--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -25,6 +25,7 @@
       - build-discarder:
           days-to-keep: 3
     dsl: |
+      library "rpc-gating@${{RPC_GATING_BRANCH}}"
       // Get list of jenkins slaves
       @NonCPS
       def getLongRunningNodes() {

--- a/rpc_jobs/pull_request_issue_link.yml
+++ b/rpc_jobs/pull_request_issue_link.yml
@@ -34,6 +34,7 @@
           name: REPO
           default: "{repo}"
     dsl: |
+      library "rpc-gating@${{RPC_GATING_BRANCH}}"
       common.shared_slave() {{
         github.add_issue_url_to_pr()
       }}

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -282,7 +282,7 @@
           cancel-builds-on-update: true
 
     dsl: |
-      // CIT Slave node
+      library "rpc-gating@${{RPC_GATING_BRANCH}}"
       currentBuild.result = 'SUCCESS'
       // pass JJB axes through to environment
       env.SCENARIO = "{scenario}"

--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -139,7 +139,7 @@
           status-context: 'CIT/artifact-{image}-{context}'
           cancel-builds-on-update: true
     dsl: |
-      // CIT slave
+      library "rpc-gating@${{RPC_GATING_BRANCH}}"
       common.shared_slave() {{
         currentBuild.result = "SUCCESS"
         // We need to checkout the rpc-openstack repo on the CIT Slave

--- a/rpc_jobs/rpc_gating_lint.yml
+++ b/rpc_jobs/rpc_gating_lint.yml
@@ -12,9 +12,12 @@
           auth-id: "github_account_rpc_jenkins_svc"
           status-context: 'CIT/lint'
           cancel-builds-on-update: true
+    parameters:
+      - rpc_gating_params
     properties:
       - rpc-gating-github
     dsl: |
+      library "rpc-gating@${{RPC_GATING_BRANCH}}"
       currentBuild.result = 'SUCCESS'
       common.shared_slave(){
         try{

--- a/rpc_jobs/single_use_slave_template.yml
+++ b/rpc_jobs/single_use_slave_template.yml
@@ -22,7 +22,7 @@
               Cleanup
               Destroy Slave
     dsl: |
-      // CIT Slave node
+      library "rpc-gating@${{RPC_GATING_BRANCH}}"
       common.shared_slave(){
         pubcloud.runonpubcloud {
           sh """

--- a/rpc_jobs/sync_credential_store.yml
+++ b/rpc_jobs/sync_credential_store.yml
@@ -23,7 +23,8 @@
             eg. git+ssh://git@repo_url/user/pwsafe.git
 
     dsl: |
-      common.internal_slave(){ // CIT slave node
+      library "rpc-gating@${{RPC_GATING_BRANCH}}"
+      common.internal_slave(){
         withCredentials([
           file(
             credentialsId: 'service_account_jenkins_ssh_key',

--- a/rpc_jobs/webhook.yml
+++ b/rpc_jobs/webhook.yml
@@ -45,6 +45,7 @@
             node ansible_host=YOUR_IP_HERE
 
     dsl: |
+      library "rpc-gating@${{RPC_GATING_BRANCH}}"
       common.internal_slave(){
           webhooks.webhooks()
       } // cit node


### PR DESCRIPTION
Currently the rpc-gating library is loaded implicitly, jenkins injects
it into the groovy environment before the script is started. The
problem with this approach is that the verison of rpc-gating used
cannot be overridden.

This version uses the RPC_GATING_BRANCH parameter to set the
version of rpc-gating that is loaded. This will return our ability
to test other jobs (such as RPC AIOs) against changes to gating.

This approach also makes it explicit in each job where the library
is coming from. Once this merges, we'll turn off implicit loading
in Jenkins global config.

Issue: [UG-646](https://rpc-openstack.atlassian.net/browse/UG-646)