### PR TITLE
RLM-58: Adds periodic AIO leapfrog jobs for deployed versions of kilo

### DIFF
--- a/rpc_jobs/rpc_aio_leapfrog.yml
+++ b/rpc_jobs/rpc_aio_leapfrog.yml
@@ -8,61 +8,73 @@
           branch: "r14.2.0"
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
+          DEPLOY_TELEGRAF: "yes"
       - newton-r11.1.15:
           UPGRADE_FROM_REF: "r11.1.15"
           branch: "r14.2.0"
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
+          DEPLOY_TELEGRAF: "yes"
       - newton-r11.1.14:
           UPGRADE_FROM_REF: "r11.1.14"
           branch: "r14.2.0"
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
+          DEPLOY_TELEGRAF: "yes"
       - newton-r11.1.10:
           UPGRADE_FROM_REF: "r11.1.10"
           branch: "r14.2.0"
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
+          DEPLOY_TELEGRAF: "yes"
       - newton-r11.1.9:
           UPGRADE_FROM_REF: "r11.1.9"
           branch: "r14.2.0"
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
+          DEPLOY_TELEGRAF: "yes"
       - newton-r11.1.6:
           UPGRADE_FROM_REF: "r11.1.6"
           branch: "r14.2.0"
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
+          DEPLOY_TELEGRAF: "yes"
       - newton-r11.1.5:
           UPGRADE_FROM_REF: "r11.1.5"
           branch: "r14.2.0"
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
+          DEPLOY_TELEGRAF: "yes"
       - newton-r11.1.4:
           UPGRADE_FROM_REF: "r11.1.4"
           branch: "r14.2.0"
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
+          DEPLOY_TELEGRAF: "yes"
       - newton-r11.1.3:
           UPGRADE_FROM_REF: "r11.1.3"
           branch: "r14.2.0"
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
+          DEPLOY_TELEGRAF: "yes"
       - newton-r11.0.4:
           UPGRADE_FROM_REF: "r11.0.4"
           branch: "r14.2.0"
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
+          DEPLOY_TELEGRAF: "yes"
       - newton-r11.0.1:
           UPGRADE_FROM_REF: "r11.0.1"
           branch: "r14.2.0"
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
+          DEPLOY_TELEGRAF: "yes"
       - newton-r11.0.0:
           UPGRADE_FROM_REF: "r11.0.0"
           branch: "r14.2.0"
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
+          DEPLOY_TELEGRAF: "yes"
     image:
       - trusty:
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"

--- a/rpc_jobs/rpc_aio_leapfrog.yml
+++ b/rpc_jobs/rpc_aio_leapfrog.yml
@@ -4,65 +4,65 @@
     #       branches is the branch pattern to match for PR Jobs.
     series:
       - newton-r11.1.18:
-          UPGRADE_FROM_REF: r11.1.18
-          branch: r14.2.0
-          branches: "r11.1.18"
-          KIBANA_SELENIUM_BRANCH: newton
+          UPGRADE_FROM_REF: "r11.1.18"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
       - newton-r11.1.15:
-          UPGRADE_FROM_REF: r11.1.15
-          branch: r14.2.0
-          branches: "r11.1.15"
-          KIBANA_SELENIUM_BRANCH: newton
+          UPGRADE_FROM_REF: "r11.1.15"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
       - newton-r11.1.14:
-          UPGRADE_FROM_REF: r11.1.14
-          branch: r14.2.0
-          branches: "r11.1.14"
-          KIBANA_SELENIUM_BRANCH: newton
+          UPGRADE_FROM_REF: "r11.1.14"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
       - newton-r11.1.10:
-          UPGRADE_FROM_REF: r11.1.10
-          branch: r14.2.0
-          branches: "r11.1.10"
-          KIBANA_SELENIUM_BRANCH: newton
+          UPGRADE_FROM_REF: "r11.1.10"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
       - newton-r11.1.9:
-          UPGRADE_FROM_REF: r11.1.9
-          branch: r14.2.0
-          branches: "r11.1.9"
-          KIBANA_SELENIUM_BRANCH: newton
+          UPGRADE_FROM_REF: "r11.1.9"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
       - newton-r11.1.6:
-          UPGRADE_FROM_REF: r11.1.6
-          branch: r14.2.0
-          branches: "r11.1.6"
-          KIBANA_SELENIUM_BRANCH: newton
+          UPGRADE_FROM_REF: "r11.1.6"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
       - newton-r11.1.5:
-          UPGRADE_FROM_REF: r11.1.5
-          branch: r14.2.0
-          branches: "r11.1.5"
-          KIBANA_SELENIUM_BRANCH: newton
+          UPGRADE_FROM_REF: "r11.1.5"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
       - newton-r11.1.4:
-          UPGRADE_FROM_REF: r11.1.4
-          branch: r14.2.0
-          branches: "r11.1.4"
-          KIBANA_SELENIUM_BRANCH: newton
+          UPGRADE_FROM_REF: "r11.1.4"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
       - newton-r11.1.3:
-          UPGRADE_FROM_REF: r11.1.3
-          branch: r14.2.0
-          branches: "r11.1.3"
-          KIBANA_SELENIUM_BRANCH: newton
+          UPGRADE_FROM_REF: "r11.1.3"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
       - newton-r11.0.4:
-          UPGRADE_FROM_REF: r11.0.4
-          branch: r14.2.0
-          branches: "r11.0.4"
-          KIBANA_SELENIUM_BRANCH: newton
+          UPGRADE_FROM_REF: "r11.0.4"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
       - newton-r11.0.1:
-          UPGRADE_FROM_REF: r11.0.1
-          branch: r14.2.0
-          branches: "r11.0.1"
-          KIBANA_SELENIUM_BRANCH: newton
+          UPGRADE_FROM_REF: "r11.0.1"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
       - newton-r11.0.0:
-          UPGRADE_FROM_REF: r11.0.0
-          branch: r14.2.0
-          branches: "r11.0.0"
-          KIBANA_SELENIUM_BRANCH: newton
+          UPGRADE_FROM_REF: "r11.0.0"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
     image:
       - trusty:
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"

--- a/rpc_jobs/rpc_aio_leapfrog.yml
+++ b/rpc_jobs/rpc_aio_leapfrog.yml
@@ -3,42 +3,66 @@
     # Note: branch is the branch for periodics to build
     #       branches is the branch pattern to match for PR Jobs.
     series:
-      - kilo-r11.1.18:
-          branch: r11.1.18
+      - newton-r11.1.18:
+          UPGRADE_FROM_REF: r11.1.18
+          branch: r14.2.0
           branches: "r11.1.18"
-      - kilo-r11.1.15:
-          branch: r11.1.15
+          KIBANA_SELENIUM_BRANCH: newton
+      - newton-r11.1.15:
+          UPGRADE_FROM_REF: r11.1.15
+          branch: r14.2.0
           branches: "r11.1.15"
-      - kilo-r11.1.14:
-          branch: r11.1.14
+          KIBANA_SELENIUM_BRANCH: newton
+      - newton-r11.1.14:
+          UPGRADE_FROM_REF: r11.1.14
+          branch: r14.2.0
           branches: "r11.1.14"
-      - kilo-r11.1.10:
-          branch: r11.1.10
+          KIBANA_SELENIUM_BRANCH: newton
+      - newton-r11.1.10:
+          UPGRADE_FROM_REF: r11.1.10
+          branch: r14.2.0
           branches: "r11.1.10"
-      - kilo-r11.1.9:
-          branch: r11.1.9
+          KIBANA_SELENIUM_BRANCH: newton
+      - newton-r11.1.9:
+          UPGRADE_FROM_REF: r11.1.9
+          branch: r14.2.0
           branches: "r11.1.9"
-      - kilo-r11.1.6:
-          branch: r11.1.6
+          KIBANA_SELENIUM_BRANCH: newton
+      - newton-r11.1.6:
+          UPGRADE_FROM_REF: r11.1.6
+          branch: r14.2.0
           branches: "r11.1.6"
-      - kilo-r11.1.5:
-          branch: r11.1.5
+          KIBANA_SELENIUM_BRANCH: newton
+      - newton-r11.1.5:
+          UPGRADE_FROM_REF: r11.1.5
+          branch: r14.2.0
           branches: "r11.1.5"
-      - kilo-r11.1.4:
-          branch: r11.1.4
+          KIBANA_SELENIUM_BRANCH: newton
+      - newton-r11.1.4:
+          UPGRADE_FROM_REF: r11.1.4
+          branch: r14.2.0
           branches: "r11.1.4"
-      - kilo-r11.1.3:
-          branch: r11.1.3
+          KIBANA_SELENIUM_BRANCH: newton
+      - newton-r11.1.3:
+          UPGRADE_FROM_REF: r11.1.3
+          branch: r14.2.0
           branches: "r11.1.3"
-      - kilo-r11.0.4:
-          branch: r11.0.4
+          KIBANA_SELENIUM_BRANCH: newton
+      - newton-r11.0.4:
+          UPGRADE_FROM_REF: r11.0.4
+          branch: r14.2.0
           branches: "r11.0.4"
-      - kilo-r11.0.1:
-          branch: r11.0.1
+          KIBANA_SELENIUM_BRANCH: newton
+      - newton-r11.0.1:
+          UPGRADE_FROM_REF: r11.0.1
+          branch: r14.2.0
           branches: "r11.0.1"
-      - kilo-r11.0.0:
-          branch: r11.0.0
+          KIBANA_SELENIUM_BRANCH: newton
+      - newton-r11.0.0:
+          UPGRADE_FROM_REF: r11.0.0
+          branch: r14.2.0
           branches: "r11.0.0"
+          KIBANA_SELENIUM_BRANCH: newton
     image:
       - trusty:
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"

--- a/rpc_jobs/rpc_aio_leapfrog.yml
+++ b/rpc_jobs/rpc_aio_leapfrog.yml
@@ -1,0 +1,69 @@
+- project:
+    name: 'RPC-AIO-Leapfrog-Testing'
+    # Note: branch is the branch for periodics to build
+    #       branches is the branch pattern to match for PR Jobs.
+    series:
+      - kilo-r11.1.18:
+          branch: r11.1.18
+          branches: "r11.1.18"
+      - kilo-r11.1.15:
+          branch: r11.1.15
+          branches: "r11.1.15"
+      - kilo-r11.1.14:
+          branch: r11.1.14
+          branches: "r11.1.14"
+      - kilo-r11.1.10:
+          branch: r11.1.10
+          branches: "r11.1.10"
+      - kilo-r11.1.9:
+          branch: r11.1.9
+          branches: "r11.1.9"
+      - kilo-r11.1.6:
+          branch: r11.1.6
+          branches: "r11.1.6"
+      - kilo-r11.1.5:
+          branch: r11.1.5
+          branches: "r11.1.5"
+      - kilo-r11.1.4:
+          branch: r11.1.4
+          branches: "r11.1.4"
+      - kilo-r11.1.3:
+          branch: r11.1.3
+          branches: "r11.1.3"
+      - kilo-r11.0.4:
+          branch: r11.0.4
+          branches: "r11.0.4"
+      - kilo-r11.0.1:
+          branch: r11.0.1
+          branches: "r11.0.1"
+      - kilo-r11.0.0:
+          branch: r11.0.0
+          branches: "r11.0.0"
+    image:
+      - trusty:
+          IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+    action:
+      - leapfrogupgrade:
+          ACTION_STAGES: >-
+            Leapfrog Upgrade,
+            Install Tempest,
+            Tempest Tests,
+            Prepare Kibana Selenium,
+            Kibana Tests
+          GENERATE_TEST_NETWORKS: "6"
+          GENERATE_TEST_SERVERS: "4"
+          GENERATE_TEST_VOLUMES: "12"
+    scenario:
+      - swift
+    ztrigger:
+      - periodic:
+          branches: "do_not_build_on_pr"
+          NUM_TO_KEEP: 10
+    # NOTE: if you want to exclude certain jobs, uncomment this section
+    # and specify the types of jobs you don't want generated
+    # exclude:
+    #   - action: leapfrogupgrade
+    #     series: kilo-r11.0.0
+    jobs:
+      # uses default template in rpc_aio.yml so we don't duplicate it here
+      - 'RPC-AIO_{series}-{image}-{action}-{scenario}-{ztrigger}'


### PR DESCRIPTION
Creates a seperate rpc_aio_leapfrog job to avoid stepping on
existing jobs in place.  Tests desired kilo branches for leapfrogs
as periodic jobs.

Reopening as a branch on the main repo, closed https://github.com/rcbops/rpc-gating/pull/416

Issue: [RLM-58](https://rpc-openstack.atlassian.net/browse/RLM-58)