### PR TITLE
RE-577 Improve respawn behaviour of webhook tunnel

### DIFF
--- a/pipeline_steps/webhooks.groovy
+++ b/pipeline_steps/webhooks.groovy
@@ -65,8 +65,14 @@ def webhooks(){
 start on runlevel 2
 # ssh will not daemonize so use the default expect.
 # expect
-exec ssh root@$ip -i \$keyfile -R 8888:localhost:443 -N
 respawn
+respawn limit unlimited
+exec ssh root@$ip -i \$keyfile -R 8888:localhost:443 -N
+# This is the recommended way of implementing a respawn delay
+# This is required to prevent a tight loop consuming jenkins master
+# resources while trying to reconnect to the webhook proxy node.
+# http://upstart.ubuntu.com/cookbook/#delay-respawn-of-a-job
+post-stop exec sleep 15
 EOF
 
                 cat > \$jdir/root_setup.sh <<EOF


### PR DESCRIPTION
CIT Jenkins is hosted internally with no forwarding for receiving
webhooks from github. To work around this we host a webhook proxy
in public cloud, this runs nginx, receives webhooks from github and
forwards them via an ssh tunnel to CIT Jenkins.

The ssh tunnel must be started on the Jenkins master and connect
out to the webhook proxy node as connections in the other direction
are not possible. The webhook setup job creates a script on the
Jenkins master that in turn creates an upstart job to manage the tunnel.

This commit improves the upstart job by removing the respawn limit
and adding a delay between respawn attempts.

Issue: [RE-577](https://rpc-openstack.atlassian.net/browse/RE-577)