### PR TITLE
Reduce pubcloud build retry count

### DIFF
--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -20,7 +20,7 @@
           auto_increment: no
       register: rax
       until: rax|success
-      retries: 120
+      retries: 5
       delay: 60
 
     - name: Display rax output on failure


### PR DESCRIPTION
We've hit a rate limit in DFW, and having builds retry 120x is
excessive.  This commit drastically reduces to 5 retries to avoid us
exceeding our rate limit.