### PR TITLE
RLM-58 Multi-node AIO gate jobs for Kilo Leapfrog testing

### DIFF
--- a/rpc_jobs/multi_node_aio_leapfrog.yml
+++ b/rpc_jobs/multi_node_aio_leapfrog.yml
@@ -7,7 +7,10 @@
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
-            tempest_test_sets: 'scenario defcore api heat_api smoke'
+            tempest_test_sets: 'all'
+            lxc_container_vg_name: "USE_DIR_NOT_VG"
+            glance_default_store: "swift"
+            neutron_legacy_ha_tool_enabled: true
           DEPLOY_TELEGRAF: "yes"
       - newton-r11.1.15:
           UPGRADE_FROM_REF: "r11.1.15"
@@ -15,7 +18,10 @@
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
-            tempest_test_sets: 'scenario defcore api heat_api smoke'
+            tempest_test_sets: 'all'
+            lxc_container_vg_name: "USE_DIR_NOT_VG"
+            glance_default_store: "swift"
+            neutron_legacy_ha_tool_enabled: true
           DEPLOY_TELEGRAF: "yes"
       - newton-r11.1.14:
           UPGRADE_FROM_REF: "r11.1.14"
@@ -23,7 +29,10 @@
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
-            tempest_test_sets: 'scenario defcore api heat_api smoke'
+            tempest_test_sets: 'all'
+            lxc_container_vg_name: "USE_DIR_NOT_VG"
+            glance_default_store: "swift"
+            neutron_legacy_ha_tool_enabled: true
           DEPLOY_TELEGRAF: "yes"
       - newton-r11.1.10:
           UPGRADE_FROM_REF: "r11.1.10"
@@ -31,7 +40,10 @@
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
-            tempest_test_sets: 'scenario defcore api heat_api smoke'
+            tempest_test_sets: 'all'
+            lxc_container_vg_name: "USE_DIR_NOT_VG"
+            glance_default_store: "swift"
+            neutron_legacy_ha_tool_enabled: true
           DEPLOY_TELEGRAF: "yes"
       - newton-r11.1.9:
           UPGRADE_FROM_REF: "r11.1.9"
@@ -39,7 +51,10 @@
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
-            tempest_test_sets: 'scenario defcore api heat_api smoke'
+            tempest_test_sets: 'all'
+            lxc_container_vg_name: "USE_DIR_NOT_VG"
+            glance_default_store: "swift"
+            neutron_legacy_ha_tool_enabled: true
           DEPLOY_TELEGRAF: "yes"
       - newton-r11.1.6:
           UPGRADE_FROM_REF: "r11.1.6"
@@ -47,7 +62,10 @@
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
-            tempest_test_sets: 'scenario defcore api heat_api smoke'
+            tempest_test_sets: 'all'
+            lxc_container_vg_name: "USE_DIR_NOT_VG"
+            glance_default_store: "swift"
+            neutron_legacy_ha_tool_enabled: true
           DEPLOY_TELEGRAF: "yes"
       - newton-r11.1.5:
           UPGRADE_FROM_REF: "r11.1.5"
@@ -55,7 +73,10 @@
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
-            tempest_test_sets: 'scenario defcore api heat_api smoke'
+            tempest_test_sets: 'all'
+            lxc_container_vg_name: "USE_DIR_NOT_VG"
+            glance_default_store: "swift"
+            neutron_legacy_ha_tool_enabled: true
           DEPLOY_TELEGRAF: "yes"
       - newton-r11.1.4:
           UPGRADE_FROM_REF: "r11.1.4"
@@ -63,7 +84,10 @@
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
-            tempest_test_sets: 'scenario defcore api heat_api smoke'
+            tempest_test_sets: 'all'
+            lxc_container_vg_name: "USE_DIR_NOT_VG"
+            glance_default_store: "swift"
+            neutron_legacy_ha_tool_enabled: true
           DEPLOY_TELEGRAF: "yes"
       - newton-r11.1.3:
           UPGRADE_FROM_REF: "r11.1.3"
@@ -71,7 +95,10 @@
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
-            tempest_test_sets: 'scenario defcore api heat_api smoke'
+            tempest_test_sets: 'all'
+            lxc_container_vg_name: "USE_DIR_NOT_VG"
+            glance_default_store: "swift"
+            neutron_legacy_ha_tool_enabled: true
           DEPLOY_TELEGRAF: "yes"
       - newton-r11.0.4:
           UPGRADE_FROM_REF: "r11.0.4"
@@ -79,7 +106,10 @@
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
-            tempest_test_sets: 'scenario defcore api heat_api smoke'
+            tempest_test_sets: 'all'
+            lxc_container_vg_name: "USE_DIR_NOT_VG"
+            glance_default_store: "swift"
+            neutron_legacy_ha_tool_enabled: true
           DEPLOY_TELEGRAF: "yes"
       - newton-r11.0.1:
           UPGRADE_FROM_REF: "r11.0.1"
@@ -87,7 +117,10 @@
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
-            tempest_test_sets: 'scenario defcore api heat_api smoke'
+            tempest_test_sets: 'all'
+            lxc_container_vg_name: "USE_DIR_NOT_VG"
+            glance_default_store: "swift"
+            neutron_legacy_ha_tool_enabled: true
           DEPLOY_TELEGRAF: "yes"
       - newton-r11.0.0:
           UPGRADE_FROM_REF: "r11.0.0"
@@ -95,7 +128,10 @@
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
-            tempest_test_sets: 'scenario defcore api heat_api smoke'
+            tempest_test_sets: 'all'
+            lxc_container_vg_name: "USE_DIR_NOT_VG"
+            glance_default_store: "swift"
+            neutron_legacy_ha_tool_enabled: true
           DEPLOY_TELEGRAF: "yes"
     image:
       - trusty:

--- a/rpc_jobs/multi_node_aio_leapfrog.yml
+++ b/rpc_jobs/multi_node_aio_leapfrog.yml
@@ -1,0 +1,108 @@
+- project:
+    name: 'Multi-Node-AIO-Leapfrog-Testing'
+    series:
+      - kilo-r11.1.18:
+          branch: r11.1.18
+          branches: "r11.1.18"
+          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+          SERIES_USER_VARS: |
+            tempest_test_sets: 'scenario defcore api heat_api smoke'
+          DEPLOY_TELEGRAF: "yes"
+      - kilo-r11.1.15:
+          branch: r11.1.15
+          branches: "r11.1.15"
+          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+          SERIES_USER_VARS: |
+            tempest_test_sets: 'scenario defcore api heat_api smoke'
+          DEPLOY_TELEGRAF: "yes"
+      - kilo-r11.1.14:
+          branch: r11.1.14
+          branches: "r11.1.14"
+          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+          SERIES_USER_VARS: |
+            tempest_test_sets: 'scenario defcore api heat_api smoke'
+          DEPLOY_TELEGRAF: "yes"
+      - kilo-r11.1.10:
+          branch: r11.1.10
+          branches: "r11.1.10"
+          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+          SERIES_USER_VARS: |
+            tempest_test_sets: 'scenario defcore api heat_api smoke'
+          DEPLOY_TELEGRAF: "yes"
+      - kilo-r11.1.9:
+          branch: r11.1.9
+          branches: "r11.1.9"
+          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+          SERIES_USER_VARS: |
+            tempest_test_sets: 'scenario defcore api heat_api smoke'
+          DEPLOY_TELEGRAF: "yes"
+      - kilo-r11.1.6:
+          branch: r11.1.6
+          branches: "r11.1.6"
+          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+          SERIES_USER_VARS: |
+            tempest_test_sets: 'scenario defcore api heat_api smoke'
+          DEPLOY_TELEGRAF: "yes"
+      - kilo-r11.1.5:
+          branch: r11.1.5
+          branches: "r11.1.5"
+          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+          SERIES_USER_VARS: |
+            tempest_test_sets: 'scenario defcore api heat_api smoke'
+          DEPLOY_TELEGRAF: "yes"
+      - kilo-r11.1.4:
+          branch: r11.1.4
+          branches: "r11.1.4"
+          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+          SERIES_USER_VARS: |
+            tempest_test_sets: 'scenario defcore api heat_api smoke'
+          DEPLOY_TELEGRAF: "yes"
+      - kilo-r11.1.3:
+          branch: r11.1.3
+          branches: "r11.1.3"
+          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+          SERIES_USER_VARS: |
+            tempest_test_sets: 'scenario defcore api heat_api smoke'
+          DEPLOY_TELEGRAF: "yes"
+      - kilo-r11.0.4:
+          branch: r11.0.4
+          branches: "r11.0.4"
+          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+          SERIES_USER_VARS: |
+            tempest_test_sets: 'scenario defcore api heat_api smoke'
+          DEPLOY_TELEGRAF: "yes"
+      - kilo-r11.0.1:
+          branch: r11.0.1
+          branches: "r11.0.1"
+          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+          SERIES_USER_VARS: |
+            tempest_test_sets: 'scenario defcore api heat_api smoke'
+          DEPLOY_TELEGRAF: "yes"
+      - kilo-r11.0.0:
+          branch: r11.0.0
+          branches: "r11.0.0"
+          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+          SERIES_USER_VARS: |
+            tempest_test_sets: 'scenario defcore api heat_api smoke'
+          DEPLOY_TELEGRAF: "yes"
+    image:
+      - trusty:
+          DEFAULT_IMAGE: "14.04.5"
+    action:
+      - leapfrogupgrade:
+          ACTION_STAGES: >-
+            Prepare MaaS,
+            Install Tempest,
+            Leapfrog Upgrade
+    resources:
+      - small:
+          GENERATE_TEST_NETWORKS: "20"
+          GENERATE_TEST_SERVERS: "20"
+          GENERATE_TEST_VOLUMES: "8"
+          COMPUTE_NODES: "2"
+          VOLUME_NODES: "2"
+    trigger:
+      - periodic:
+          CRON: "H H * * H/2"
+    jobs:
+      - 'OnMetal-Multi-Node-AIO_{series}-{image}-{action}-{resources}-{trigger}'

--- a/rpc_jobs/multi_node_aio_leapfrog.yml
+++ b/rpc_jobs/multi_node_aio_leapfrog.yml
@@ -1,87 +1,99 @@
 - project:
     name: 'Multi-Node-AIO-Leapfrog-Testing'
     series:
-      - kilo-r11.1.18:
-          branch: r11.1.18
-          branches: "r11.1.18"
-          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+      - newton-r11.1.18:
+          UPGRADE_FROM_REF: "r11.1.18"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
             tempest_test_sets: 'scenario defcore api heat_api smoke'
           DEPLOY_TELEGRAF: "yes"
-      - kilo-r11.1.15:
-          branch: r11.1.15
-          branches: "r11.1.15"
-          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+      - newton-r11.1.15:
+          UPGRADE_FROM_REF: "r11.1.15"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
             tempest_test_sets: 'scenario defcore api heat_api smoke'
           DEPLOY_TELEGRAF: "yes"
-      - kilo-r11.1.14:
-          branch: r11.1.14
-          branches: "r11.1.14"
-          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+      - newton-r11.1.14:
+          UPGRADE_FROM_REF: "r11.1.14"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
             tempest_test_sets: 'scenario defcore api heat_api smoke'
           DEPLOY_TELEGRAF: "yes"
-      - kilo-r11.1.10:
-          branch: r11.1.10
-          branches: "r11.1.10"
-          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+      - newton-r11.1.10:
+          UPGRADE_FROM_REF: "r11.1.10"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
             tempest_test_sets: 'scenario defcore api heat_api smoke'
           DEPLOY_TELEGRAF: "yes"
-      - kilo-r11.1.9:
-          branch: r11.1.9
-          branches: "r11.1.9"
-          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+      - newton-r11.1.9:
+          UPGRADE_FROM_REF: "r11.1.9"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
             tempest_test_sets: 'scenario defcore api heat_api smoke'
           DEPLOY_TELEGRAF: "yes"
-      - kilo-r11.1.6:
-          branch: r11.1.6
-          branches: "r11.1.6"
-          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+      - newton-r11.1.6:
+          UPGRADE_FROM_REF: "r11.1.6"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
             tempest_test_sets: 'scenario defcore api heat_api smoke'
           DEPLOY_TELEGRAF: "yes"
-      - kilo-r11.1.5:
-          branch: r11.1.5
-          branches: "r11.1.5"
-          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+      - newton-r11.1.5:
+          UPGRADE_FROM_REF: "r11.1.5"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
             tempest_test_sets: 'scenario defcore api heat_api smoke'
           DEPLOY_TELEGRAF: "yes"
-      - kilo-r11.1.4:
-          branch: r11.1.4
-          branches: "r11.1.4"
-          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+      - newton-r11.1.4:
+          UPGRADE_FROM_REF: "r11.1.4"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
             tempest_test_sets: 'scenario defcore api heat_api smoke'
           DEPLOY_TELEGRAF: "yes"
-      - kilo-r11.1.3:
-          branch: r11.1.3
-          branches: "r11.1.3"
-          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+      - newton-r11.1.3:
+          UPGRADE_FROM_REF: "r11.1.3"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
             tempest_test_sets: 'scenario defcore api heat_api smoke'
           DEPLOY_TELEGRAF: "yes"
-      - kilo-r11.0.4:
-          branch: r11.0.4
-          branches: "r11.0.4"
-          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+      - newton-r11.0.4:
+          UPGRADE_FROM_REF: "r11.0.4"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
             tempest_test_sets: 'scenario defcore api heat_api smoke'
           DEPLOY_TELEGRAF: "yes"
-      - kilo-r11.0.1:
-          branch: r11.0.1
-          branches: "r11.0.1"
-          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+      - newton-r11.0.1:
+          UPGRADE_FROM_REF: "r11.0.1"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
             tempest_test_sets: 'scenario defcore api heat_api smoke'
           DEPLOY_TELEGRAF: "yes"
-      - kilo-r11.0.0:
-          branch: r11.0.0
-          branches: "r11.0.0"
-          KIBANA_SELENIUM_BRANCH: "liberty-12.2"
+      - newton-r11.0.0:
+          UPGRADE_FROM_REF: "r11.0.0"
+          branch: "r14.2.0"
+          branches: "r14.2.0"
+          KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
             tempest_test_sets: 'scenario defcore api heat_api smoke'
           DEPLOY_TELEGRAF: "yes"


### PR DESCRIPTION
Adds multi-node AIO gate jobs for Kilo Leapfrog Testing.  Uses small resources only to limit the number of jobs, can be adjusted as we determine our testing needs.

Issue: [RLM-58](https://rpc-openstack.atlassian.net/browse/RLM-58)