### PR TITLE
RE-142 Fix Merge-Trigger-JJB job

### DIFF
--- a/rpc_jobs/jjb_setup.yml
+++ b/rpc_jobs/jjb_setup.yml
@@ -11,6 +11,8 @@
       daysToKeep: 14
     properties:
       - rpc-gating-github
+    parameters:
+      - rpc_gating_params
     triggers:
       - github # triggered post merge, not on PR
     dsl: |


### PR DESCRIPTION
05ab12c9ad4bce1e67563548068a1fd6926d2fd1 has introduced a bug. The
parameter `RPC_GATING_BRANCH` is required but undefined. This commit
adds `rpc_gating_params` from the params file which includes the
required variable.

Issue: [RE-142](https://rpc-openstack.atlassian.net/browse/RE-142)