### PR TITLE
Clean up Single use slave example instances.

### DIFF
--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -9,7 +9,7 @@
             Hours. Instances older than this will be removed.
       - string:
           name: "INSTANCE_PREFIX"
-          default: "ra|ri|om"
+          default: "ra|ri|om|su"
           description: |
             Only instances whose names match the supplied prefix pattern will
             be cleaned up.

--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -15,7 +15,7 @@
             be cleaned up.
       - string:
           name: "REGIONS"
-          default: "DFW IAD"
+          default: "DFW IAD ORD"
           description: |
             Only instances in the specified region will be cleaned up.
       - rpc_gating_params


### PR DESCRIPTION
These are built on PRs to rpc-gating as a way of testing the mechanism for booting instances and attaching them as Jenkins slaves. However sometimes cleanup fails, so we need to sweep these instances in the periodic cleanup job.