### PR TITLE
RE-584 Remove unnecessary brackets

### DIFF
--- a/playbooks/archive_artifacts.yml
+++ b/playbooks/archive_artifacts.yml
@@ -72,5 +72,5 @@
         - skip_ansible_lint
   vars:
     workspace: "{{ lookup('env', 'WORKSPACE') }}"
-    artifacts_dir: "{{ workspace }}/artifacts }}"
+    artifacts_dir: "{{ workspace }}/artifacts"
     target_hosts: "localhost"


### PR DESCRIPTION
Commit 13a82431 introduced a bug due to an extra pair of `}}` in an
Ansible var. This commit removes them to fix the collection of build
artefacts.

Issue: [RE-584](https://rpc-openstack.atlassian.net/browse/RE-584)