### PR TITLE
RE-223 Deploy tempest resources for major upgrade

### DIFF
--- a/pipeline_steps/deploy.groovy
+++ b/pipeline_steps/deploy.groovy
@@ -88,6 +88,8 @@ def upgrade_minor(Map args) {
 }
 
 def upgrade_major(Map args) {
+  // Required to run first for major upgrade resource generation
+  tempest.tempest_install()
   upgrade("Major Upgrade", "test-upgrade.sh", args.environment_vars)
 }
 


### PR DESCRIPTION
The pre-upgrade role requires routers, etc. to exist and the removal
of tempest.tempest() from the initial deployment of a major upgrade has
resulted in our major upgrade jobs failing:

```
TASK: [rpc_pre_upgrade | Write file containing agent for each router] *********
[0;31mfatal: [localhost] => with_items expects a list or a set[0m
[0;31m
FATAL: all hosts have already failed -- aborting[0m
```

It looks like these tasks need to be updated to handle no routers in
an env, but at the same time we want to ensure we have resources so
these tasks are being exercised correctly.

Issue: [RE-223](https://rpc-openstack.atlassian.net/browse/RE-223)