### PR TITLE
RE-398 Use latest Ubuntu 16.04 ISO

### DIFF
--- a/rpc_jobs/hardening.yml
+++ b/rpc_jobs/hardening.yml
@@ -7,7 +7,7 @@
             tempest_test_sets: 'scenario'
     context:
       - xenial:
-          DEFAULT_IMAGE: "16.04.2"
+          DEFAULT_IMAGE: "16.04.3"
     trigger:
       - periodic:
           CRON: "0 2 * * 7"

--- a/rpc_jobs/hw_multi_node_aio.yml
+++ b/rpc_jobs/hw_multi_node_aio.yml
@@ -13,7 +13,7 @@
       - trusty:
           DEFAULT_IMAGE: "14.04.5"
       - xenial:
-          DEFAULT_IMAGE: "16.04.2"
+          DEFAULT_IMAGE: "16.04.3"
 
     # NOTE: Hugh tested this and found that ztrigger overrides series and
     #       trigger doesn't, which is odd because both trigger and ztrigger

--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -38,7 +38,7 @@
           DEPLOY_TELEGRAF: "yes"
     image:
       - xenial:
-          DEFAULT_IMAGE: "16.04.2"
+          DEFAULT_IMAGE: "16.04.3"
       - trusty:
           DEFAULT_IMAGE: "14.04.5"
     action:


### PR DESCRIPTION
Current MNAIO jobs are failing with:

```
--2017-09-08 00:53:50--  http://releases.ubuntu.com/16.04/ubuntu-16.04.2-server-amd64.iso
Resolving releases.ubuntu.com (releases.ubuntu.com)... 91.189.88.23, 2001:6b0:e:2018::1337
Connecting to releases.ubuntu.com (releases.ubuntu.com)|91.189.88.23|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2017-09-08 00:53:50 ERROR 404: Not Found.
```

Issue: [RE-398](https://rpc-openstack.atlassian.net/browse/RE-398)