### PR TITLE
RLM-204 Fix build failure issue creation

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -330,9 +330,9 @@
                 currentBuild.result = 'FAILURE'
                 if (env.TRIGGER == 'periodic'){{
                   print("Creating jira issue in project RO for failed periodic build")
-                  common.create_jira_issue(project="RO")
+                  common.create_jira_issue("RO")
                 }} else {{
-                  print ("Not creating jira issue as this build is not periodic, trigger: ${env.TRIGGER}")
+                  print ("Not creating jira issue as this build is not periodic, trigger: ${{env.TRIGGER}}")
                 }}
                 throw e
               }} finally {{

--- a/rpc_jobs/rpc_gating_lint.yml
+++ b/rpc_jobs/rpc_gating_lint.yml
@@ -24,14 +24,11 @@
           stage("Prepare"){
             common.docker_cache_workaround()
             dir ('rpc-gating'){
+              common.clone_with_pr_refs()
               lint_container = docker.build env.BUILD_TAG.toLowerCase()
             }
           }
           lint_container.inside {
-            stage("Checkout"){
-              common.configure_git()
-              common.clone_with_pr_refs()
-            }
             stage("Lint"){
               withEnv([
                 'RPC_GATING_LINT_USE_VENV=no'


### PR DESCRIPTION
Currently the mechanism that creates a jira issue when a periodic
build fails is not working. The problem is a call:
  common.create_jira_issue(project="RO")

This looks like a calll that passes a keyword argument, its not. Its
an assignment with a function call. In CPS groovy assignments return
null, so this is effectively common.create_jira_issue(null).

The fix is to remove project=.

Issue: [RLM-204](https://rpc-openstack.atlassian.net/browse/RLM-204)