### PR TITLE
RE-148 Remove newton-14.0 branch from gating

### DIFF
--- a/rpc_jobs/hw_multi_node_aio.yml
+++ b/rpc_jobs/hw_multi_node_aio.yml
@@ -6,7 +6,7 @@
       - mitaka:
           branch: mitaka-13.1
       - newton:
-          branch: newton-14.0
+          branch: newton-14.1
       - master:
           branch: master
     context:

--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -22,11 +22,6 @@
           SERIES_USER_VARS: |
             tempest_test_sets: 'scenario defcore api heat_api smoke'
           DEPLOY_TELEGRAF: "yes"
-      - newton140:
-          branch: newton-14.0
-          SERIES_USER_VARS: |
-            tempest_test_sets: 'all'
-          DEPLOY_TELEGRAF: "yes"
       - newton141:
           branch: newton-14.1
           SERIES_USER_VARS: |
@@ -111,8 +106,6 @@
       - series: liberty
         action: leapfrogupgrade
       - series: mitaka
-        action: leapfrogupgrade
-      - series: newton140
         action: leapfrogupgrade
       - series: master
         action: leapfrogupgrade

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -14,10 +14,6 @@
           branch: mitaka-13.1
           branches: "mitaka-.*"
           UPGRADE_FROM_REF: "liberty-12.2"
-      - newton140:
-          branch: newton-14.0
-          branches: "newton-14.0.*"
-          DEPLOY_TELEGRAF: "yes"
       - newton141:
           branch: newton-14.1
           branches: "newton-14.1.*"
@@ -67,7 +63,7 @@
       - minorupgrade:
           ACTION_STAGES: >-
             Minor Upgrade
-          UPGRADE_FROM_REF: "newton-14.0"
+          UPGRADE_FROM_REF: "r14.0.1"
     scenario:
       - swift
       - ceph:
@@ -96,7 +92,7 @@
           DEPLOY_SUPPORT_ROLE: "yes"
     exclude:
       # Minor upgrades are only being executed
-      # for newton140->newton141 for now until
+      # for r14.0.1->newton141 for now until
       # the minor upgrade testing process is
       # stabilised.
       - series: kilo
@@ -104,8 +100,6 @@
       - series: liberty
         action: minorupgrade
       - series: mitaka
-        action: minorupgrade
-      - series: newton140
         action: minorupgrade
       - series: master
         action: minorupgrade
@@ -115,8 +109,6 @@
       - series: kilo
         action: majorupgrade
       - series: liberty
-        action: majorupgrade
-      - series: newton140
         action: majorupgrade
       - series: newton141
         action: majorupgrade
@@ -137,8 +129,6 @@
       - series: liberty
         action: leapfrogupgrade
       - series: mitaka
-        action: leapfrogupgrade
-      - series: newton140
         action: leapfrogupgrade
       - series: master
         action: leapfrogupgrade
@@ -164,8 +154,6 @@
       # scenario for newton onwards, but it will only
       # consume the cluster, not deploy it. At that
       # time the scenario can be added back again.
-      - series: newton140
-        scenario: ceph
       - series: newton141
         scenario: ceph
       # Ceph builds are not tested for leapfrog upgrades


### PR DESCRIPTION
The newton-14.0 branch for rpc-openstack has been
removed, so the jenkins jobs for it should also be
removed.

Issue: [RE-148](https://rpc-openstack.atlassian.net/browse/RE-148)