### PR TITLE
RE-207 Standardise elements of archiving artefacts

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -356,8 +356,6 @@ def archive_artifacts(String build_type = "AIO"){
       print "Uploading artifacts to Cloud Files..."
       pubcloud.uploadToCloudFiles(
         container: "jenkins_logs",
-        src: "${env.WORKSPACE}/artifacts_${env.BUILD_TAG}.tar.bz2",
-        html_report_dest: "${env.WORKSPACE}/artifacts_report/index.html")
       publishHTML(
         allowMissing: true,
         alwaysLinkToLastBuild: true,

--- a/pipeline_steps/irr_role_tests.groovy
+++ b/pipeline_steps/irr_role_tests.groovy
@@ -47,8 +47,6 @@ def irr_archive_artifacts(){
       // artifact collection failed.
       pubcloud.uploadToCloudFiles(
         container: "jenkins_logs",
-        src: "${env.WORKSPACE}/artifacts_${env.BUILD_TAG}.tar.bz2",
-        html_report_dest: "${env.WORKSPACE}/artifacts_report/index.html")
       publishHTML(
         allowMissing: true,
         alwaysLinkToLastBuild: true,

--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -209,8 +209,6 @@ def uploadToCloudFiles(Map args){
           playbooks: ["upload_to_cloud_files.yml"],
           vars: [
             container: args.container,
-            src: args.src,
-            html_report_dest: args.html_report_dest,
             description_file: args.description_file
           ]
         ) // venvPlaybook

--- a/playbooks/archive_artifacts.yml
+++ b/playbooks/archive_artifacts.yml
@@ -2,7 +2,7 @@
   tasks:
     - name: Create temporary directory to store artifacts
       file:
-        path: "{{ artifacts_path }}"
+        path: "{{ artifacts_dir }}"
         state: directory
       delegate_to: "localhost"
       run_once: yes
@@ -17,7 +17,7 @@
                --rsh 'ssh -o StrictHostKeyChecking=no'
                --ignore-missing-args
                {{ inventory_hostname }}:{{ item }}
-               {{ artifacts_path }}/{{ ansible_hostname }}
+               {{ artifacts_dir }}/{{ ansible_hostname }}
       with_items:
         - "/openstack/log"
         - "/etc"
@@ -36,7 +36,7 @@
                --include '*.leap'
                --exclude '*'
                {{ inventory_hostname }}:/opt/rpc-leapfrog/leap42/
-               {{ artifacts_path }}/{{ ansible_hostname }}/leap_marker_files
+               {{ artifacts_dir }}/{{ ansible_hostname }}/leap_marker_files
       delegate_to: "localhost"
       ignore_errors: yes
       tags:
@@ -60,7 +60,7 @@
                --rsh 'ssh -o StrictHostKeyChecking=no'
                --ignore-missing-args
                {{ inventory_hostname }}:{{ item[1].pre }}/{{ item[0] }}{{ item[1].post }}
-               {{ artifacts_path }}/{{ ansible_hostname }}
+               {{ artifacts_dir }}/{{ ansible_hostname }}
       when: "{{ containers.rc == 0 }}"
       with_nested:
         - "{{ containers.stdout_lines | default([]) }}"
@@ -70,18 +70,7 @@
       delegate_to: "localhost"
       tags:
         - skip_ansible_lint
-
-    - name: Create archive
-      command: "tar -cjf {{ artifacts_basename }}.tar.bz2 {{ artifacts_basename }}"
-      args:
-        chdir: "{{ artifacts_basedir }}"
-      delegate_to: "localhost"
-      run_once: yes
-      tags:
-        - skip_ansible_lint
   vars:
-    build_tag: "{{ lookup('env','BUILD_TAG') }}"
-    artifacts_basename: "artifacts_{{ build_tag }}"
-    artifacts_basedir: "{{ lookup('env','WORKSPACE') }}"
-    artifacts_path: "{{ artifacts_basedir }}/{{ artifacts_basename }}"
+    workspace: "lookup('env', 'WORKSPACE') }}"
+    artifacts_dir: "{{ workspace }}/artifacts }}"
     target_hosts: "localhost"

--- a/playbooks/templates/cloudfiles.html.j2
+++ b/playbooks/templates/cloudfiles.html.j2
@@ -1,6 +1,6 @@
 <html>
 <body>
-<a href="{{ public_container.container_urls.ssl_url }}/{{ src | basename }}">{{ src | basename }}</a>
+<a href="{{ public_container.container_urls.ssl_url }}/{{ archive_name }}">{{ archive_name }}</a>
 <div style="white-space: pre">
 {{ artifact_description | default("") }}
 </div>

--- a/playbooks/upload_to_cloud_files.yml
+++ b/playbooks/upload_to_cloud_files.yml
@@ -3,6 +3,13 @@
   connection: local
   gather_facts: False
   tasks:
+    - name: Create archive
+      command: "tar -cjf {{ archive_name }} {{ artifacts_dir }}"
+      args:
+        chdir: "{{ artifacts_parent_dir }}"
+      tags:
+        - skip_ansible_lint
+
     - name: Create a public Cloud Files container
       rax_files:
         container: "{{ container }}"
@@ -16,7 +23,7 @@
         region: "DFW"
         expires: 2592000
         method: put
-        src: "{{ src }}"
+        src: "{{ artifacts_parent_dir }}/{{ archive_name }}"
 
     - name: Read artifact description file
       set_fact:
@@ -28,10 +35,17 @@
 
     - name: Create artifact report location if doesn't exist
       file:
-        path: "{{ html_report_dest | dirname }}"
+        path: "{{ report_dir }}"
         state: directory
 
     - name: Generate HTML report with file URL
       template:
         src: cloudfiles.html.j2
-        dest: "{{ html_report_dest }}"
+        dest: "{{ report_dir }}/index.html"
+  vars:
+    build_tag: "{{ lookup('env','BUILD_TAG') }}"
+    archive_name: "artifacts_{{ build_tag }}.tar.bz2"
+    workspace: "lookup('env', 'WORKSPACE') }}"
+    artifacts_parent_dir: "{{ workspace }}"
+    artifacts_dir: "{{ artifacts_parent_dir }}/artifacts }}"
+    report_dir: "{{ artifacts_parent_dir }}/artifacts_report"

--- a/rpc_jobs/single_use_slave_template.yml
+++ b/rpc_jobs/single_use_slave_template.yml
@@ -40,8 +40,6 @@
             // upload the artifact to cloudfiles
             pubcloud.uploadToCloudFiles(
               container: "jenkins_logs",
-              src: "${WORKSPACE}/artifacts/datestamp",
-              html_report_dest: "${WORKSPACE}/artifacts/artifacts.html"
             )
           }
 


### PR DESCRIPTION
Artefacts, such as logs and configuration files, need to be stored for
finished builds. This commit changes some aspects of how this is done to
provide a cleaner separation between the responsibilities of RE and its
customers.

With this change `upload_to_cloud_files.yml` is now responsible for
taking the data to be archived, creating an appropriately named
compressed tarball, and uploading it to Cloud Files. This reduces the
responsibility of `archive_artifacts.yml`, the RPCO-specific artefact
script, to collecting all the required data into one directory.

`html_report_dest` is removed given there is no need to be able to
override it, the report file is created temporarily and is not something
that needs to be configured for a job.

The result of these changes is that any job must store all of its
artefacts in `$WORKSPACE/artifacts`.

Issue: [RE-207](https://rpc-openstack.atlassian.net/browse/RE-207)