### PR TITLE
Increase instance age limit to 24 hours

### DIFF
--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -4,7 +4,7 @@
     parameters:
       - string:
           name: "INSTANCE_AGE_LIMIT"
-          default: "12"
+          default: "24"
           description: |
             Hours. Instances older than this will be removed.
       - string:


### PR DESCRIPTION
12 Hours is too short for debugging mnaio issues.