### PR TITLE
RE-205 Only run tempest_install() on leapfrog

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -329,7 +329,6 @@
                   ]
                 aio_prepare.prepare()
                 deploy.deploy_sh(environment_vars: environment_vars)
-                tempest.tempest_install()
                 kibana.kibana(kibana_branch)
                 holland.holland()
                 if (env.STAGES.contains("Minor Upgrade")) {{
@@ -339,6 +338,8 @@
                   kibana.kibana(env.KIBANA_SELENIUM_BRANCH)
                   holland.holland()
                 }} else if (env.STAGES.contains("Leapfrog Upgrade")) {{
+                  // Required for leapfrog resource generation
+                  tempest.tempest_install()
                   deploy.upgrade_leapfrog(environment_vars: environment_vars)
                   kibana.kibana(env.KIBANA_SELENIUM_BRANCH)
                 }}


### PR DESCRIPTION
If you now attempt to run the Destroy Slave and Cleanup stages on their
own, the build will attempt to first install tempest.  This may or may
not succeed depending on the state of the AIO.

Since the initial tempest resources are only required for the resource
generation tests run in a leapfrog upgrade, we move this line to within
the leapfrog block.