### PR TITLE
RE-133 Make runonpubcloud take an image parameter

### DIFF
--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -1,43 +1,3 @@
-/* Create public cloud node
- * Params:
- *  - region: Rax region to build in
- *  - name: Name of instance to build
- *  - count: Number of instances to build
- *  - flavor: Flavor to build
- *  - image: Image to build from
- *  - keyname: Name of existing nova keypair
- * Environment Variables:
- *  - WORKSPACE
- */
-def create(Map args){
-  withEnv(["RAX_REGION=${args.region}"]){
-    withCredentials(common.get_cloud_creds()){
-      dir("rpc-gating/playbooks"){
-        pyrax_cfg = common.writePyraxCfg(
-          username: env.PUBCLOUD_USERNAME,
-          api_key: env.PUBCLOUD_API_KEY
-        )
-        withEnv(["RAX_CREDS_FILE=${pyrax_cfg}"]){
-          common.venvPlaybook(
-            playbooks: ["allocate_pubcloud.yml",
-                        "drop_ssh_auth_keys.yml"],
-            args: [
-              "-i inventory",
-              "--private-key=\"${env.JENKINS_SSH_PRIVKEY}\""
-            ],
-            vars: args
-          )
-        }
-        stash (
-          name: "pubcloud_inventory",
-          include: "inventory/hosts"
-        )
-      }
-    }
-  }
-}
-
-
 /* Remove public cloud instances
  */
 def cleanup(Map args){
@@ -54,11 +14,7 @@ def cleanup(Map args){
             args: [
               "--private-key=\"${env.JENKINS_SSH_PRIVKEY}\"",
             ],
-            vars: [
-              "instance_name": args.instance_name,
-              "server_name": args.server_name,
-              "region": args.region
-            ]
+            vars: args
           )
         } // withEnv
       } // directory
@@ -67,22 +23,50 @@ def cleanup(Map args){
 } //call
 
 
+/* Create public cloud node
+ * Params:
+ *  - region: Rax region to build in
+ *  - instance_name: Name of instance to build
+ *  - flavor: Flavor to build
+ *  - image: Image to build from
+ * Environment Variables:
+ *  - WORKSPACE
+ * The args required can be supplied uppercase in the env dictionary, or lower
+ * case as direct arguments.
+ */
 def getPubCloudSlave(Map args){
   common.conditionalStep(
     step_name: 'Allocate Resources',
     step: {
-      create (
-        name: args.instance_name,
-        count: 1,
-        region: env.REGION,
-        flavor: env.FLAVOR,
-        image: env.IMAGE,
-        keyname: "jenkins",
-      )
-    } //step
-  ) //conditionalsteps
+      add_instance_env_params_to_args(args)
+      env.RAX_REGION = args.region
+      withCredentials(common.get_cloud_creds()){
+        dir("rpc-gating/playbooks"){
+          pyrax_cfg = common.writePyraxCfg(
+            username: env.PUBCLOUD_USERNAME,
+            api_key: env.PUBCLOUD_API_KEY
+          )
+          env.RAX_CREDS_FILE = pyrax_cfg
+          common.venvPlaybook(
+            playbooks: ["allocate_pubcloud.yml",
+                        "drop_ssh_auth_keys.yml"],
+            args: [
+              "-i inventory",
+              "--private-key=\"${env.JENKINS_SSH_PRIVKEY}\""
+            ],
+            vars: args
+          )
+          stash (
+            name: "pubcloud_inventory",
+            include: "inventory/hosts"
+          )
+        }
+      }
+    }
+  )
   ssh_slave.connect()
 }
+
 def delPubCloudSlave(Map args){
   common.conditionalStep(
     step_name: "Pause",
@@ -98,16 +82,46 @@ def delPubCloudSlave(Map args){
         server_name:  args.instance_name,
         region: env.REGION,
       )
-    } //step
-  ) //conditionalstep
+    }
+  )
   ssh_slave.destroy(args.instance_name)
 }
 
-/* One func entrypoint to run a script on a single use slave */
-def runonpubcloud(body){
+// if the instance params are set in the environment
+// but not passed as args, add them to the args.
+// nothing is returned as "args" is passed by ref.
+// env vars are upper case while args are lower case
+void add_instance_env_params_to_args(Map args){
+  instance_params=[
+    'flavor',
+    'image',
+    'region'
+  ]
+  for (p in instance_params){
+    if (!(p in args)){
+      P = p.toUpperCase()
+      if (env[P] != null){
+        args[p] = env[P]
+        print ("${p} not supplied to runonpubcloud or getPubCloudSlave"
+               + " using env var ${P}=${env[P]} instead.")
+      } else {
+        throw new Exception(
+          "Missing required param for building an instance."
+          + " Couldn't find value for ${p} in args or environment.")
+      }
+    }
+  }
+}
+
+/* One func entrypoint to run a script on a single use slave.
+The args required are shown in allocate_pubcloud.yml, they can
+be supplied uppercase in the env dictionary, or lower case as
+direct arguments. */
+def runonpubcloud(Map args=[:], body){
+  add_instance_env_params_to_args(args)
   instance_name = common.gen_instance_name()
   try{
-    getPubCloudSlave(instance_name: instance_name)
+    getPubCloudSlave(args + [instance_name: instance_name])
     common.use_node(instance_name){
       body()
     }

--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -2,15 +2,17 @@
 - hosts: localhost
   connection: local
   gather_facts: False
+  vars:
+    count: 1
   tasks:
     - name: Provision a set of public cloud instances
       local_action:
           module: rax
-          name: "{{ name }}"
+          name: "{{ instance_name }}"
           flavor: "{{ flavor }}"
           image: "{{ image }}"
           count: "{{ count }}"
-          key_name: "{{ keyname }}"
+          key_name: "jenkins"
           region: "{{ region }}"
           wait: yes
           wait_timeout: 900


### PR DESCRIPTION
* Removes pubcloud.create as its only used once
* Allows instance creation params to be supplied by environment
  or argument.
* Hard codes keyname and count, as they weren't fully exposed previously
  and may cause problems if changed.

Issue: [RE-133](https://rpc-openstack.atlassian.net/browse/RE-133)