### PR TITLE
RE-458 Prevent unattended upgrades executing

### DIFF
--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -4,7 +4,8 @@
   gather_facts: False
   vars:
     count: 1
-    inventory_path: '{{lookup("env", "WORKSPACE")}}/rpc-gating/playbooks/inventory'
+    inventory_path: "{{ lookup('env', 'WORKSPACE') }}/rpc-gating/playbooks/inventory"
+    user_data_path: "{{ lookup('env', 'WORKSPACE') }}/rpc-gating/scripts/user_data_pubcloud.sh"
   tasks:
     - name: Provision a set of public cloud instances
       local_action:
@@ -15,6 +16,13 @@
           count: "{{ count }}"
           key_name: "jenkins"
           region: "{{ region }}"
+          # TODO(odyssey4me):
+          # In Ansible<2.3 there is a bug which prevents the rax module from
+          # reading user_data files. To work around that bug, we supply the
+          # contents of the user_data file rather than the path to it. This
+          # bug is fixed in 2.3, so once we upgrade to 2.3+, we can set
+          # user_data: user_data_path
+          user_data: "{{ lookup('file', user_data_path) }}"
           meta:
             build_config: core
           wait: yes
@@ -53,7 +61,7 @@
 
     - name: Create inventory directory
       file:
-        path: "{{inventory_path}}"
+        path: "{{ inventory_path }}"
         state: directory
 
     - name: Write inventory
@@ -66,7 +74,7 @@
           {% for instance in rax.success %}
           {{instance.name}} ansible_host={{instance.accessIPv4}} ansible_user=root
           {% endfor %}
-        dest: '{{inventory_path}}/hosts'
+        dest: '{{ inventory_path }}/hosts'
 
     - name: Wait for SSH to be available on all hosts
       wait_for: port=22 host="{{ item.accessIPv4 }}"

--- a/scripts/user_data_pubcloud.sh
+++ b/scripts/user_data_pubcloud.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# This file is used when creating public
+# cloud instances.
+# See playbooks/allocate_pubcloud.yml
+
+source /etc/lsb-release
+
+# Delete configuration which enables automatic upgrades
+# to prevent the instance packages being upgraded before
+# the correct apt repositories have been configured.
+# ref: RE-458 / RE-473
+if [[ "${DISTRIB_CODENAME}" == "trusty" ]]; then
+    # The 'unattended-upgrades' package cannot
+    # be purged on trusty as it is a dependency
+    # for cloud-init. So instead we just remove
+    # the configuration.
+    rm -f /etc/apt/apt.conf.d/*unattended-upgrades
+else
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get purge -y unattended-upgrades
+fi
+exit 0


### PR DESCRIPTION
The default public cloud image includes the unattended
upgrades package which automatically upgrades all
installed packages when booting the instance.

RPC-O instance builds must not automatically upgrade
packages on boot as the test may require the use of
the apt artifacts repo which has differing, often older,
packages than those available upstream.

This patch uses cloud-init to prevent unattended
upgrades executing on boot.

Issue: [RE-473](https://rpc-openstack.atlassian.net/browse/RE-473)

Issue: [RE-458](https://rpc-openstack.atlassian.net/browse/RE-458)