### PR TITLE
RE-103 Store rpc-gating venvs

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -115,7 +115,7 @@ def venvPlaybook(Map args){
         write_json(file: vars_file, obj: args.vars)
         sh """#!/bin/bash -x
           which scl && source /opt/rh/python27/enable
-          . ${env.WORKSPACE}/.venv/bin/activate
+          set +x; . ${env.WORKSPACE}/.venv/bin/activate; set -x
           export ANSIBLE_HOST_KEY_CHECKING=False
           ansible-playbook ${args.args.join(' ')} -e@${vars_file} ${playbook}
         """
@@ -545,7 +545,7 @@ def create_jira_issue(project="RE", tag=env.BUILD_TAG, link=env.BUILD_URL, type=
   ]){
     sh """#!/bin/bash -xe
       cd ${env.WORKSPACE}
-      . .venv/bin/activate
+      set +x; . .venv/bin/activate; set -x
       python rpc-gating/scripts/jirautils.py create_issue\
         --tag '$tag'\
         --link '$link'\

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1,71 +1,94 @@
 import groovy.json.JsonSlurperClassic
 import groovy.json.JsonOutput
 
-def void create_workspace_venv(){
-  print "create_workspace_venv"
-  sh """#!/bin/bash -xe
+def void install_ansible(){
+  print "install_ansible"
+  sh """#!/bin/bash -e
+    REPO_BASE="https://rpc-repo.rackspace.com/rpcgating/venvs"
     cd ${env.WORKSPACE}
 
-    # Create venv
-    if [[ ! -d ".venv" ]]; then
-      requirements="virtualenv==15.1.0"
-      pip install -U "\${requirements}" \
-        || pip install --isolated -U "\${requirements}"
-      if which scl
-      then
-        # redhat/centos
-        source /opt/rh/python27/enable
-        virtualenv --no-pip --no-setuptools --no-wheel --python=/opt/rh/python27/root/usr/bin/python .venv
-        # hack the selinux module into the venv
-        cp -r /usr/lib64/python2.6/site-packages/selinux .venv/lib64/python2.7/site-packages/ ||:
-      else
-        virtualenv --no-pip --no-setuptools --no-wheel .venv
+    create_venv(){
+      if [[ ! -d ".venv" ]]; then
+        requirements="virtualenv==15.1.0"
+        pip install -U "\${requirements}" \
+          || pip install --isolated -U "\${requirements}"
+        if which scl
+        then
+          # redhat/centos
+          source /opt/rh/python27/enable
+          virtualenv --no-pip --no-setuptools --no-wheel --python=/opt/rh/python27/root/usr/bin/python .venv
+          # hack the selinux module into the venv
+          cp -r /usr/lib64/python2.6/site-packages/selinux .venv/lib64/python2.7/site-packages/ ||:
+        else
+          virtualenv --no-pip --no-setuptools --no-wheel .venv
+        fi
       fi
+
+      # Install Pip
+      source .venv/bin/activate
+
+      # UG-613 change TMPDIR to directory with more space
+      export TMPDIR="/var/lib/jenkins/tmp"
+
+      # If the pip version we're using is not the same as the constraint then replace it
+      PIP_TARGET="\$(awk -F= '/^pip==/ {print \$3}' rpc-gating/constraints.txt)"
+      VENV_PYTHON=".venv/bin/python"
+      VENV_PIP=".venv/bin/pip"
+      if [[ "\$(\${VENV_PIP} --version)" != "pip \${PIP_TARGET}"* ]]; then
+        # Install a known version of pip, setuptools, and wheel in the venv
+        CURL_CMD="curl --silent --show-error --retry 5"
+        OUTPUT_FILE="get-pip.py"
+        \${CURL_CMD} https://bootstrap.pypa.io/get-pip.py > \${OUTPUT_FILE} \
+          || \${CURL_CMD} https://raw.githubusercontent.com/pypa/get-pip/master/get-pip.py > \${OUTPUT_FILE}
+        GETPIP_OPTIONS="pip setuptools wheel --constraint rpc-gating/constraints.txt"
+        \${VENV_PYTHON} \${OUTPUT_FILE} \${GETPIP_OPTIONS} \
+          || \${VENV_PYTHON} \${OUTPUT_FILE} --isolated \${GETPIP_OPTIONS}
+      fi
+
+      # Install rpc-gating requirements
+      PIP_OPTIONS="-c rpc-gating/constraints.txt -r rpc-gating/requirements.txt"
+      \${VENV_PIP} install \${PIP_OPTIONS} \
+        || \${VENV_PIP} install --isolated \${PIP_OPTIONS}
+
+      # Install ansible roles
+      mkdir -p rpc-gating/playbooks/roles
+      ansible-galaxy install -r rpc-gating/role_requirements.yml -p rpc-gating/playbooks/roles
+    }
+
+    download_venv(){
+      curl -s "\${REPO_BASE}/rpcgatingvenv_\${SHA}.tbz" > venv.tbz
+      tar xjfp venv.tbz
+      op=\$(cat .venv/original_venv_path) # Original Path
+      np=\${PWD}/.venv                    # New Path
+      grep -ri --files-with-match \$op \
+        |while read f; do sed -i.bak "s|\$op|\$np|" \$f; done
+      if which scl; then
+        echo "CentOS node detected, copying in external python interpreter and setting PYTHONPATH in activate script"
+        # CentOS 6 can take a hike, its glibc isn't new enough for python 2.7.12
+        cp /opt/rh/python27/root/usr/bin/python .venv/bin/python
+        # I'm not sure why this is needed, but I assume its due to a change in python's
+        # default module search paths between 2.7.8 and 2.7.12
+        echo "export PYTHONPATH=${env.WORKSPACE}/.venv/lib/python2.7/site-packages" >> .venv/bin/activate
+      fi
+    }
+
+    pushd rpc-gating
+      SHA=\$(git rev-parse HEAD)
+    popd
+
+    curl -s "\${REPO_BASE}/index" > index ||:
+    if grep -q \$SHA index; then
+      echo "Found rpc-gating venv tar on rpc-repo for \$SHA, downloading."
+      download_venv
+      echo "Venv download and modification complete. SHA:\${SHA}"
+    else
+      echo "rpc-gating venv tar not found on rpc-repo for \$SHA, creating venv locally."
+      create_venv
+      echo "workspace/.venv creation complete"
     fi
-
-    # Install Pip
-    source .venv/bin/activate
-
-    # UG-613 change TMPDIR to directory with more space
-    export TMPDIR="/var/lib/jenkins/tmp"
-
-    # If the pip version we're using is not the same as the constraint then replace it
-    PIP_TARGET="\$(awk -F= '/^pip==/ {print \$3}' rpc-gating/constraints.txt)"
-    VENV_PYTHON=".venv/bin/python"
-    VENV_PIP=".venv/bin/pip"
-    if [[ "\$(\${VENV_PIP} --version)" != "pip \${PIP_TARGET}"* ]]; then
-      # Install a known version of pip, setuptools, and wheel in the venv
-      CURL_CMD="curl --silent --show-error --retry 5"
-      OUTPUT_FILE="get-pip.py"
-      \${CURL_CMD} https://bootstrap.pypa.io/get-pip.py > \${OUTPUT_FILE} \
-        || \${CURL_CMD} https://raw.githubusercontent.com/pypa/get-pip/master/get-pip.py > \${OUTPUT_FILE}
-      GETPIP_OPTIONS="pip setuptools wheel --constraint rpc-gating/constraints.txt"
-      \${VENV_PYTHON} \${OUTPUT_FILE} \${GETPIP_OPTIONS} \
-        || \${VENV_PYTHON} \${OUTPUT_FILE} --isolated \${GETPIP_OPTIONS}
-    fi
-
-    # Install rpc-gating requirements
-    PIP_OPTIONS="-c rpc-gating/constraints.txt -r rpc-gating/requirements.txt"
-    \${VENV_PIP} install \${PIP_OPTIONS} \
-      || \${VENV_PIP} install --isolated \${PIP_OPTIONS}
   """
 }
 
-def install_ansible_roles(){
-  print "install_ansible_roles"
-  sh """#!/bin/bash -xe
-    cd ${env.WORKSPACE}
-    . .venv/bin/activate
-    mkdir -p rpc-gating/playbooks/roles
-    ansible-galaxy install -r rpc-gating/role_requirements.yml -p rpc-gating/playbooks/roles
-  """
-}
-
-// Install ansible on a jenkins slave
-def install_ansible(){
-  create_workspace_venv()
-  install_ansible_roles()
-}
 
 /* Run ansible-playbooks within a venev
  * Sadly the standard ansibleplaybook step doesn't allow specifying a custom

--- a/pipeline_steps/github.groovy
+++ b/pipeline_steps/github.groovy
@@ -13,7 +13,7 @@ def create_issue(
   ]){
     sh """#!/bin/bash -xe
       cd ${env.WORKSPACE}
-      . .venv/bin/activate
+      set +x; . .venv/bin/activate; set -x
       python rpc-gating/scripts/ghutils.py\
         --org '$org'\
         --repo '$repo'\
@@ -58,7 +58,7 @@ void add_issue_url_to_pr(upstream="upstream"){
   ]){
     sh """#!/bin/bash -xe
       cd $env.WORKSPACE
-      . .venv/bin/activate
+      set +x; . .venv/bin/activate; set -x
       python rpc-gating/scripts/ghutils.py\
         --org '$org'\
         --repo '$repo'\

--- a/pipeline_steps/horizon.groovy
+++ b/pipeline_steps/horizon.groovy
@@ -33,7 +33,7 @@ def mitaka_prep() {
         pip install virtualenv
         virtualenv .venv
     fi
-    source .venv/bin/activate
+    set +x; source .venv/bin/activate; set -x
 
     mv ~/.pip/pip.conf ~/.pip/pip.conf.bak
     pip install selenium==2.53.1
@@ -62,7 +62,7 @@ def mitaka_tests(){
         set -x
 
         # Run Horizon tests
-        source .venv/bin/activate
+        set +x; source .venv/bin/activate; set -x
         export TMP_CONF="/tmp/\${BUILD_TAG}_horizon_conf"
         mv openstack_dashboard/test/integration_tests/horizon.conf \$TMP_CONF
         export HORIZON_INTEGRATION_TESTS_CONFIG_FILE=\$TMP_CONF

--- a/pipeline_steps/kibana.groovy
+++ b/pipeline_steps/kibana.groovy
@@ -30,7 +30,7 @@ def kibana_prep(branch){
           pip install virtualenv
           virtualenv .venv
       fi
-      source .venv/bin/activate
+      set +x; source .venv/bin/activate; set -x
       if [ -f ~/.pip/pip.conf ]; then
         mv ~/.pip/pip.conf ~/.pip/pip.conf.bak
         pip install -r requirements.txt
@@ -47,7 +47,7 @@ def kibana_tests(branch){
     dir("kibana-selenium") {
       git url: env.KIBANA_SELENIUM_REPO, branch: "${branch}"
       sh """#!/bin/bash
-        source .venv/bin/activate
+        set +x; source .venv/bin/activate; set -x
         export PYTHONPATH=\$(pwd)
         export PATH=\$PATH:./phantomjs-2.1.1-linux-x86_64/bin
         # Remove any existing screenshots from old runs

--- a/pipeline_steps/maas.groovy
+++ b/pipeline_steps/maas.groovy
@@ -93,7 +93,7 @@ def maas_utils(List args){
     return sh (
       script: """#!/bin/bash
         cd ${env.WORKSPACE}/rpc-gating/scripts
-        . ${env.WORKSPACE}/.venv/bin/activate
+        set +x; . ${env.WORKSPACE}/.venv/bin/activate; set -x
         ./maasutils.py --username ${env.PUBCLOUD_USERNAME} --api-key ${env.PUBCLOUD_API_KEY} ${args.join(" ")}
       """,
       returnStdout: true

--- a/pipeline_steps/ssh_slave.groovy
+++ b/pipeline_steps/ssh_slave.groovy
@@ -67,7 +67,7 @@ def destroy(slave_name){
           dir("rpc-gating/scripts"){
             retry(5) {
               sh """
-                . ${env.WORKSPACE}/.venv/bin/activate
+                set +x; . ${env.WORKSPACE}/.venv/bin/activate; set +x
                 python jenkins_node.py \
                   delete --name "${slave_name}"
               """

--- a/playbooks/setup_jenkins_slave.yml
+++ b/playbooks/setup_jenkins_slave.yml
@@ -122,7 +122,7 @@
       delegate_to: localhost
       shell: |
         cd  {{ lookup('env', 'WORKSPACE') }}
-        . .venv/bin/activate
+        set +x; . .venv/bin/activate; set -x
         python rpc-gating/scripts/jenkins_node.py \
           create \
           --name {{inventory_hostname}} \

--- a/rpc_jobs/build_gating_venv.yml
+++ b/rpc_jobs/build_gating_venv.yml
@@ -1,0 +1,43 @@
+- job:
+    name: Build-Gating-Venv
+    project-type: workflow
+    concurrent: false
+    properties:
+      - rpc-gating-github
+    triggers:
+      - github # triggered post merge, not on PR
+    parameters:
+      - rpc_gating_params
+    dsl: |
+      library "rpc-gating@${RPC_GATING_BRANCH}"
+      common.shared_slave(){
+        withCredentials(artifact_build.get_rpc_repo_creds()) {
+          sh """#!/bin/bash -xeu
+            # Tar venv and roles
+            pushd rpc-gating
+              SHA=\$(git rev-parse HEAD)
+            popd
+            archive="rpcgatingvenv_\${SHA}.tbz"
+            find .venv -name \\*.pyc -delete
+            echo "\${PWD}/.venv" > .venv/original_venv_path
+            echo \$SHA > .venv/venv_sha
+            tar cjfp \$archive .venv rpc-gating/playbooks/roles
+
+            # Add ssh host key
+            grep "\${REPO_HOST}" ~/.ssh/known_hosts \
+              || echo "\${REPO_HOST} \$(cat \$REPO_HOST_PUBKEY)" \
+              >> ~/.ssh/known_hosts
+
+            REPO_PATH="/var/www/repo/rpcgating/venvs"
+
+            # Upload generated version
+            scp -i \$REPO_USER_KEY \$archive \$REPO_USER@\$REPO_HOST:\$REPO_PATH
+
+            # Generate index
+            ssh -i \$REPO_USER_KEY \$REPO_USER@\$REPO_HOST "cd \$REPO_PATH; ls -1 *tbz > index"
+
+            # Keep 10 newest archives, remove the rest.
+            ssh -i \$REPO_USER_KEY \$REPO_USER@\$REPO_HOST "cd \$REPO_PATH && ls -t1 *tbz |tail -n +11 |while read f; do echo "'removing \$f'"; rm "'\$f'"; done"
+          """
+        }
+      }

--- a/rpc_jobs/sync_credential_store.yml
+++ b/rpc_jobs/sync_credential_store.yml
@@ -48,7 +48,7 @@
                   if [[ ! -d ".venv" ]]; then
                       virtualenv -p /opt/rh/python27/root/usr/bin/python .venv
                   fi
-                  source .venv/bin/activate
+                  set +x; source .venv/bin/activate; set -x
 
                   pip install ${PIP_PWSAFE_LOCATION}
                   pip install functools32


### PR DESCRIPTION
RPC-Gating currently builds a venv in the workspace of every node
that is used as part of a job. This is useful as we can rely on the
right version of various tools to be available, however it is network
intensive and slow. This commit reduces the time taken by using a pre
built venv when one is available.

* Adds a job to build a tar containing the rpc-gating venv and ansible
  roles. This tar is pushed to rpc-repo, and named with the SHA of
  rpc-gating it was built with. The most recent ten tars are kept.
  This job is triggered by pushes to rpc-gating, so new versions
  will automatically built as changes are merged.

* Adds functionality to common.install_ansible to check for a venv tar
  if one exists, it is downloaded, expanded and fixed. Otherwise the
  venv is built locally.

  Jobs won't be blocked between a change merging and the venv tar being
  available on the repo servers, as they will fall back to creating the
  venv locally.

Issue: [RE-103](https://rpc-openstack.atlassian.net/browse/RE-103)