### PR TITLE
RE-224 prevent cleanup errors from failing a build

### DIFF
--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -138,7 +138,13 @@ def runonpubcloud(Map args=[:], body){
     print(e)
     throw e
   }finally {
-    delPubCloudSlave(instance_name: instance_name)
+    try {
+      delPubCloudSlave(instance_name: instance_name)
+    } catch (e){
+      print "Error while cleaning up, swallowing this exception to prevent "\
+            +"cleanup errors from failing the build: ${e}"
+      common.create_jira_issue("RE", "Cleanup Failure: ${env.BUILD_TAG}")
+    }
   }
 }
 


### PR DESCRIPTION
Cleanup errors are an RE problem, not an indication that the code
under test is bad.

Issue: [RE-224](https://rpc-openstack.atlassian.net/browse/RE-224)