### PR TITLE
[WIP] Expand UPGRADE_FROM_REF

### DIFF
--- a/pipeline_steps/aio_prepare.groovy
+++ b/pipeline_steps/aio_prepare.groovy
@@ -2,7 +2,9 @@ def prepare(){
   common.conditionalStage(
     stage_name: "Prepare Deployment",
     stage: {
-      if (env.STAGES.contains("Major Upgrade") || env.STAGES.contains("Leapfrog Upgrade")) {
+      if (env.STAGES.contains("Minor Upgrade")
+          || env.STAGES.contains("Major Upgrade")
+          || env.STAGES.contains("Leapfrog Upgrade")) {
         common.prepareRpcGit(env.UPGRADE_FROM_REF)
       } else {
         common.prepareRpcGit()

--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -22,6 +22,15 @@
           SERIES_USER_VARS: |
             tempest_test_sets: 'scenario defcore api heat_api smoke'
           DEPLOY_TELEGRAF: "yes"
+      - newton:
+          branch: newton
+          SERIES_USER_VARS: |
+            tempest_test_sets: 'all'
+            lxc_container_vg_name: "USE_DIR_NOT_VG"
+            glance_default_store: "swift"
+            neutron_legacy_ha_tool_enabled: true
+          UPGRADE_FROM_REF: "kilo"
+          DEPLOY_TELEGRAF: "yes"
       - newton141:
           branch: newton-14.1
           SERIES_USER_VARS: |

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -14,6 +14,11 @@
           branch: mitaka-13.1
           branches: "mitaka-.*"
           UPGRADE_FROM_REF: "liberty-12.2"
+      - newton:
+          branch: newton
+          branches: "newton"
+          UPGRADE_FROM_REF: "kilo"
+          DEPLOY_TELEGRAF: "yes"
       - newton141:
           branch: newton-14.1
           branches: "newton-14.1.*"
@@ -63,6 +68,9 @@
       - minorupgrade:
           ACTION_STAGES: >-
             Minor Upgrade
+          # NOTE: Once the newton stabilization branch has been created
+          #       (newton-14.2 or similar), we'll need to find a way to
+          #       set this differently depending on the newton series.
           UPGRADE_FROM_REF: "r14.0.1"
     scenario:
       - swift
@@ -110,6 +118,8 @@
         action: majorupgrade
       - series: liberty
         action: majorupgrade
+      - series: newton
+        action: majorupgrade
       - series: newton141
         action: majorupgrade
       - series: master
@@ -154,6 +164,8 @@
       # scenario for newton onwards, but it will only
       # consume the cluster, not deploy it. At that
       # time the scenario can be added back again.
+      - series: newton
+        scenario: ceph
       - series: newton141
         scenario: ceph
       # Ceph builds are not tested for leapfrog upgrades

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -304,13 +304,7 @@
             // We need to checkout the rpc-openstack repo on the CIT Slave
             // so that we can check whether the patch is a docs-only patch
             // before allocating resources unnecessarily.
-            if (env.STAGES.contains("Minor Upgrade")
-                || env.STAGES.contains("Major Upgrade")
-                || env.STAGES.contains("Leapfrog Upgrade")) {{
-              common.prepareRpcGit(env.UPGRADE_FROM_REF, env.WORKSPACE)
-            }} else {{
-              common.prepareRpcGit("auto", env.WORKSPACE)
-            }}
+            common.prepareRpcGit("auto", env.WORKSPACE)
             if(common.is_doc_update_pr("${{env.WORKSPACE}}/rpc-openstack")){{
               return
             }}

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -13,16 +13,19 @@
       - mitaka:
           branch: mitaka-13.1
           branches: "mitaka-.*"
-          UPGRADE_FROM_REF: "liberty-12.2"
+          MAJOR_UPGRADE_FROM_REF: "liberty-12.2"
       - newton:
           branch: newton
           branches: "newton"
-          UPGRADE_FROM_REF: "kilo"
+          LEAPFROG_UPGRADE_FROM_REF: "kilo"
+          # NOTE: This branch is TBD
+          MINOR_UPGRADE_FROM_REF: "newton-14.2"
           DEPLOY_TELEGRAF: "yes"
       - newton141:
           branch: newton-14.1
           branches: "newton-14.1.*"
-          UPGRADE_FROM_REF: "kilo"
+          LEAPFROG_UPGRADE_FROM_REF: "kilo"
+          MINOR_UPGRADE_FROM_REF: "r14.0.1"
           DEPLOY_TELEGRAF: "yes"
       - master:
           branch: master
@@ -68,10 +71,6 @@
       - minorupgrade:
           ACTION_STAGES: >-
             Minor Upgrade
-          # NOTE: Once the newton stabilization branch has been created
-          #       (newton-14.2 or similar), we'll need to find a way to
-          #       set this differently depending on the newton series.
-          UPGRADE_FROM_REF: "r14.0.1"
     scenario:
       - swift
       - ceph:
@@ -295,24 +294,31 @@
           try {{
             // This sets kibana_branch based on STAGES
             // Note that we do this before the block below since
-            // env.UPGRADE_FROM_ENV gets overwritten
-            if (env.STAGES.contains("Minor Upgrade")
-                || env.STAGES.contains("Major Upgrade")
-                || env.STAGES.contains("Leapfrog Upgrade")) {{
-              kibana_branch = env.UPGRADE_FROM_REF
+            // env.UPGRADE_FROM_ENV may get overwritten
+            if (env.STAGES.contains("Minor Upgrade")) {{
+              env.UPGRADE_FROM_REF = env.MINOR_UPGRADE_FROM_REF
+              kibana_branch        = env.MINOR_UPGRADE_FROM_REF
+            }} else if (env.STAGES.contains("Major Upgrade")) {{
+              env.UPGRADE_FROM_REF = env.MAJOR_UPGRADE_FROM_REF
+              kibana_branch        = env.MAJOR_UPGRADE_FROM_REF
+            }} else if (env.STAGES.contains("Leapfrog Upgrade")) {{
+              env.UPGRADE_FROM_REF = env.LEAPFROG_UPGRADE_FROM_REF
+              kibana_branch        = env.LEAPFROG_UPGRADE_FROM_REF
             }} else {{
               kibana_branch = env.KIBANA_SELENIUM_BRANCH
             }}
+
             // prepare vars for leapfrog upgrade test of changes proposed to kilo
             // this is a special case as we only usually test upgrades on
             // changes to the destination branch.
             if (env.SERIES == "kilo"
                 && env.TRIGGER == "pr"
                 && env.ACTION == "leapfrogupgrade" ){{
-                env.UPGRADE_FROM_REF="origin/pr/${{env.ghprbPullId}}/merge"
-                kibana_branch = "kilo"
-                env.KIBANA_SELENIUM_BRANCH="newton-14.1"
+              env.UPGRADE_FROM_REF       = "origin/pr/${{env.ghprbPullId}}/merge"
+              kibana_branch              = "kilo"
+              env.KIBANA_SELENIUM_BRANCH = "newton-14.1"
             }}
+
             // We need to checkout the rpc-openstack repo on the CIT Slave
             // so that we can check whether the patch is a docs-only patch
             // before allocating resources unnecessarily.
@@ -320,6 +326,7 @@
             if(common.is_doc_update_pr("${{env.WORKSPACE}}/rpc-openstack")){{
               return
             }}
+
             // Adds maas token and url to environment
             // without adding another level of nesting
             maas.add_maas_env_vars()


### PR DESCRIPTION
The newton-14.1 branch, for example, can do a minor upgrade and a
leapfrog upgrade.  Having a single UPGRADE_FROM_REF makes it difficult
to correctly set the required initial branch.

This commit adds {MAJOR,MINOR,LEAPFROG}_UPGRADE_FROM_REF and sets
UPGRADE_FROM_REF to the relevant value depending on the action.

Issue: newton-14