### PR TITLE
RE-156 Checkout UPGRADE_FROM_REF on minor upgrade

### DIFF
--- a/pipeline_steps/aio_prepare.groovy
+++ b/pipeline_steps/aio_prepare.groovy
@@ -2,7 +2,9 @@ def prepare(){
   common.conditionalStage(
     stage_name: "Prepare Deployment",
     stage: {
-      if (env.STAGES.contains("Major Upgrade") || env.STAGES.contains("Leapfrog Upgrade")) {
+      if (env.STAGES.contains("Minor Upgrade")
+          || env.STAGES.contains("Major Upgrade")
+          || env.STAGES.contains("Leapfrog Upgrade")) {
         common.prepareRpcGit(env.UPGRADE_FROM_REF)
       } else {
         common.prepareRpcGit()


### PR DESCRIPTION
Currently, when we do a minor upgrade the initial checkout is of the
current branch, and not UPGRADE_FROM_REF.

Issue: [RE-156](https://rpc-openstack.atlassian.net/browse/RE-156)