### PR TITLE
Add gate job for ops fabric chatbot

### DIFF
--- a/rpc_jobs/ops_fabric_chatbot.yml
+++ b/rpc_jobs/ops_fabric_chatbot.yml
@@ -1,0 +1,27 @@
+- job:
+    name: ops-fabric-chatbot-gate
+    description: "lint and unit tests for ops-fabric-chatbot"
+    disabled: false
+    display-name: "ops-fabric-chatbot lint and unit tests"
+    properties:
+      - github:
+          url: https://github.com/rcbops/ops-fabric-chatbot/
+    scm:
+      - git:
+          url: ssh://git@github.com/rcbops/ops-fabric-chatbot.git
+          refspec: '+refs/pull/*:refs/remotes/origin/pr/*'
+          branches:
+              - "${sha1}"
+    triggers:
+        - github-pull-request:
+            org-list:
+                - rcbops
+            github-hooks: true
+            trigger-phrase: 'recheck'
+            only-trigger-phrase: false
+            auth-id: "github_account_rpc_jenkins_svc"
+            permit-all: true
+            status-context: 'ops-fabric-chatbot-gate'
+    builders:
+        shell: 'ops-fabric-chatbot/install-deps.sh'
+        shell: 'ops-fabric-chatbot/run-tests.sh'


### PR DESCRIPTION
This is my first attempt at adding a gate job for the
rcbops/ops-fabric-chatbot repo. I want this job to:

- Install any needed dependencies (ops-fabric-chatbot/install-deps.sh)
- Run tests (ops-fabric-chatbot/run-tests.sh)

I would like this job to fail if either of the above commands return
exit code != 0. A timeout of 5 minutes would be good, too, but I haven't
implemented that yet.

Issue: [TURTLES-67](https://rpc-openstack.atlassian.net/browse/TURTLES-67)