### PR TITLE
RLM-58 Adds periodic AIO leapfrog jobs for deployed versions of kilo

### DIFF
--- a/rpc_jobs/rpc_aio_leapfrog.yml
+++ b/rpc_jobs/rpc_aio_leapfrog.yml
@@ -1,0 +1,69 @@
+- project:
+    name: 'RPC-AIO-Leapfrog-Testing'
+    # Note: branch is the branch for periodics to build
+    #       branches is the branch pattern to match for PR Jobs.
+    series:
+      - kilo-r11.1.18:
+          branch: r11.1.18
+          branches: "r11.1.18"
+      - kilo-r11.1.15:
+          branch: r11.1.15
+          branches: "r11.1.15"
+      - kilo-r11.1.14:
+          branch: r11.1.14
+          branches: "r11.1.14"
+      - kilo-r11.1.10:
+          branch: r11.1.10
+          branches: "r11.1.10"
+      - kilo-r11.1.9:
+          branch: r11.1.9
+          branches: "r11.1.9"
+      - kilo-r11.1.6:
+          branch: r11.1.6
+          branches: "r11.1.6"
+      - kilo-r11.1.5:
+          branch: r11.1.5
+          branches: "r11.1.5"
+      - kilo-r11.1.4:
+          branch: r11.1.4
+          branches: "r11.1.4"
+      - kilo-r11.1.3:
+          branch: r11.1.3
+          branches: "r11.1.3"
+      - kilo-r11.0.4:
+          branch: r11.0.4
+          branches: "r11.0.4"
+      - kilo-r11.0.1:
+          branch: r11.0.1
+          branches: "r11.0.1"
+      - kilo-r11.0.0:
+          branch: r11.0.0
+          branches: "r11.0.0"
+    image:
+      - trusty:
+          IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+    action:
+      - leapfrogupgrade:
+          ACTION_STAGES: >-
+            Leapfrog Upgrade,
+            Install Tempest,
+            Tempest Tests,
+            Prepare Kibana Selenium,
+            Kibana Tests
+          GENERATE_TEST_NETWORKS: "6"
+          GENERATE_TEST_SERVERS: "4"
+          GENERATE_TEST_VOLUMES: "12"
+    scenario:
+      - swift
+    ztrigger:
+      - periodic:
+          branches: "do_not_build_on_pr"
+          NUM_TO_KEEP: 10
+    # NOTE: if you want to exclude certain jobs, uncomment this section
+    # and specify the types of jobs you don't want generated
+    # exclude:
+    #   - action: leapfrogupgrade
+    #     series: kilo-r11.0.0
+    jobs:
+      # uses default template in rpc_aio.yml so we don't duplicate it here
+      - 'RPC-AIO_{series}-{image}-{action}-{scenario}-{ztrigger}'


### PR DESCRIPTION
Creates a seperate rpc_aio_leapfrog job to avoid stepping on
existing jobs in place.  Tests desired kilo branches for leapfrogs
as periodic jobs.

Issue: [RLM-58](https://rpc-openstack.atlassian.net/browse/RLM-58)