### PR TITLE
RE-190 Discard builds when more than 30

### DIFF
--- a/rpc_jobs/single_use_slave_template.yml
+++ b/rpc_jobs/single_use_slave_template.yml
@@ -2,6 +2,9 @@
     name: Single-Use-Slave-Example
     project-type: workflow
     concurrent: true
+    properties:
+      - build-discarder:
+          num-to-keep: 30
     parameters:
       # Default params are provided by macro, add any extra params, or
       # params you want to override the defaults for.


### PR DESCRIPTION
The Single-Use-Slave-Example job currently does not clear out old
builds, which resulted in master jenkins running out of space.

This commit updates Single-Use-Slave-Example to discard builds when
there are more than 30.