### PR TITLE
RE-133 Convert allocation stages into steps

### DIFF
--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -68,9 +68,9 @@ def cleanup(Map args){
 
 
 def getPubCloudSlave(Map args){
-  common.conditionalStage(
-    stage_name: 'Allocate Resources',
-    stage: {
+  common.conditionalStep(
+    step_name: 'Allocate Resources',
+    step: {
       create (
         name: args.instance_name,
         count: 1,
@@ -79,8 +79,8 @@ def getPubCloudSlave(Map args){
         image: env.IMAGE,
         keyname: "jenkins",
       )
-    } //stage
-  ) //conditionalStages
+    } //step
+  ) //conditionalsteps
   ssh_slave.connect()
 }
 def delPubCloudSlave(Map args){
@@ -98,8 +98,8 @@ def delPubCloudSlave(Map args){
         server_name:  args.instance_name,
         region: env.REGION,
       )
-    } //stage
-  ) //conditionalStage
+    } //step
+  ) //conditionalstep
   ssh_slave.destroy(args.instance_name)
 }
 

--- a/pipeline_steps/ssh_slave.groovy
+++ b/pipeline_steps/ssh_slave.groovy
@@ -17,9 +17,9 @@
  *  - playbooks/inventory/hosts
  */
 def connect(port=22){
-  common.conditionalStage(
-    stage_name: "Connect Slave",
-    stage: {
+  common.conditionalStep(
+    step_name: "Connect Slave",
+    step: {
       common.internal_slave(){
         withCredentials([
           file(


### PR DESCRIPTION
Stages should be used for organising a job, jenkins internals
(such as allocating instances) should not be exposed as stages.

This is important because nested stages are not well supported, though
work is in progress to improve that for blue ocean.

Issue: [RE-133](https://rpc-openstack.atlassian.net/browse/RE-133)