### PR TITLE
RE-8 Cleanup when job times out

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -276,66 +276,66 @@
       env.TARGET = "aio"
       env.ACTION = "{action}"
       env.SERIES = "{series}"
-      timeout(time: 8, unit: 'HOURS'){{
         common.shared_slave() {{
           try {{
-            // prepare vars for leapfrog upgrade test of changes proposed to kilo
-            // this is a special case as we only usually test upgrades on
-            // changes to the destination branch.
-            if (env.SERIES == "kilo"
-                && env.TRIGGER == "pr"
-                && env.ACTION == "leapfrogupgrade" ){{
-                env.UPGRADE_FROM_REF="origin/pr/${{env.ghprbPullId}}/merge"
-                kibana_branch = "kilo"
-                env.KIBANA_SELENIUM_BRANCH="newton-14.1"
-            }}
-            // We need to checkout the rpc-openstack repo on the CIT Slave
-            // so that we can check whether the patch is a docs-only patch
-            // before allocating resources unnecessarily.
-            common.prepareRpcGit("auto", env.WORKSPACE)
-            if(common.is_doc_update_pr("${{env.WORKSPACE}}/rpc-openstack")){{
-              return
-            }}
-            // Adds maas token and url to environment
-            // without adding another level of nesting
-            maas.add_maas_env_vars()
-            pubcloud.runonpubcloud {{
-              // try within pubcloud node so we can archive archive_artifacts
-              // after a failure, before the node is cleaned up.
-              try {{
-                environment_vars = [
-                  "DEPLOY_HAPROXY=yes",
-                  "DEPLOY_AIO=no",
-                  "DEPLOY_TEMPEST=no",
-                  "DEPLOY_SWIFT=${{DEPLOY_SWIFT}}",
-                  "DEPLOY_CEPH=${{DEPLOY_CEPH}}",
-                  "DEPLOY_ELK=${{DEPLOY_ELK}}",
-                  ]
-                aio_prepare.prepare()
-                deploy.deploy_sh(environment_vars: environment_vars)
-                if (env.STAGES.contains("Minor Upgrade")) {{
-                  deploy.upgrade_minor(environment_vars: environment_vars)
-                }} else if (env.STAGES.contains("Major Upgrade")) {{
-                  deploy.upgrade_major(environment_vars: environment_vars)
-                }} else if (env.STAGES.contains("Leapfrog Upgrade")) {{
-                  deploy.upgrade_leapfrog(environment_vars: environment_vars)
-                }}
-                tempest.tempest()
-                kibana.kibana(env.KIBANA_SELENIUM_BRANCH)
-              }} catch (e) {{
-                print(e)
-                currentBuild.result = 'FAILURE'
-                if (env.TRIGGER == 'periodic'){{
-                  common.create_jira_issue(project="RO")
-                }}
-                throw e
-              }} finally {{
-                common.archive_artifacts()
-                common.safe_jira_comment("${{currentBuild.result}}: [${{env.BUILD_TAG}}|${{env.BUILD_URL}}]")
+            timeout(time: 8, unit: 'HOURS'){{
+              // prepare vars for leapfrog upgrade test of changes proposed to kilo
+              // this is a special case as we only usually test upgrades on
+              // changes to the destination branch.
+              if (env.SERIES == "kilo"
+                  && env.TRIGGER == "pr"
+                  && env.ACTION == "leapfrogupgrade" ){{
+                  env.UPGRADE_FROM_REF="origin/pr/${{env.ghprbPullId}}/merge"
+                  kibana_branch = "kilo"
+                  env.KIBANA_SELENIUM_BRANCH="newton-14.1"
               }}
-            }} //pubcloud slave
+              // We need to checkout the rpc-openstack repo on the CIT Slave
+              // so that we can check whether the patch is a docs-only patch
+              // before allocating resources unnecessarily.
+              common.prepareRpcGit("auto", env.WORKSPACE)
+              if(common.is_doc_update_pr("${{env.WORKSPACE}}/rpc-openstack")){{
+                return
+              }}
+              // Adds maas token and url to environment
+              // without adding another level of nesting
+              maas.add_maas_env_vars()
+              pubcloud.runonpubcloud {{
+                // try within pubcloud node so we can archive archive_artifacts
+                // after a failure, before the node is cleaned up.
+                try {{
+                  environment_vars = [
+                    "DEPLOY_HAPROXY=yes",
+                    "DEPLOY_AIO=no",
+                    "DEPLOY_TEMPEST=no",
+                    "DEPLOY_SWIFT=${{DEPLOY_SWIFT}}",
+                    "DEPLOY_CEPH=${{DEPLOY_CEPH}}",
+                    "DEPLOY_ELK=${{DEPLOY_ELK}}",
+                    ]
+                  aio_prepare.prepare()
+                  deploy.deploy_sh(environment_vars: environment_vars)
+                  if (env.STAGES.contains("Minor Upgrade")) {{
+                    deploy.upgrade_minor(environment_vars: environment_vars)
+                  }} else if (env.STAGES.contains("Major Upgrade")) {{
+                    deploy.upgrade_major(environment_vars: environment_vars)
+                  }} else if (env.STAGES.contains("Leapfrog Upgrade")) {{
+                    deploy.upgrade_leapfrog(environment_vars: environment_vars)
+                  }}
+                  tempest.tempest()
+                  kibana.kibana(env.KIBANA_SELENIUM_BRANCH)
+                }} catch (e) {{
+                  print(e)
+                  currentBuild.result = 'FAILURE'
+                  if (env.TRIGGER == 'periodic'){{
+                    common.create_jira_issue(project="RO")
+                  }}
+                  throw e
+                }} finally {{
+                  common.archive_artifacts()
+                  common.safe_jira_comment("${{currentBuild.result}}: [${{env.BUILD_TAG}}|${{env.BUILD_URL}}]")
+                }}
+              }} //pubcloud slave
+            }} // timeout
           }} finally {{
             common.delete_workspace()
           }}
         }} // cit node
-      }} // timeout


### PR DESCRIPTION
Currently, if a job times out no cleanup is triggered.  This commit moves the
timeout block inside the try/except so that cleanup is triggered if a job
actually times out.

Issue: [RE-8](https://rpc-openstack.atlassian.net/browse/RE-8)