### PR TITLE
RE-106 Specify leapfrog upgrades environment_vars

### DIFF
--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -285,12 +285,13 @@
                 }}
               }}
             }}
+            environment_vars = [
+              "DEPLOY_HAPROXY=yes",
+              "DEPLOY_TEMPEST=no",
+              "DEPLOY_AIO=no",
+            ]
             deploy.deploy_sh(
-              environment_vars: [
-                "DEPLOY_HAPROXY=yes",
-                "DEPLOY_TEMPEST=no",
-                "DEPLOY_AIO=no",
-                ]
+              environment_vars: environment_vars
             ) // deploy_sh
             parallel(
               "tempest": {{


### PR DESCRIPTION
Define the variable `environment_vars` to prevent leapfrog upgrades
failing due to its absence.

A recent change appears to have broken leapfrog upgrades on multi-node
AIOs which was not detected due to the inherent race that exists with
the current testing and merging process. `environment_vars` was no
longer defined when `deploy.upgrade_leapfrog` is run causing a failure.
In reality this failure has exposed a hidden bug because
`environment_vars` should not be defined as a by-product of some other
part of the code and so this change should now address the underlying
issue.

Issue: [RE-106](https://rpc-openstack.atlassian.net/browse/RE-106)