### PR TITLE
TURTLES-67 Add gate job for ops fabric chatbot

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -247,6 +247,11 @@ def run_script(Map args) {
  *    - STAGES: String list of stages that should be run
  */
 def conditionalStage(Map args){
+  if (env.STAGES == null){
+  throw new Exception(
+    "ConditionalStage used without STAGES env var existing."\
+    + " Ensure the top level job has a string param called STAGES.")
+  }
   stage(args.stage_name){
     if (env.STAGES.contains(args.stage_name)){
         print "Stage Start: ${args.stage_name}"
@@ -271,6 +276,11 @@ def conditionalStage(Map args){
  * run in a stage.
  */
 def conditionalStep(Map args){
+  if (env.STAGES == null){
+    throw new Exception(
+      "ConditionalStep used without STAGES env var existing."\
+      + " Ensure the top level job has a string param called STAGES.")
+  }
   if (env.STAGES.contains(args.step_name)){
       print "Step Start: ${args.step_name}"
       args.step()

--- a/pipeline_steps/irr_role_tests.groovy
+++ b/pipeline_steps/irr_role_tests.groovy
@@ -6,18 +6,7 @@ def run_irr_tests() {
         dir("${env.WORKSPACE}/${env.ghprbGhRepository}") {
           stage('Checkout'){
             print("Triggered by PR: ${env.ghprbPullLink}")
-            checkout([$class: 'GitSCM',
-              branches: [[name: "origin/pr/${env.ghprbPullId}/merge"]],
-              doGenerateSubmoduleConfigurations: false,
-              extensions: [[$class: 'CleanCheckout']],
-              submoduleCfg: [],
-              userRemoteConfigs: [
-                [
-                  url: "https://github.com/${env.ghprbGhRepository}.git",
-                  refspec: '+refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*'
-                ]
-              ]
-            ])
+            common.clone_with_pr_refs()
           }
           stage('Execute ./run_tests.sh'){
             withCredentials(common.get_cloud_creds()) {

--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -123,6 +123,9 @@ direct arguments. */
 def runonpubcloud(Map args=[:], body){
   add_instance_env_params_to_args(args)
   // randomised inventory_path to avoid parallel conflicts
+  if (env.WORKSPACE == null){
+    throw new Exception("runonpubcloud must be run from within a node")
+  }
   args.inventory="inventory.${common.rand_int_str()}"
   args.inventory_path="${WORKSPACE}/rpc-gating/playbooks/${args.inventory}"
   String instance_name = common.gen_instance_name()

--- a/rpc_jobs/ops_fabric_chatbot.yml
+++ b/rpc_jobs/ops_fabric_chatbot.yml
@@ -25,12 +25,27 @@
       library "rpc-gating@${env.RPC_GATING_BRANCH}"
       common.shared_slave(){
         common.clone_with_pr_refs()
-        timeout(time: 5, units: "MINUTES"){
-          stage("Install Deps"){
-            sh "./install-deps.sh"
-          }
-          stage("Run Tests"){
-            sh "./run-tests.sh"
-          }
+        stage("Build Docker Image"){
+            chatbot_container = docker.build env.BUILD_TAG.toLowerCase()
         }
-      }
+        chatbot_container.inside {
+          timeout(time: 5, units: "MINUTES"){
+            stage("Install Deps"){
+              // Install deps is run here to ensure project level npm deps
+              // are installed.
+              sh """#!/bin/bash -xe
+                ./install-deps.sh
+              """
+            }
+            stage("Run Tests"){
+              sh """#!/bin/bash -xe
+                ./gate.sh
+              """
+            }
+            stage("Collect Results"){
+              sh "ls *-results.xml"
+              junit testResults: '*-results.xml'
+            }
+          } // timeout
+        } // docker container
+      } // shared_slave

--- a/rpc_jobs/ops_fabric_chatbot.yml
+++ b/rpc_jobs/ops_fabric_chatbot.yml
@@ -1,0 +1,27 @@
+- job:
+    name: ops-fabric-chatbot-gate
+    description: "lint and unit tests for ops-fabric-chatbot"
+    disabled: false
+    display-name: "ops-fabric-chatbot lint and unit tests"
+    properties:
+      - github:
+          url: https://github.com/rcbops/ops-fabric-chatbot/
+    scm:
+      - git:
+          url: ssh://git@github.com/rcbops/ops-fabric-chatbot.git
+          refspec: '+refs/pull/*:refs/remotes/origin/pr/*'
+          branches:
+              - "${sha1}"
+    triggers:
+        - github-pull-request:
+            org-list:
+                - rcbops
+            github-hooks: true
+            trigger-phrase: 'recheck'
+            only-trigger-phrase: false
+            auth-id: "github_account_rpc_jenkins_svc"
+            permit-all: true
+            status-context: 'ops-fabric-chatbot-gate'
+    builders:
+        shell: 'ops-fabric-chatbot/install-deps.sh'
+        shell: 'ops-fabric-chatbot/run-tests.sh'

--- a/rpc_jobs/ops_fabric_chatbot.yml
+++ b/rpc_jobs/ops_fabric_chatbot.yml
@@ -1,27 +1,36 @@
 - job:
-    name: ops-fabric-chatbot-gate
+    name: Ops-Fabric-Chatbot-Gate
     description: "lint and unit tests for ops-fabric-chatbot"
     disabled: false
     display-name: "ops-fabric-chatbot lint and unit tests"
+    project-type: workflow
+    concurrent: true
     properties:
       - github:
           url: https://github.com/rcbops/ops-fabric-chatbot/
-    scm:
-      - git:
-          url: ssh://git@github.com/rcbops/ops-fabric-chatbot.git
-          refspec: '+refs/pull/*:refs/remotes/origin/pr/*'
-          branches:
-              - "${sha1}"
+      - build-discarder:
+          num-to-keep: 30
+    parameters:
+      - rpc_gating_params
     triggers:
-        - github-pull-request:
-            org-list:
-                - rcbops
-            github-hooks: true
-            trigger-phrase: 'recheck'
-            only-trigger-phrase: false
-            auth-id: "github_account_rpc_jenkins_svc"
-            permit-all: true
-            status-context: 'ops-fabric-chatbot-gate'
-    builders:
-        shell: 'ops-fabric-chatbot/install-deps.sh'
-        shell: 'ops-fabric-chatbot/run-tests.sh'
+      - github-pull-request:
+          org-list:
+              - rcbops
+          github-hooks: true
+          trigger-phrase: 'recheck'
+          only-trigger-phrase: false
+          auth-id: "github_account_rpc_jenkins_svc"
+          status-context: 'ops-fabric-chatbot-gate'
+    dsl: |
+      library "rpc-gating@${env.RPC_GATING_BRANCH}"
+      common.shared_slave(){
+        common.clone_with_pr_refs()
+        timeout(time: 5, units: "MINUTES"){
+          stage("Install Deps"){
+            sh "./install-deps.sh"
+          }
+          stage("Run Tests"){
+            sh "./run-tests.sh"
+          }
+        }
+      }

--- a/rpc_jobs/rpc_gating_lint.yml
+++ b/rpc_jobs/rpc_gating_lint.yml
@@ -29,7 +29,7 @@
           }
           lint_container.inside {
             stage("Checkout"){
-              git url: env.ghprbAuthorRepoGitUrl, branch: ghprbSourceBranch
+              common.clone_with_pr_refs()
             }
             stage("Lint"){
               withEnv([


### PR DESCRIPTION
This is my first attempt at adding a gate job for the
rcbops/ops-fabric-chatbot repo. I want this job to:

- Install any needed dependencies (ops-fabric-chatbot/install-deps.sh)
- Run tests (ops-fabric-chatbot/run-tests.sh)

I would like this job to fail if either of the above commands return
exit code != 0. A timeout of 5 minutes would be good, too, but I haven't
implemented that yet.

Issue: [TURTLES-67](https://rpc-openstack.atlassian.net/browse/TURTLES-67)