### PR TITLE
RLM-204 Move Kilo Leapfrog Jobs to Periodic Only

### DIFF
--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -101,7 +101,10 @@
       # Leapfrog upgrades are only run for kilo --> newton141
       # as the upgrade method is not supported for any
       # other target series.
-      # the kilo --> newton141 job is triggered by PRs to either branch.
+      # the kilo --> newton141 job is only ran as a periodic job until
+      # it's more reliable and can be tested as a PR
+      - action: leapfrogupgrade
+        trigger: pr
       - series: liberty
         action: leapfrogupgrade
       - series: mitaka

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -125,7 +125,10 @@
       # Leapfrog upgrades are only run for kilo --> newton
       # as the upgrade method is not supported for any
       # other target series.
-      # the kilo --> newton job is triggered by PRs to either branch.
+      # the kilo --> newton job is only ran as a periodic job until
+      # it's more reliable and can be tested as a PR
+      - action: leapfrogupgrade
+        trigger: pr
       - series: liberty
         action: leapfrogupgrade
       - series: mitaka


### PR DESCRIPTION
Adds Kilo Leapfrog PRs to the exclude list for MultiAIO and AIO:

Issue: [RLM-204](https://rpc-openstack.atlassian.net/browse/RLM-204)

