### PR TITLE
Set issue type for RPCO periodic failure issues.

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -330,7 +330,7 @@
                 currentBuild.result = 'FAILURE'
                 if (env.TRIGGER == 'periodic'){{
                   print("Creating jira issue in project RO for failed periodic build")
-                  common.create_jira_issue("RO")
+                  common.create_jira_issue("RO", env.BUILD_TAG, env.BUILD_URL, "Task")
                 }} else {{
                   print ("Not creating jira issue as this build is not periodic, trigger: ${{env.TRIGGER}}")
                 }}


### PR DESCRIPTION
This is required because the default issue type `Issue-releng-platform-alert` is not available in the RO project.

Test job: https://rpc.jenkins.cit.rackspace.net/job/scratchpipeline/413/console
Test job definition:
```
library "rpc-gating@master"
common.shared_slave(){
    common.create_jira_issue("RO", env.BUILD_TAG, env.BUILD_URL, "Task")
}
throw new Exception("stop now")
```
Resulting Issue: https://rpc-openstack.atlassian.net/projects/RO/issues/RO-2471?filter=allopenissues&orderby=created+DESC%2C+priority+DESC%2C+updated+DESC