### PR TITLE
RE-151 Set artifact jobs for all newton branches

### DIFF
--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -7,8 +7,8 @@
           branch: master
           branches: "master"
       - newton:
-          branch: newton-14.1
-          branches: "newton-14.1.*"
+          branch: newton
+          branches: "newton.*"
     ztrigger:
       - pr:
           CRON: ""


### PR DESCRIPTION
Currently only the newton-14.1 branch is used.
This patch sets it to work with any branch
prefixed with the word 'newton' to cover the
mainline development branch and the 'newton-rc'
branch.

Issue: [RE-151](https://rpc-openstack.atlassian.net/browse/RE-151)