### PR TITLE
RE-133 Ensure variables are typed/scoped

### DIFF
--- a/pipeline_steps/aio_prepare.groovy
+++ b/pipeline_steps/aio_prepare.groovy
@@ -25,7 +25,7 @@ def prepare(){
         }
       }
       // If this branch can prepare its own configs, common.prepareConfigs
-      config_cap_file="/opt/rpc-openstack/gating/capabilities/aio_config"
+      String config_cap_file="/opt/rpc-openstack/gating/capabilities/aio_config"
       if (fileExists(config_cap_file)){
         print ("Skipping rpc-gating config prep (common.prepareConfigs)"
                +" as this is handled in repo."

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -109,9 +109,10 @@ def venvPlaybook(Map args){
       if (!('args' in args)){
         args.args=[]
       }
-      for (def i=0; i<args.playbooks.size(); i++){
-        playbook = args.playbooks[i]
-        vars_file="vars.${playbook.split('/')[-1]}"
+      for (int i=0; i<args.playbooks.size(); i++){
+        String playbook = args.playbooks[i]
+        // randomised vars file path for parallel safety
+        String vars_file="vars.${playbook.split('/')[-1]}.${rand_int_str()}"
         write_json(file: vars_file, obj: args.vars)
         sh """#!/bin/bash -x
           which scl && source /opt/rh/python27/enable

--- a/pipeline_steps/deploy.groovy
+++ b/pipeline_steps/deploy.groovy
@@ -2,11 +2,11 @@ def deploy(){
   common.conditionalStep(
     step_name: "Deploy",
     step: {
-      playbooks = common._parse_json_string(json_text: env.PLAYBOOKS)
+      List playbooks = common._parse_json_string(json_text: env.PLAYBOOKS)
       print(playbooks)
       print(playbooks.size())
       for (def i=0; i<playbooks.size(); i++){
-        playbook = playbooks[i]
+        String playbook = playbooks[i]
         print(playbook)
         stage(playbook.playbook){
           common.openstack_ansible(playbook)
@@ -20,7 +20,8 @@ def deploy_sh(Map args) {
   common.conditionalStage(
     stage_name: "Deploy RPC w/ Script",
     stage: {
-      environment_vars = args.environment_vars + common.get_deploy_script_env()
+      List environment_vars = args.environment_vars \
+                              + common.get_deploy_script_env()
       withCredentials([
         string(
           credentialsId: "INFLUX_IP",
@@ -59,7 +60,7 @@ def upgrade(String stage_name, String upgrade_script, List env_vars,
   common.conditionalStage(
     stage_name: stage_name,
     stage: {
-      environment_vars = env_vars + common.get_deploy_script_env()
+      List environment_vars = env_vars + common.get_deploy_script_env()
       withEnv(environment_vars){
         dir("/opt/rpc-openstack/openstack-ansible"){
           sh "git reset --hard"
@@ -93,7 +94,7 @@ def upgrade_major(Map args) {
 def upgrade_leapfrog(Map args) {
   // for a PR to kilo, we don't want to checkout the PR commit at this point
   // as it's already been used to deploy kilo.
-  branch = "auto"
+  String branch = "auto"
   if (env.SERIES == "kilo" && env.TRIGGER == "pr"){
     branch="newton"
   }

--- a/pipeline_steps/github.groovy
+++ b/pipeline_steps/github.groovy
@@ -1,10 +1,10 @@
 
 def create_issue(
-    tag,
-    link,
-    label="jenkins-build-failure",
-    org="rcbops",
-    repo="u-suk-dev"){
+    String tag,
+    String link,
+    String label="jenkins-build-failure",
+    String org="rcbops",
+    String repo="u-suk-dev"){
   withCredentials([
     string(
       credentialsId: 'rpc-jenkins-svc-github-pat',
@@ -33,7 +33,7 @@ def create_issue(
  * Update the description of the current GitHub pull request with a link to
  * the Jira issue.
  */
-void add_issue_url_to_pr(upstream="upstream"){
+void add_issue_url_to_pr(String upstream="upstream"){
   List org_repo = env.ghprbGhRepository.split("/")
   String org = org_repo[0]
   String repo = org_repo[1]

--- a/pipeline_steps/influx.groovy
+++ b/pipeline_steps/influx.groovy
@@ -1,5 +1,5 @@
 def setup(){
-  instance_name = common.gen_instance_name("influx")
+  String instance_name = common.gen_instance_name("influx")
   pubcloud.getPubCloudSlave(instance_name: instance_name)
   common.override_inventory()
   try{

--- a/pipeline_steps/irr_role_tests.groovy
+++ b/pipeline_steps/irr_role_tests.groovy
@@ -1,6 +1,6 @@
 def run_irr_tests() {
   pubcloud.runonpubcloud {
-    currentBuild.result="SUCCESS"
+    String currentBuild.result="SUCCESS"
     try {
       ansiColor('xterm') {
         dir("${env.WORKSPACE}/${env.ghprbGhRepository}") {

--- a/pipeline_steps/kibana.groovy
+++ b/pipeline_steps/kibana.groovy
@@ -1,4 +1,4 @@
-def kibana(branch){
+def kibana(String branch){
   common.conditionalStage(
     stage_name: "Prepare Kibana Selenium",
     stage: {
@@ -13,7 +13,7 @@ def kibana(branch){
   )
 }
 
-def kibana_prep(branch){
+def kibana_prep(String branch){
   dir("kibana-selenium") {
     git url: env.KIBANA_SELENIUM_REPO, branch: "${branch}"
 
@@ -42,7 +42,7 @@ def kibana_prep(branch){
   }
 }
 
-def kibana_tests(branch){
+def kibana_tests(String branch){
   try {
     dir("kibana-selenium") {
       git url: env.KIBANA_SELENIUM_REPO, branch: "${branch}"

--- a/pipeline_steps/maas.groovy
+++ b/pipeline_steps/maas.groovy
@@ -1,5 +1,5 @@
 String get_mnaio_entity_names() {
-  entities = sh (
+  String entities = sh (
     script: """#!/usr/bin/env python
 from __future__ import print_function
 from itertools import chain
@@ -79,7 +79,7 @@ def verify() {
 void add_maas_env_vars(){
   List vars = get_maas_token_and_url()
   for (def i=0; i<vars.size(); i++){
-    kv = vars[i].split('=')
+    List kv = vars[i].split('=')
     env[kv[0]] = kv[1]
   }
 }

--- a/pipeline_steps/multi_node_aio_prepare.groovy
+++ b/pipeline_steps/multi_node_aio_prepare.groovy
@@ -164,7 +164,7 @@ def connect_deploy_node(name, instance_ip) {
       include: "inventory/hosts"
     )
   }
-  ssh_slave.connect(2222)
+  ssh_slave.connect(port: 2222)
 }
 
 return this;

--- a/pipeline_steps/multi_node_aio_prepare.groovy
+++ b/pipeline_steps/multi_node_aio_prepare.groovy
@@ -151,7 +151,7 @@ EOF
 }
 
 def connect_deploy_node(name, instance_ip) {
-  inventory_content = """
+  String inventory_content = """
   [job_nodes:children]
   hosts
   [hosts]

--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -34,7 +34,7 @@ def cleanup(Map args){
  * The args required can be supplied uppercase in the env dictionary, or lower
  * case as direct arguments.
  */
-def getPubCloudSlave(Map args){
+String getPubCloudSlave(Map args){
   common.conditionalStep(
     step_name: 'Allocate Resources',
     step: {
@@ -92,14 +92,14 @@ def delPubCloudSlave(Map args){
 // nothing is returned as "args" is passed by ref.
 // env vars are upper case while args are lower case
 void add_instance_env_params_to_args(Map args){
-  instance_params=[
+  List instance_params=[
     'flavor',
     'image',
     'region'
   ]
-  for (p in instance_params){
+  for (String p in instance_params){
     if (!(p in args)){
-      P = p.toUpperCase()
+      String P = p.toUpperCase()
       if (env[P] != null){
         args[p] = env[P]
         print ("${p} not supplied to runonpubcloud or getPubCloudSlave"
@@ -119,7 +119,7 @@ be supplied uppercase in the env dictionary, or lower case as
 direct arguments. */
 def runonpubcloud(Map args=[:], body){
   add_instance_env_params_to_args(args)
-  instance_name = common.gen_instance_name()
+  String instance_name = common.gen_instance_name()
   try{
     getPubCloudSlave(args + [instance_name: instance_name])
     common.use_node(instance_name){

--- a/pipeline_steps/ssh_slave.groovy
+++ b/pipeline_steps/ssh_slave.groovy
@@ -16,11 +16,17 @@
  * Files:
  *  - playbooks/inventory/hosts
  */
-def connect(port=22){
+def connect(Map args){
   common.conditionalStep(
     step_name: "Connect Slave",
     step: {
       common.internal_slave(){
+        if (!("inventory" in args)){
+          args.inventory == "inventory"
+        }
+        if (!("port" in args)){
+          args.port = 22
+        }
         withCredentials([
           file(
             credentialsId: 'id_rsa_cloud10_jenkins_file',
@@ -33,13 +39,13 @@ def connect(port=22){
           )
         ]){
           dir("rpc-gating/playbooks"){
-            unstash "pubcloud_inventory"
+            unstash args.inventory
             common.venvPlaybook(
               playbooks: ["setup_jenkins_slave.yml"],
               args: [
-                "-i inventory",
+                "-i ${args.inventory}",
                 "--limit job_nodes",
-                "--extra-vars='ansible_port=${port}'",
+                "--extra-vars='ansible_port=${args.port}'",
                 "--private-key=\"${env.JENKINS_SSH_PRIVKEY}\""
               ]
             )

--- a/pipeline_steps/webhooks.groovy
+++ b/pipeline_steps/webhooks.groovy
@@ -1,5 +1,5 @@
 def webhooks(){
-  instance_name = "WEBHOOK-PROXY"
+  String instance_name = "WEBHOOK-PROXY"
   pubcloud.getPubCloudSlave(instance_name: instance_name)
   common.override_inventory()
   try{
@@ -48,7 +48,7 @@ def webhooks(){
             ) //venvPlaybook
           } //dir
         } //withCredentials
-        ip = readFile file: "instance_address"
+        String ip = readFile file: "instance_address"
        common.use_node("master"){
           withCredentials([
             file(

--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -4,6 +4,7 @@
   gather_facts: False
   vars:
     count: 1
+    inventory_path: '{{lookup("env", "WORKSPACE")}}/rpc-gating/playbooks/inventory'
   tasks:
     - name: Provision a set of public cloud instances
       local_action:
@@ -48,6 +49,11 @@
         msg: "At least one public cloud instance failed to start :("
       when: rax.success|length < count
 
+    - name: Create inventory directory
+      file:
+        path: "{{inventory_path}}"
+        state: directory
+
     - name: Write inventory
       copy:
         content: |
@@ -58,7 +64,7 @@
           {% for instance in rax.success %}
           {{instance.name}} ansible_host={{instance.accessIPv4}} ansible_user=root
           {% endfor %}
-        dest: '{{lookup("env", "WORKSPACE")}}/rpc-gating/playbooks/inventory/hosts'
+        dest: '{{inventory_path}}/hosts'
 
     - name: Wait for SSH to be available on all hosts
       wait_for: port=22 host="{{ item.accessIPv4 }}"

--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -203,14 +203,14 @@
             // necessary due to a race condition when updating the
             // image index.
             // ref: RE-115
-            stage('Container'){{
-              lock('artifact_container'){{
-                for (x in image_list[env.series]){{
-                  def image = x
+            lock('artifact_container'){{
+              for (x in image_list[env.series]){{
+                def image = x
+                stage("Container ${{image}}"){{
                   artifact_build.container(image)
-                }} //for
-              }} //lock
-            }} //stage
+                }} //stage
+              }} //for
+            }} //lock
           }} //if
         }} catch (e) {{
           print e


### PR DESCRIPTION
In groovy untyped variables are almost global. In order to prevent
conflicts when using parallel, when need to ensure all variables are
typed and therefore scoped.

Also adds a random string to the vars file written by the venvplaybook
function to avoid conflicts.

Issue: [RE-133](https://rpc-openstack.atlassian.net/browse/RE-133)