### PR TITLE
RE-209 Avoid archiving venv with html report

### DIFF
--- a/rpc_jobs/single_use_slave_template.yml
+++ b/rpc_jobs/single_use_slave_template.yml
@@ -31,7 +31,8 @@
           // Do something that creates an artifact
           stage("Build"){
             sh """
-              date > datestamp
+              mkdir -p artifacts
+              date > artifacts/datestamp
             """
           }
 
@@ -39,8 +40,8 @@
             // upload the artifact to cloudfiles
             pubcloud.uploadToCloudFiles(
               container: "jenkins_logs",
-              src: "${WORKSPACE}/datestamp",
-              html_report_dest: "${WORKSPACE}/artifacts.html"
+              src: "${WORKSPACE}/artifacts/datestamp",
+              html_report_dest: "${WORKSPACE}/artifacts/artifacts.html"
             )
           }
 
@@ -51,7 +52,7 @@
               keepAll: true,
               reportFiles: "artifacts.html",
               reportName: "Build Artifact Links",
-              reportDir: "${WORKSPACE}"
+              reportDir: "${WORKSPACE}/artifacts"
             )
           }
         }


### PR DESCRIPTION
The master was filling up with disk space as the rpc-gating dir
and workspace venv were collected along with the report files.
To avoid this, report files are moved to a subdirectory.

Issue: [RE-209](https://rpc-openstack.atlassian.net/browse/RE-209)