### PR TITLE
RLM-204 Trigger axis is called ztrigger

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -128,7 +128,7 @@
       # the kilo --> newton job is only ran as a periodic job until
       # it's more reliable and can be tested as a PR
       - action: leapfrogupgrade
-        trigger: pr
+        ztrigger: pr
       - series: liberty
         action: leapfrogupgrade
       - series: mitaka


### PR DESCRIPTION
There is no trigger axis, so trigger: pr was ignored in 2e774d7.

Issue: [RLM-204](https://rpc-openstack.atlassian.net/browse/RLM-204)