### PR TITLE
RE-359 change gate failure ticket type to 'Issue-gate-failure'

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -592,7 +592,7 @@ def delete_workspace() {
 def create_jira_issue(String project="RE",
                       String tag=env.BUILD_TAG,
                       String link=env.BUILD_URL,
-                      String type="Task"){
+                      String type="Issue-releng-platform-alert"){
   withCredentials([
     usernamePassword(
       credentialsId: "jira_user_pass",

--- a/webhooktranslator/webhooktranslator/webhooktranslator.py
+++ b/webhooktranslator/webhooktranslator/webhooktranslator.py
@@ -114,7 +114,7 @@ def create_jira_issue(summary, description, labels):
         project=app.config['jproject'],
         summary=summary,
         description=description,
-        issuetype={'name': 'Task'},
+        issuetype={'name': 'Issue-releng-platform-alert'},
         labels=labels
     )
 


### PR DESCRIPTION
The Aglie Analytics tool is unable to filter on JIRA ticket labels, so
we need to ensrue gate failure tickets are created with a bespoke issue
type (Issue-releng-platform-alert) which we *can* filter on

Issue: [RE-359](https://rpc-openstack.atlassian.net/browse/RE-359)