### PR TITLE
Remove unnecessary double brackets

### DIFF
--- a/rpc_jobs/long_running_slave.yml
+++ b/rpc_jobs/long_running_slave.yml
@@ -31,7 +31,7 @@
               Destroy Slave
 
     dsl: |
-      library "rpc-gating@${{RPC_GATING_BRANCH}}"
+      library "rpc-gating@${RPC_GATING_BRANCH}"
       common.shared_slave(){
           dir("rpc-maas"){
             git branch: env.RPC_MAAS_BRANCH, url: env.RPC_MAAS_REPO


### PR DESCRIPTION
Double brackets are only required in job templates, not jobs.