### PR TITLE
Add git-core to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu
 RUN apt-get update && apt-get install -y groovy2 python-pip build-essential python-dev libssl-dev
 RUN apt-get install -y libffi-dev
 RUN apt-get install -y sudo
+RUN apt-get install -y git-core
 COPY requirements.txt /requirements.txt
 COPY test-requirements.txt /test-requirements.txt
 COPY constraints.txt /constraints.txt


### PR DESCRIPTION
The git-core package needs to be installed into the
container in order to handle git commands.

All packages are now installed in a single line to
be a little more optimal, and the 'apt-get update'
is done on a seperate line to ensure that a failed
update is exposed properly.