### PR TITLE
Add issue creation logging

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -326,7 +326,10 @@
                 print(e)
                 currentBuild.result = 'FAILURE'
                 if (env.TRIGGER == 'periodic'){{
+                  print("Creating jira issue in project RO for failed periodic build")
                   common.create_jira_issue(project="RO")
+                }} else {{
+                  print ("Not creating jira issue as this build is not periodic, trigger: ${env.TRIGGER}")
                 }}
                 throw e
               }} finally {{


### PR DESCRIPTION
Issues are not getting created in the RO project for aio build failures. Its not clear to me why, this commit adds logging to determine whether issue creation is attempted.