### PR TITLE
RE-136 Pin openstack-ansible-ops repo

### DIFF
--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -69,7 +69,7 @@
           default: https://github.com/openstack/openstack-ansible-ops
       - string:
           name: OSA_OPS_BRANCH
-          default: master
+          default: b291961361c6f3a3921ca55f73cef36211876f1a
       - string:
           name: DEFAULT_IMAGE
           default: "{DEFAULT_IMAGE}"


### PR DESCRIPTION
The MNAIO tooling we use for multi-node tests is
currently using the head of the openstack-ansible-ops
repo, so any patch upstream could break our tests.

This patch sets the branch to use to the current
head of master's SHA.

Issue: [RE-136](https://rpc-openstack.atlassian.net/browse/RE-136)