### PR TITLE
RE-451 Fix bug getting OSA SHA on multi-node

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -608,18 +608,6 @@ def create_jira_issue(String project="RE",
   }
 }
 
-String get_current_git_sha(String repo_path) {
-  String sha = ""
-  dir(repo_path) {
-    sha = sh(
-      returnStdout: true,
-      script: "git rev-parse --verify HEAD",
-    ).trim()
-  }
-  print("Current SHA for '${repo_path}' is '${sha}'.")
-  return sha
-}
-
 // Create inventory file. Useful for running part of a job against
 // an existing node, where the job expects an inventory file to
 // have been created by the resource allocation step.


### PR DESCRIPTION
This changes updates how the OSA SHA is identified, for use by the
openstack-ansible-ops multi-nodes scripts, so that it accounts for use
of a submodule or being specified in a file. This change is required due
to the RPCO commit 4d12456c1ab1111823e7b0cb8f01d37a4b2a7f4f.

Issue: [RE-451](https://rpc-openstack.atlassian.net/browse/RE-451)