### PR TITLE
TURTLES-67 Add ops fabric analytics service gate

### DIFF
--- a/rpc_jobs/ops_fabric_analytics.yml
+++ b/rpc_jobs/ops_fabric_analytics.yml
@@ -1,0 +1,40 @@
+- job:
+    name: Ops-Fabric-Analytics-Gate
+    description: "lint and unit tests for ops-fabric-analytics"
+    disabled: false
+    display-name: "ops-fabric-analytics lint and unit tests"
+    project-type: workflow
+    concurrent: true
+    properties:
+      - github:
+          url: https://github.com/rcbops/ops-fabric-analytics/
+      - build-discarder:
+          num-to-keep: 30
+    parameters:
+      - rpc_gating_params
+    triggers:
+      - github-pull-request:
+          org-list:
+              - rcbops
+          github-hooks: true
+          trigger-phrase: 'recheck'
+          only-trigger-phrase: false
+          auth-id: "github_account_rpc_jenkins_svc"
+          status-context: 'ops-fabric-analytics-gate'
+    dsl: |
+      library "rpc-gating@${env.RPC_GATING_BRANCH}"
+      common.shared_slave(){
+        common.clone_with_pr_refs()
+        stage("Build Docker Image"){
+            analytics_container = docker.build env.BUILD_TAG.toLowerCase()
+        }
+        analytics_container.inside {
+          timeout(time: 5, units: "MINUTES"){
+            stage("Run Tests"){
+              sh """#!/bin/bash -xe
+                cd ./source && tox
+              """
+            }
+          } // timeout
+        } // docker container
+      } // shared_slave


### PR DESCRIPTION
This adds a gate job for the ops-fabric-analytics repo. I copied most of this from the chatbot gate PR.

I am not sure that I have API access to Jenkins, so I have not tested
this yet.

The goal of this gate is to return failed status if any of the tox (py35
or pep8 tests) fail. JUnit output is nice to have, but I would rather
have a working gate more quickly if possible.

The one part I'm not sure of is if tox exists in the container at
the time the tests are run.

Issue: [TURTLES-67](https://rpc-openstack.atlassian.net/browse/TURTLES-67)