### PR TITLE
RE-157 Allow prepareRpcGit() to figure out branch

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -304,13 +304,7 @@
             // We need to checkout the rpc-openstack repo on the CIT Slave
             // so that we can check whether the patch is a docs-only patch
             // before allocating resources unnecessarily.
-            if (env.STAGES.contains("Minor Upgrade")
-                || env.STAGES.contains("Major Upgrade")
-                || env.STAGES.contains("Leapfrog Upgrade")) {{
-              common.prepareRpcGit(env.UPGRADE_FROM_REF, env.WORKSPACE)
-            }} else {{
-              common.prepareRpcGit("auto", env.WORKSPACE)
-            }}
+            common.prepareRpcGit("auto", env.WORKSPACE)
             if(common.is_doc_update_pr("${{env.WORKSPACE}}/rpc-openstack")){{
               return
             }}


### PR DESCRIPTION
Currently, if we're running an upgrade job, we run prepareRpcGit()
using UPGRADE_FROM_REF, which isn't correct.  This means we're
actually not running is_doc_update_pr() against the checkout for the PR
that triggered the job.

Issue: [RE-157](https://rpc-openstack.atlassian.net/browse/RE-157)