### PR TITLE
RE-201 Use docker cli's filtering instead of awk

### DIFF
--- a/scripts/docker_cleanup.sh
+++ b/scripts/docker_cleanup.sh
@@ -2,7 +2,8 @@
 
 set -xe
 echo "Remove exited containers"
-docker ps -a |awk '/Exited/{print $1}' |while read cid; do docker rm $cid||:; done
+#https://docs.docker.com/engine/reference/commandline/ps/#examples
+(docker ps -a -q -f "status=exited"; docker ps -a -q -f "status=dead")| while read cid; do docker rm $cid||:; done
 
 echo "Remove old Images"
 # Remove any images that have been created more than a day ago, unless it is


### PR DESCRIPTION
This is likely to be more reliable than awking the output.
The awk version missed some containers as they didn't contain
"Exited" in the status field even though they were no longer running.

Issue: [RE-201](https://rpc-openstack.atlassian.net/browse/RE-201)