### PR TITLE
RE-105 Use instance_name argument for deletion

### DIFF
--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -55,7 +55,7 @@ def cleanup(Map args){
               "--private-key=\"${env.JENKINS_SSH_PRIVKEY}\"",
             ],
             vars: [
-              "instance_name": instance_name,
+              "instance_name": args.instance_name,
               "server_name": args.server_name,
               "region": args.region
             ]
@@ -94,13 +94,13 @@ def delPubCloudSlave(Map args){
     step_name: 'Cleanup',
     step: {
       cleanup (
-        instance_name: instance_name,
-        server_name: instance_name,
+        instance_name: args.instance_name,
+        server_name:  args.instance_name,
         region: env.REGION,
       )
     } //stage
   ) //conditionalStage
-  ssh_slave.destroy(instance_name)
+  ssh_slave.destroy(args.instance_name)
 }
 
 /* One func entrypoint to run a script on a single use slave */


### PR DESCRIPTION
The instance_name was being passed to the delete
methods but global variable instance_name was
being used instead.

Issue: [RE-105](https://rpc-openstack.atlassian.net/browse/RE-105)