### PR TITLE
RE-143 Separate Clone and checkout steps

### DIFF
--- a/pipeline_steps/multi_node_aio_prepare.groovy
+++ b/pipeline_steps/multi_node_aio_prepare.groovy
@@ -88,7 +88,8 @@ def prepare() {
       }
       String osa_commit = common.get_current_git_sha("/opt/rpc-openstack/openstack-ansible")
       dir("openstack-ansible-ops") {
-        git url: env.OSA_OPS_REPO, branch: env.OSA_OPS_BRANCH
+        git url: env.OSA_OPS_REPO, branch: "master"
+        sh "git checkout ${env.OSA_OPS_BRANCH}"
       }
       dir("openstack-ansible-ops/${env.MULTI_NODE_AIO_DIR}") {
         timeout(time: 45, unit: "MINUTES") {


### PR DESCRIPTION
A repo can only be cloned at a ref that has been fetched, as there
is no tag for the SHA we are using, it can't be fetched directly.

This commit clones master, then checks out the required SHA as a
second step.

Issue: [RE-143](https://rpc-openstack.atlassian.net/browse/RE-143)