### PR TITLE
RLM-209 Set newton excludes for leapfrogupgrades

### DIFF
--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -109,6 +109,8 @@
         action: leapfrogupgrade
       - series: mitaka
         action: leapfrogupgrade
+      - series: newton
+        action: leapfrogupgrade
       - series: master
         action: leapfrogupgrade
       # Leapfrog upgrades cannot be executed on

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -133,6 +133,8 @@
         action: leapfrogupgrade
       - series: mitaka
         action: leapfrogupgrade
+      - series: newton
+        action: leapfrogupgrade
       - series: master
         action: leapfrogupgrade
       # This combo tests the same thing as


### PR DESCRIPTION
Looks like we never added excludes for newton on leapfrogupgrades, so this removes those jobs.



Issue: [RLM-209](https://rpc-openstack.atlassian.net/browse/RLM-209)