### PR TITLE
RE-220 Use fork of openstack-ansible-ops

### DIFF
--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -66,10 +66,10 @@
     parameters:
       - string:
           name: OSA_OPS_REPO
-          default: https://github.com/openstack/openstack-ansible-ops
+          default: https://github.com/git-harry/openstack-ansible-ops
       - string:
           name: OSA_OPS_BRANCH
-          default: b291961361c6f3a3921ca55f73cef36211876f1a
+          default: 93ac83d3436fd078500d6fd85ec5078e357f4db4
       - string:
           name: DEFAULT_IMAGE
           default: "{DEFAULT_IMAGE}"


### PR DESCRIPTION
The current SHA is broken (cobbler26 no longer available), and upstream
has completely rewritten the mnaio build tool which will require a
bunch of RE effort to integrate into rpc-gating.  As a stop gate, we're
going to use a fork of openstack-ansible-ops so we can continue to use
the mnaio jobs until we're able to bump to the head of
openstack-ansible-ops.

Issue: [RE-220](https://rpc-openstack.atlassian.net/browse/RE-220)