### PR TITLE
Require pubcloud_multiuse label for shared_slave

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -596,7 +596,7 @@ void use_node(label=null, body){
 //shortcut functions for a shared slave or internal shared slave
 
 void shared_slave(body){
-  use_node(body)
+  use_node("pubcloud_multiuse", body)
 }
 
 void internal_slave(body){


### PR DESCRIPTION
This allows us to avoid the CentOS slave, even when puppet sets it back to "Use as much as possible". CentOS slaves may be allocated using `internal_slave()`