### PR TITLE
RE-133 Pass image param to runonpubcloud

### DIFF
--- a/pipeline_steps/artifact_build.groovy
+++ b/pipeline_steps/artifact_build.groovy
@@ -43,8 +43,7 @@ def apt() {
 }
 
 def git(String image) {
-  env.IMAGE = image
-  pubcloud.runonpubcloud() {
+  pubcloud.runonpubcloud(image: image) {
     try {
       withCredentials(get_rpc_repo_creds()) {
         common.prepareRpcGit()
@@ -66,8 +65,7 @@ def git(String image) {
 }
 
 def python(String image) {
-  env.IMAGE = image
-  pubcloud.runonpubcloud() {
+  pubcloud.runonpubcloud(image: image) {
     try {
       withCredentials(get_rpc_repo_creds()) {
         common.prepareRpcGit()
@@ -89,8 +87,7 @@ def python(String image) {
 }
 
 def container(String image) {
-  env.IMAGE = image
-  pubcloud.runonpubcloud() {
+  pubcloud.runonpubcloud(image: image) {
     try {
       withCredentials(get_rpc_repo_creds()) {
         common.prepareRpcGit()


### PR DESCRIPTION
In #370 the runonpubcloud function was modified to take an image
parameter as we need to use different images in parallel. However
the artifact build groovy functions were not updated to supply the image
parameter and will still setting the image env var instead.

Setting the env var causes problems with parallelism as the env
is shared between parallel branches.

Issue: [RE-133](https://rpc-openstack.atlassian.net/browse/RE-133)