### PR TITLE
RE-211 Remove the origin before adding it

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -484,6 +484,8 @@ void clone_with_pr_refs(
     sh """#!/bin/bash -xe
       # use init + fetch to avoid the "dir not empty git fail"
       git init .
+      # If the git repo previously existed, we remove the origin
+      git remote remove origin || true
       git remote add origin "${repo}"
       # Don't quote refspec as it should be separate args to git.
       git fetch --tags origin ${refspec}


### PR DESCRIPTION
Commit 7481a60 changed the way the git repo was
cloned, causing a 'remote already exists' error
when being executed on a long running slave.

This patch ensures that the remote is removed before
being added.

Issue: [RE-211](https://rpc-openstack.atlassian.net/browse/RE-211)