### PR TITLE
RE-458 Build RAX instances with build_config=core

### DIFF
--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -15,6 +15,8 @@
           count: "{{ count }}"
           key_name: "jenkins"
           region: "{{ region }}"
+          meta:
+            build_config: core
           wait: yes
           wait_timeout: 900
           auto_increment: no


### PR DESCRIPTION
This patch allows us to build RAX instances without automatic
updates applied by the Rackspace agent. Automatic updates are causing
problems with artifacting and general gate jobs.

The documentation for this option is here:

  https://support.rackspace.com/how-to/cloud-server-configuration-options/

Issue: [RE-458](https://rpc-openstack.atlassian.net/browse/RE-458)