### PR TITLE
Move issue creation to before throw statement

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -325,10 +325,10 @@
               }} catch (e) {{
                 print(e)
                 currentBuild.result = 'FAILURE'
-                throw e
-                if (TRIGGER == 'periodic'){{
+                if (env.TRIGGER == 'periodic'){{
                   common.create_jira_issue(project="RO")
                 }}
+                throw e
               }} finally {{
                 common.archive_artifacts()
                 common.safe_jira_comment("${{currentBuild.result}}: [${{env.BUILD_TAG}}|${{env.BUILD_URL}}]")


### PR DESCRIPTION
RO periodic failure issues were not being created as the block that creates them was after a throw statement so was never reached.