### PR TITLE
LA-408 Archive log/config artefacts for MNAIOs

### DIFF
--- a/playbooks/archive_artifacts.yml
+++ b/playbooks/archive_artifacts.yml
@@ -19,7 +19,7 @@
                {{ inventory_hostname }}:{{ item }}
                {{ artifacts_path }}/{{ ansible_hostname }}
       with_items:
-        - "/openstack/log/{{ ansible_hostname }}-lxc"
+        - "/openstack/log"
         - "/etc"
         - "/var/log"
       delegate_to: "localhost"
@@ -65,7 +65,6 @@
       with_nested:
         - "{{ containers.stdout_lines | default([]) }}"
         -
-          - { pre: "/openstack/log", post: "" }
           - { pre: "/var/lib/lxc", post: "/rootfs/etc" }
           - { pre: "/var/lib/lxc", post: "/delta0/etc" }
       delegate_to: "localhost"

--- a/playbooks/archive_artifacts.yml
+++ b/playbooks/archive_artifacts.yml
@@ -1,0 +1,88 @@
+- hosts: "{{ target_hosts }}"
+  tasks:
+    - name: Create temporary directory to store artifacts
+      file:
+        path: "{{ artifacts_path }}"
+        state: directory
+      delegate_to: "localhost"
+      run_once: yes
+
+    - name: Grab host data
+      command: >
+               rsync
+               --archive
+               --compress
+               --verbose
+               --relative
+               --rsh 'ssh -o StrictHostKeyChecking=no'
+               --ignore-missing-args
+               {{ inventory_hostname }}:{{ item }}
+               {{ artifacts_path }}/{{ ansible_hostname }}
+      with_items:
+        - "/openstack/log/{{ ansible_hostname }}-lxc"
+        - "/etc"
+        - "/var/log"
+      delegate_to: "localhost"
+      tags:
+        - skip_ansible_lint
+
+    - name: Grab leapfrog upgrade .leap marker files
+      command: >
+               rsync
+               --archive
+               --compress
+               --verbose
+               --rsh 'ssh -o StrictHostKeyChecking=no'
+               --include '*.leap'
+               --exclude '*'
+               {{ inventory_hostname }}:/opt/rpc-leapfrog/leap42/
+               {{ artifacts_path }}/{{ ansible_hostname }}/leap_marker_files
+      delegate_to: "localhost"
+      ignore_errors: yes
+      tags:
+        - skip_ansible_lint
+
+    - name: List containers
+      command: "lxc-ls -1"
+      failed_when:
+        - "{{ containers.rc != 0 }}"
+        - "{{ containers.msg != '[Errno 2] No such file or directory' }}"
+      changed_when: false
+      register: containers
+
+    - name: Grab container data
+      command: >
+               rsync
+               --archive
+               --compress
+               --verbose
+               --relative
+               --rsh 'ssh -o StrictHostKeyChecking=no'
+               --ignore-missing-args
+               {{ inventory_hostname }}:{{ item[1].pre }}/{{ item[0] }}{{ item[1].post }}
+               {{ artifacts_path }}/{{ ansible_hostname }}
+      when: "{{ containers.rc == 0 }}"
+      with_nested:
+        - "{{ containers.stdout_lines | default([]) }}"
+        -
+          - { pre: "/openstack/log", post: "" }
+          - { pre: "/var/lib/lxc", post: "/rootfs/etc" }
+          - { pre: "/var/lib/lxc", post: "/delta0/etc" }
+      delegate_to: "localhost"
+      tags:
+        - skip_ansible_lint
+
+    - name: Create archive
+      command: "tar -cjf {{ artifacts_basename }}.tar.bz2 {{ artifacts_basename }}"
+      args:
+        chdir: "{{ artifacts_basedir }}"
+      delegate_to: "localhost"
+      run_once: yes
+      tags:
+        - skip_ansible_lint
+  vars:
+    build_tag: "{{ lookup('env','BUILD_TAG') }}"
+    artifacts_basename: "artifacts_{{ build_tag }}"
+    artifacts_basedir: "{{ lookup('env','WORKSPACE') }}"
+    artifacts_path: "{{ artifacts_basedir }}/{{ artifacts_basename }}"
+    target_hosts: "localhost"

--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -259,38 +259,42 @@
           maas.prepare(instance_name: instance_name)
 
           common.use_node(deploy_node){{
-            // MNAIO prevents ANSIBLE_GIT_REPO and ANSIBLE_GIT_RELEASE from being overridden
-            // Re-running bootstrap-ansible.sh to use ssh_retry
-            if (env.STAGES.contains("Deploy RPC w/ Script")) {{
-              dir("/opt/rpc-openstack/openstack-ansible") {{
-                withEnv(common.get_deploy_script_env()) {{
-                  sh """#!/bin/bash -xe
-                     ./scripts/bootstrap-ansible.sh
-                     """
+            try {{
+              // MNAIO prevents ANSIBLE_GIT_REPO and ANSIBLE_GIT_RELEASE from being overridden
+              // Re-running bootstrap-ansible.sh to use ssh_retry
+              if (env.STAGES.contains("Deploy RPC w/ Script")) {{
+                dir("/opt/rpc-openstack/openstack-ansible") {{
+                  withEnv(common.get_deploy_script_env()) {{
+                    sh """#!/bin/bash -xe
+                       ./scripts/bootstrap-ansible.sh
+                       """
+                  }}
                 }}
               }}
-            }}
-            environment_vars = [
-              "DEPLOY_HAPROXY=yes",
-              "DEPLOY_TEMPEST=no",
-              "DEPLOY_AIO=no",
-            ]
-            deploy.deploy_sh(
-              environment_vars: environment_vars
-            ) // deploy_sh
-            parallel(
-              "tempest": {{
-                tempest.tempest()
-              }},
-              "horizon": {{
-                horizon.horizon_integration()
-              }},
-              "kibana": {{
-                kibana.kibana(env.KIBANA_SELENIUM_BRANCH)
+              environment_vars = [
+                "DEPLOY_HAPROXY=yes",
+                "DEPLOY_TEMPEST=no",
+                "DEPLOY_AIO=no",
+              ]
+              deploy.deploy_sh(
+                environment_vars: environment_vars
+              ) // deploy_sh
+              parallel(
+                "tempest": {{
+                  tempest.tempest()
+                }},
+                "horizon": {{
+                  horizon.horizon_integration()
+                }},
+                "kibana": {{
+                  kibana.kibana(env.KIBANA_SELENIUM_BRANCH)
+                }}
+              ) // parallel
+              if (env.STAGES.contains("Leapfrog Upgrade")) {{
+                deploy.upgrade_leapfrog(environment_vars: environment_vars)
               }}
-            ) // parallel
-            if (env.STAGES.contains("Leapfrog Upgrade")) {{
-              deploy.upgrade_leapfrog(environment_vars: environment_vars)
+            }} finally {{
+              common.archive_artifacts("MNAIO")
             }}
           }}// deploy node on public cloud node
         }} catch (e){{


### PR DESCRIPTION
The change updates the `multi_node_aio.yml` so that multi-node builds
now have their log/config artefacts saved. To enable this to work
`archive_artifacts` has been modified to support both AIO and MNAIO
builds.

Issue: [LA-408](https://rpc-openstack.atlassian.net/browse/LA-408)