### PR TITLE
RLM-214 Leapfrog Gate Job Modifications

### DIFF
--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -49,35 +49,12 @@
             Tempest Tests,
             Prepare Kibana Selenium,
             Kibana Tests
-      - leapfrogupgrade:
-          ACTION_STAGES: >-
-            Prepare MaaS,
-            Install Tempest,
-            Leapfrog Upgrade
     resources:
       - none:
           GENERATE_TEST_NETWORKS: "0"
           GENERATE_TEST_SERVERS: "0"
           GENERATE_TEST_VOLUMES: "0"
           COMPUTE_NODES: "2"
-          VOLUME_NODES: "2"
-      - small:
-          GENERATE_TEST_NETWORKS: "20"
-          GENERATE_TEST_SERVERS: "20"
-          GENERATE_TEST_VOLUMES: "8"
-          COMPUTE_NODES: "2"
-          VOLUME_NODES: "2"
-      - medium:
-          GENERATE_TEST_NETWORKS: "50"
-          GENERATE_TEST_SERVERS: "50"
-          GENERATE_TEST_VOLUMES: "20"
-          COMPUTE_NODES: "5"
-          VOLUME_NODES: "2"
-      - large:
-          GENERATE_TEST_NETWORKS: "100"
-          GENERATE_TEST_SERVERS: "100"
-          GENERATE_TEST_VOLUMES: "40"
-          COMPUTE_NODES: "10"
           VOLUME_NODES: "2"
     trigger:
       - periodic:
@@ -98,34 +75,6 @@
       # Ocata onwards.
       - series: master
         image: trusty
-      # Leapfrog upgrades are only run for kilo --> newton141
-      # as the upgrade method is not supported for any
-      # other target series.
-      # the kilo --> newton141 job is only ran as a periodic job until
-      # it's more reliable and can be tested as a PR
-      - action: leapfrogupgrade
-        trigger: pr
-      - series: liberty
-        action: leapfrogupgrade
-      - series: mitaka
-        action: leapfrogupgrade
-      - series: master
-        action: leapfrogupgrade
-      # Leapfrog upgrades cannot be executed on
-      # xenial as it is not possible to install
-      # the source series (kilo-mitaka) on xenial.
-      - image: xenial
-        action: leapfrogupgrade
-      # Resources are currently only used to measure end-user impact of
-      # leapfrog upgrades
-      - action: deploy
-        resources: small
-      - action: deploy
-        resources: medium
-      - action: deploy
-        resources: large
-      - action: leapfrogupgrade
-        resources: none
     jobs:
       - 'OnMetal-Multi-Node-AIO_{series}-{image}-{action}-{resources}-{trigger}'
       - 'OnMetal-Multi-Node-AIO-Merge-Trigger_{series}'

--- a/rpc_jobs/multi_node_aio_leapfrog.yml
+++ b/rpc_jobs/multi_node_aio_leapfrog.yml
@@ -1,8 +1,19 @@
 - project:
     name: 'Multi-Node-AIO-Leapfrog-Testing'
     series:
-      - newton-r11.1.18:
-          UPGRADE_FROM_REF: "r11.1.18"
+      - newton-kilo:
+          UPGRADE_FROM_REF: "kilo"
+          branch: "newton"
+          branches: "newton"
+          KIBANA_SELENIUM_BRANCH: "newton"
+          SERIES_USER_VARS: |
+            tempest_test_sets: 'all'
+            lxc_container_vg_name: "USE_DIR_NOT_VG"
+            glance_default_store: "swift"
+            neutron_legacy_ha_tool_enabled: true
+          DEPLOY_TELEGRAF: "yes"
+      - r14.2.0-kilo:
+          UPGRADE_FROM_REF: "kilo"
           branch: "r14.2.0"
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
@@ -12,10 +23,10 @@
             glance_default_store: "swift"
             neutron_legacy_ha_tool_enabled: true
           DEPLOY_TELEGRAF: "yes"
-      - newton-r11.1.15:
-          UPGRADE_FROM_REF: "r11.1.15"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
+      - newton-liberty:
+          UPGRADE_FROM_REF: "liberty"
+          branch: "newton"
+          branches: "newton"
           KIBANA_SELENIUM_BRANCH: "newton"
           SERIES_USER_VARS: |
             tempest_test_sets: 'all'
@@ -23,107 +34,8 @@
             glance_default_store: "swift"
             neutron_legacy_ha_tool_enabled: true
           DEPLOY_TELEGRAF: "yes"
-      - newton-r11.1.14:
-          UPGRADE_FROM_REF: "r11.1.14"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
-          SERIES_USER_VARS: |
-            tempest_test_sets: 'all'
-            lxc_container_vg_name: "USE_DIR_NOT_VG"
-            glance_default_store: "swift"
-            neutron_legacy_ha_tool_enabled: true
-          DEPLOY_TELEGRAF: "yes"
-      - newton-r11.1.10:
-          UPGRADE_FROM_REF: "r11.1.10"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
-          SERIES_USER_VARS: |
-            tempest_test_sets: 'all'
-            lxc_container_vg_name: "USE_DIR_NOT_VG"
-            glance_default_store: "swift"
-            neutron_legacy_ha_tool_enabled: true
-          DEPLOY_TELEGRAF: "yes"
-      - newton-r11.1.9:
-          UPGRADE_FROM_REF: "r11.1.9"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
-          SERIES_USER_VARS: |
-            tempest_test_sets: 'all'
-            lxc_container_vg_name: "USE_DIR_NOT_VG"
-            glance_default_store: "swift"
-            neutron_legacy_ha_tool_enabled: true
-          DEPLOY_TELEGRAF: "yes"
-      - newton-r11.1.6:
-          UPGRADE_FROM_REF: "r11.1.6"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
-          SERIES_USER_VARS: |
-            tempest_test_sets: 'all'
-            lxc_container_vg_name: "USE_DIR_NOT_VG"
-            glance_default_store: "swift"
-            neutron_legacy_ha_tool_enabled: true
-          DEPLOY_TELEGRAF: "yes"
-      - newton-r11.1.5:
-          UPGRADE_FROM_REF: "r11.1.5"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
-          SERIES_USER_VARS: |
-            tempest_test_sets: 'all'
-            lxc_container_vg_name: "USE_DIR_NOT_VG"
-            glance_default_store: "swift"
-            neutron_legacy_ha_tool_enabled: true
-          DEPLOY_TELEGRAF: "yes"
-      - newton-r11.1.4:
-          UPGRADE_FROM_REF: "r11.1.4"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
-          SERIES_USER_VARS: |
-            tempest_test_sets: 'all'
-            lxc_container_vg_name: "USE_DIR_NOT_VG"
-            glance_default_store: "swift"
-            neutron_legacy_ha_tool_enabled: true
-          DEPLOY_TELEGRAF: "yes"
-      - newton-r11.1.3:
-          UPGRADE_FROM_REF: "r11.1.3"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
-          SERIES_USER_VARS: |
-            tempest_test_sets: 'all'
-            lxc_container_vg_name: "USE_DIR_NOT_VG"
-            glance_default_store: "swift"
-            neutron_legacy_ha_tool_enabled: true
-          DEPLOY_TELEGRAF: "yes"
-      - newton-r11.0.4:
-          UPGRADE_FROM_REF: "r11.0.4"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
-          SERIES_USER_VARS: |
-            tempest_test_sets: 'all'
-            lxc_container_vg_name: "USE_DIR_NOT_VG"
-            glance_default_store: "swift"
-            neutron_legacy_ha_tool_enabled: true
-          DEPLOY_TELEGRAF: "yes"
-      - newton-r11.0.1:
-          UPGRADE_FROM_REF: "r11.0.1"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
-          SERIES_USER_VARS: |
-            tempest_test_sets: 'all'
-            lxc_container_vg_name: "USE_DIR_NOT_VG"
-            glance_default_store: "swift"
-            neutron_legacy_ha_tool_enabled: true
-          DEPLOY_TELEGRAF: "yes"
-      - newton-r11.0.0:
-          UPGRADE_FROM_REF: "r11.0.0"
+      - r14.2.0-liberty:
+          UPGRADE_FROM_REF: "liberty"
           branch: "r14.2.0"
           branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
@@ -148,6 +60,18 @@
           GENERATE_TEST_SERVERS: "20"
           GENERATE_TEST_VOLUMES: "8"
           COMPUTE_NODES: "2"
+          VOLUME_NODES: "2"
+      - medium:
+          GENERATE_TEST_NETWORKS: "50"
+          GENERATE_TEST_SERVERS: "50"
+          GENERATE_TEST_VOLUMES: "20"
+          COMPUTE_NODES: "5"
+          VOLUME_NODES: "2"
+      - large:
+          GENERATE_TEST_NETWORKS: "100"
+          GENERATE_TEST_SERVERS: "100"
+          GENERATE_TEST_VOLUMES: "40"
+          COMPUTE_NODES: "10"
           VOLUME_NODES: "2"
     trigger:
       - periodic:

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -46,20 +46,6 @@
       # to test the convergance of the upgrade itself
       # without additional complexity. Once this is
       # working well, additional stages may be added.
-      - leapfrogupgrade:
-          ACTION_STAGES: >-
-            Leapfrog Upgrade,
-            Install Tempest,
-            Tempest Tests,
-            Prepare Kibana Selenium,
-            Kibana Tests
-          GENERATE_TEST_NETWORKS: "6"
-          GENERATE_TEST_SERVERS: "4"
-          GENERATE_TEST_VOLUMES: "12"
-      # A minimum set of stages is chosen deliberately
-      # to test the convergance of the upgrade itself
-      # without additional complexity. Once this is
-      # working well, additional stages may be added.
       - minorupgrade:
           ACTION_STAGES: >-
             Minor Upgrade
@@ -122,30 +108,6 @@
         image: xenial
       - series: mitaka
         image: xenial
-      # Leapfrog upgrades are only run for kilo --> newton
-      # as the upgrade method is not supported for any
-      # other target series.
-      # the kilo --> newton job is only ran as a periodic job until
-      # it's more reliable and can be tested as a PR
-      - action: leapfrogupgrade
-        ztrigger: pr
-      - series: liberty
-        action: leapfrogupgrade
-      - series: mitaka
-        action: leapfrogupgrade
-      - series: master
-        action: leapfrogupgrade
-      # This combo tests the same thing as
-      # RPC-AIO_newton-trusty-leapfrogupgrade-swift-periodic and is not
-      # needed
-      #- series: kilo
-      #  action: leapfrogupgrade
-      #  trigger: periodic
-      # Leapfrog upgrades cannot be executed on
-      # xenial as it is not possible to install
-      # the source series (kilo-mitaka) on xenial.
-      - image: xenial
-        action: leapfrogupgrade
       # Ceph builds are not run for kilo at this time
       # as ceph deployment is not supported for
       # newton (yet) and the purpose of executing
@@ -158,11 +120,6 @@
       # consume the cluster, not deploy it. At that
       # time the scenario can be added back again.
       - series: newton
-        scenario: ceph
-      # Ceph builds are not tested for leapfrog upgrades
-      # at this time due to the failure for ceph to
-      # install on kilo.
-      - action: leapfrogupgrade
         scenario: ceph
       # Ceph builds are not tested for minor upgrades
       # at this time due to the minor upgrades only being

--- a/rpc_jobs/rpc_aio_leapfrog.yml
+++ b/rpc_jobs/rpc_aio_leapfrog.yml
@@ -3,78 +3,30 @@
     # Note: branch is the branch for periodics to build
     #       branches is the branch pattern to match for PR Jobs.
     series:
-      - newton-r11.1.18:
-          UPGRADE_FROM_REF: "r11.1.18"
+      - newton-kilo:
+          branch: newton
+          branches: "newton"
+          UPGRADE_FROM_REF: "kilo"
+          DEPLOY_TELEGRAF: "yes"
+          KIBANA_SELENIUM_BRANCH: "newton"
+      - r14.2.0-kilo:
           branch: "r14.2.0"
           branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
+          UPGRADE_FROM_REF: "kilo"
           DEPLOY_TELEGRAF: "yes"
-      - newton-r11.1.15:
-          UPGRADE_FROM_REF: "r11.1.15"
+          KIBANA_SELENIUM_BRANCH: "newton"
+      - newton-liberty:
+          branch: newton
+          branches: "newton"
+          UPGRADE_FROM_REF: "liberty"
+          DEPLOY_TELEGRAF: "yes"
+          KIBANA_SELENIUM_BRANCH: "newton"
+      - r14.2.0-liberty:
           branch: "r14.2.0"
           branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
+          UPGRADE_FROM_REF: "liberty"
           DEPLOY_TELEGRAF: "yes"
-      - newton-r11.1.14:
-          UPGRADE_FROM_REF: "r11.1.14"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
           KIBANA_SELENIUM_BRANCH: "newton"
-          DEPLOY_TELEGRAF: "yes"
-      - newton-r11.1.10:
-          UPGRADE_FROM_REF: "r11.1.10"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
-          DEPLOY_TELEGRAF: "yes"
-      - newton-r11.1.9:
-          UPGRADE_FROM_REF: "r11.1.9"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
-          DEPLOY_TELEGRAF: "yes"
-      - newton-r11.1.6:
-          UPGRADE_FROM_REF: "r11.1.6"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
-          DEPLOY_TELEGRAF: "yes"
-      - newton-r11.1.5:
-          UPGRADE_FROM_REF: "r11.1.5"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
-          DEPLOY_TELEGRAF: "yes"
-      - newton-r11.1.4:
-          UPGRADE_FROM_REF: "r11.1.4"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
-          DEPLOY_TELEGRAF: "yes"
-      - newton-r11.1.3:
-          UPGRADE_FROM_REF: "r11.1.3"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
-          DEPLOY_TELEGRAF: "yes"
-      - newton-r11.0.4:
-          UPGRADE_FROM_REF: "r11.0.4"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
-          DEPLOY_TELEGRAF: "yes"
-      - newton-r11.0.1:
-          UPGRADE_FROM_REF: "r11.0.1"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
-          DEPLOY_TELEGRAF: "yes"
-      - newton-r11.0.0:
-          UPGRADE_FROM_REF: "r11.0.0"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
-          DEPLOY_TELEGRAF: "yes"
     image:
       - trusty:
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"


### PR DESCRIPTION
* Removes all kilo point release branch jobs from
AIO/Multi as we are not going to test test individual
point release of Kilo
* Sets up K->N, K->N-14.2.0, L->N, L-> N-14.2.0 Periodics
as these will be our primary gate jobs to know if things broke.
Since we're getting ready for Liberty, adding these now as well.
* Moves leapfrogupgrade items to the _leapfrog config files, so
we can avoid issues with the existing jobs and own changes in
our config

Issue: [RLM-214](https://rpc-openstack.atlassian.net/browse/RLM-214)