### PR TITLE
RE-216 Configure git before checkout

### DIFF
--- a/rpc_jobs/rpc_gating_lint.yml
+++ b/rpc_jobs/rpc_gating_lint.yml
@@ -29,13 +29,14 @@
           }
           lint_container.inside {
             stage("Checkout"){
+              common.configure_git()
               common.clone_with_pr_refs()
             }
             stage("Lint"){
               withEnv([
                 'RPC_GATING_LINT_USE_VENV=no'
               ]){
-                sh "./lint.sh 2>&1"
+                sh "cd rpc-gating && ./lint.sh 2>&1"
               }// withenv
             }// stage
           }// inside


### PR DESCRIPTION
The RPC-Gating-Lint job is currently failing because we're attempting to
use git inside the container before it's been configured.  This commit
simply adds a configure_git() inside the container so it's properly
prepped.  There may be a more suitable place to put this so we don't
have to explicitly do this inside each container, however we can look at
that further in a subsequent patch.

Additionally, we have to cd into rpc-gating otherwise the lint.sh fails
due to the .venv in ${WORKSPACE}.  Oddly this cd was not required
before [1] merged so some behaviour has changed somewhere making this
necessary now.  Adding a simple dir() to change directory using groovy
logs the following to the console:

JENKINS-33510: working directory will be \
               /var/lib/jenkins/workspace/RPC-Gating-Lint not \
               /var/lib/jenkins/workspace/RPC-Gating-Lint/rpc-gating

For this reason we add the cd to the shell call.

[1] https://github.com/rcbops/rpc-gating/pull/390

Issue: [RE-216](https://rpc-openstack.atlassian.net/browse/RE-216)