### PR TITLE
RE-188 Fix stashing of multi-node inventory

### DIFF
--- a/pipeline_steps/multi_node_aio_prepare.groovy
+++ b/pipeline_steps/multi_node_aio_prepare.groovy
@@ -160,7 +160,7 @@ def connect_deploy_node(name, instance_ip) {
   common.drop_inventory_file(inventory_content)
   dir("rpc-gating/playbooks"){
     stash (
-      name: "pubcloud_inventory",
+      name: "inventory",
       include: "inventory/hosts"
     )
   }

--- a/pipeline_steps/ssh_slave.groovy
+++ b/pipeline_steps/ssh_slave.groovy
@@ -22,7 +22,7 @@ def connect(Map args){
     step: {
       common.internal_slave(){
         if (!("inventory" in args)){
-          args.inventory == "inventory"
+          args.inventory = "inventory"
         }
         if (!("port" in args)){
           args.port = 22


### PR DESCRIPTION
01eac2741173f3016e016f0cbcb31d986ff5c25c modified the process of
stashing the inventory. This change resulted in `connect_deploy_node`
creating a stash that neither used the default name nor passed the
correct name to `ssh_slave.connect`.

This change updates `connect_deploy_node` to use the default.

The setting of the default for `args.inventory` is also fixed so that
the value is correctly assigned.

Issue: [RE-188](https://rpc-openstack.atlassian.net/browse/RE-188)