### PR TITLE
LA-436 Re-add Python path in influx-report.sh

### DIFF
--- a/influx-reports/influx-report.sh
+++ b/influx-reports/influx-report.sh
@@ -5,4 +5,4 @@ INFLUX_DOWNTIME_FOLDER="$(dirname "${BASH_SOURCE[0]}")"
 ADDITIONAL_ARGS="$*"
 
 mkdir -p "${REPORTS_FOLDER}"
-$INFLUX_DOWNTIME_FOLDER/influx.py --ymlreport $REPORTS_FOLDER/influx-downtime.yml --subunitreport $REPORTS_FOLDER/influx-downtime.bin $ADDITIONAL_ARGS
+$PYTHON_PATH $INFLUX_DOWNTIME_FOLDER/influx.py --ymlreport $REPORTS_FOLDER/influx-downtime.yml --subunitreport $REPORTS_FOLDER/influx-downtime.bin $ADDITIONAL_ARGS


### PR DESCRIPTION
The use of python in the virtual env `.venv` was incorrectly removed.
This change adds it back so the script `influx.py` is run with the
required dependencies.

Issue: [LA-436](https://rpc-openstack.atlassian.net/browse/LA-436)