### PR TITLE
LA-436 Fix issues relating to testing instances

### DIFF
--- a/pipeline_steps/deploy.groovy
+++ b/pipeline_steps/deploy.groovy
@@ -42,19 +42,6 @@ def deploy_sh(Map args) {
   ) // conditionalStage
 }
 
-void create_test_resource_load(Integer servers, Integer networks, Integer volumes) {
-  dir("/opt/rpc-openstack/scripts/leapfrog/playbooks/") {
-    sh """
-      openstack-ansible \
-        -i /opt/rpc-openstack/openstack-ansible/playbooks/inventory/dynamic_inventory.py \
-        -e server_count=$servers \
-        -e network_count=$networks \
-        -e volume_count=$volumes \
-        generate-resources.yml
-    """
-  }
-}
-
 def upgrade(String stage_name, String upgrade_script, List env_vars,
             String branch = "auto", String dest = "/opt") {
   common.conditionalStage(
@@ -66,18 +53,18 @@ def upgrade(String stage_name, String upgrade_script, List env_vars,
           sh "git reset --hard"
         }
         common.prepareRpcGit(branch, dest)
-        if ( stage_name == "Leapfrog Upgrade" ) {
-          create_test_resource_load(
-            env.GENERATE_TEST_SERVERS as Integer,
-            env.GENERATE_TEST_NETWORKS as Integer,
-            env.GENERATE_TEST_VOLUMES as Integer,
+        withCredentials([
+          string(
+            credentialsId: "INFLUX_IP",
+            variable: "INFLUX_IP"
           )
+        ]){
+          dir("/opt/rpc-openstack"){
+            sh """
+              scripts/$upgrade_script
+            """
+          } // dir
         }
-        dir("/opt/rpc-openstack"){
-          sh """
-            scripts/$upgrade_script
-          """
-        } // dir
       } // withEnv
     } // stage
   ) // conditionalStage

--- a/playbooks/vars/all.yml
+++ b/playbooks/vars/all.yml
@@ -27,3 +27,7 @@ default_gating_overrides:
   # too low for the liberty->mitaka upgrade job where more space is used by
   # additional packages, venvs, logs, etc.
   percent_used_critical_threshold: 95
+  # These neutron vars are required to allow instances to be pinged after an
+  # upgrade when using vxlan
+  neutron_l2_population: False
+  neutron_vxlan_group: 224.0.0.1

--- a/playbooks/vars/all.yml
+++ b/playbooks/vars/all.yml
@@ -27,7 +27,3 @@ default_gating_overrides:
   # too low for the liberty->mitaka upgrade job where more space is used by
   # additional packages, venvs, logs, etc.
   percent_used_critical_threshold: 95
-  # These neutron vars are required to allow instances to be pinged after an
-  # upgrade when using vxlan
-  neutron_l2_population: False
-  neutron_vxlan_group: 224.0.0.1

--- a/playbooks/vars/onmetal.yml
+++ b/playbooks/vars/onmetal.yml
@@ -12,3 +12,7 @@ gating_overrides:
     - '--concurrency 3'
   tempest_run_tempest_opts: []
   tempest_public_subnet_cidr: "172.29.248.0/22"
+  # These neutron vars are required to allow instances to be pinged after an
+  # upgrade when using vxlan
+  neutron_l2_population: "False"
+  neutron_vxlan_group: "224.0.0.1"

--- a/playbooks/vars/onmetal.yml
+++ b/playbooks/vars/onmetal.yml
@@ -11,3 +11,4 @@ gating_overrides:
   tempest_testr_opts:
     - '--concurrency 3'
   tempest_run_tempest_opts: []
+  tempest_public_subnet_cidr: "172.29.248.0/22"


### PR DESCRIPTION
The running of `generate-resources.yml` is now managed by rpc-openstack,
the code to perform that function here is removed.

To ensure that Telegraf is properly installed during the upgrade phase
of an upgrade, the appropriate credentials are supplied to the upgrade
script.

To test instance networking a number have vars are set because pinging
using the floating IP address does not work with the default
configuration when using vxlan.

Issue: [LA-436](https://rpc-openstack.atlassian.net/browse/LA-436)