### PR TITLE
RE-145 Move mnaio params to params.yml

### DIFF
--- a/rpc_jobs/hardening.yml
+++ b/rpc_jobs/hardening.yml
@@ -35,6 +35,8 @@
       - osa_ops_params:
           DEFAULT_IMAGE: "{DEFAULT_IMAGE}"
           DATA_DISK_DEVICE: "sdb"
+          COMPUTE_NODES: "{COMPUTE_NODES}"
+          VOLUME_NODES: "{VOLUME_NODES}"
       - text:
           name: "USER_VARS"
           default: "{USER_VARS}"

--- a/rpc_jobs/hw_multi_node_aio.yml
+++ b/rpc_jobs/hw_multi_node_aio.yml
@@ -49,6 +49,8 @@
       - osa_ops_params:
           DEFAULT_IMAGE: "{DEFAULT_IMAGE}"
           DATA_DISK_DEVICE: "mapper/lxc-aio"
+          COMPUTE_NODES: "{COMPUTE_NODES}"
+          VOLUME_NODES: "{VOLUME_NODES}"
       - rpc_repo_params:
           RPC_BRANCH: "{branch}"
       - string:

--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -208,6 +208,8 @@
       - osa_ops_params:
           DEFAULT_IMAGE: "{DEFAULT_IMAGE}"
           DATA_DISK_DEVICE: "sdb"
+          COMPUTE_NODES: "{COMPUTE_NODES}"
+          VOLUME_NODES: "{VOLUME_NODES}"
       - rpc_deploy_params:
           DEPLOY_SWIFT: "{DEPLOY_SWIFT}"
           DEPLOY_CEPH: "{DEPLOY_CEPH}"
@@ -246,14 +248,6 @@
           GENERATE_TEST_NETWORKS: "{GENERATE_TEST_NETWORKS}"
           GENERATE_TEST_SERVERS: "{GENERATE_TEST_SERVERS}"
           GENERATE_TEST_VOLUMES: "{GENERATE_TEST_VOLUMES}"
-      - string:
-          name: "COMPUTE_NODES"
-          default: "{COMPUTE_NODES}"
-          description: "The number of compute nodes to deploy."
-      - string:
-          name: "VOLUME_NODES"
-          default: "{VOLUME_NODES}"
-          description: "The number of volume nodes to deploy."
 
     dsl: |
       library "rpc-gating@${{RPC_GATING_BRANCH}}"

--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -94,6 +94,14 @@
             Options:
               multi-node-aio
               multi-node-aio-xenial-ansible
+      - string:
+          name: "COMPUTE_NODES"
+          default: "{COMPUTE_NODES}"
+          description: "The number of compute nodes to deploy."
+      - string:
+          name: "VOLUME_NODES"
+          default: "{VOLUME_NODES}"
+          description: "The number of volume nodes to deploy."
 
 - parameter:
     name: rpc_deploy_params


### PR DESCRIPTION
Currently, jobs that use pipeline_steps/multi_node_aio_prepare.groovy
are failing if they do not have the COMPUTE_NODES and VOLUME_NODES
parameters defined.  Since these parameters are necessary for anything
using pipeline_steps/multi_node_aio_prepare.groovy, we add the params
to rpc_jobs/params.yml instead.

Issue: [RE-145](https://rpc-openstack.atlassian.net/browse/RE-145)