### PR TITLE
RE-506 Implement pre_merge_test standard job

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -1,0 +1,15 @@
+#!/bin/bash -xeu
+mkdir -p ${RE_HOOK_ARTIFACT_DIR}
+
+# Record the datetime as a basic artifact
+date > ${RE_HOOK_ARTIFACT_DIR}/datestamp
+
+# Record the job parameters as an artifact
+cat <<EOF > ${RE_HOOK_ARTIFACT_DIR}/environment
+RE_JOB_NAME: ${RE_JOB_NAME}
+RE_JOB_IMAGE: ${RE_JOB_IMAGE}
+RE_JOB_SCENARIO: ${RE_JOB_SCENARIO}
+RE_JOB_ACTION: ${RE_JOB_ACTION}
+RE_JOB_FLAVOR: ${RE_JOB_FLAVOR}
+RE_JOB_TRIGGER: ${RE_JOB_TRIGGER}
+EOF

--- a/pipeline_steps/artifact_build.groovy
+++ b/pipeline_steps/artifact_build.groovy
@@ -59,7 +59,7 @@ def git(String image) {
       print(e)
       throw e
     } finally {
-      common.archive_artifacts()
+      common.rpco_archive_artifacts()
     }
   } // pubcloud slave
 }
@@ -81,7 +81,7 @@ def python(String image) {
       print(e)
       throw e
     } finally {
-      common.archive_artifacts()
+      common.rpco_archive_artifacts()
     }
   } // pubcloud slave
 }
@@ -103,7 +103,7 @@ def container(String image) {
       print(e)
       throw e
     } finally {
-      common.archive_artifacts()
+      common.rpco_archive_artifacts()
     }
   } // pubcloud slave
 }

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -325,7 +325,7 @@ def String gen_instance_name(String prefix="AUTO"){
   return instance_name
 }
 
-def archive_artifacts(String build_type = "AIO"){
+def rpco_archive_artifacts(String build_type = "AIO"){
   try{
     if ( build_type == "MNAIO" ){
       args = [
@@ -351,24 +351,23 @@ def archive_artifacts(String build_type = "AIO"){
     print(e)
     throw(e)
   } finally{
-    // still worth trying to archiveArtifacts even if some part of
-    // artifact collection failed.
-      print "Uploading artifacts to Cloud Files..."
-      pubcloud.uploadToCloudFiles(
-        container: "jenkins_logs",
-      )
-      publishHTML(
-        allowMissing: true,
-        alwaysLinkToLastBuild: true,
-        keepAll: true,
-        reportDir: 'artifacts_report',
-        reportFiles: 'index.html',
-        reportName: 'Build Artifact Links'
-      )
-    sh """
-    rm -rf artifacts_\${BUILD_TAG}
-    rm -f artifacts_${env.BUILD_TAG}.tar.bz2
-    """
+    archive_artifacts()
+  }
+}
+
+def archive_artifacts(){
+  stage('Compress and Publish Artifacts'){
+    pubcloud.uploadToCloudFiles(
+      container: "jenkins_logs",
+    )
+    publishHTML(
+      allowMissing: true,
+      alwaysLinkToLastBuild: true,
+      keepAll: true,
+      reportDir: 'artifacts_report',
+      reportFiles: 'index.html',
+      reportName: 'Build Artifact Links'
+    )
   }
 }
 

--- a/pipeline_steps/irr_role_tests.groovy
+++ b/pipeline_steps/irr_role_tests.groovy
@@ -27,25 +27,9 @@ def run_irr_tests() {
       throw e
     } finally {
       common.safe_jira_comment("${currentBuild.result}: [${env.BUILD_TAG}|${env.BUILD_URL}]")
-      irr_archive_artifacts()
+      common.archive_artifacts()
     }
   } // pubcloud slave
-}
-
-def irr_archive_artifacts(){
-  stage('Compress and Publish Artefacts'){
-    pubcloud.uploadToCloudFiles(
-      container: "jenkins_logs",
-    )
-    publishHTML(
-      allowMissing: true,
-      alwaysLinkToLastBuild: true,
-      keepAll: true,
-      reportDir: 'artifacts_report',
-      reportFiles: 'index.html',
-      reportName: 'Build Artifact Links'
-    )
-  }
 }
 
 return this;

--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -249,7 +249,7 @@
                 deploy.upgrade_leapfrog(environment_vars: environment_vars)
               }}
             }} finally {{
-              common.archive_artifacts("MNAIO")
+              common.rpco_archive_artifacts("MNAIO")
             }}
           }}// deploy node on public cloud node
         }} catch (e){{

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -331,7 +331,7 @@
                 }}
                 throw e
               }} finally {{
-                common.archive_artifacts()
+                common.rpco_archive_artifacts()
                 common.safe_jira_comment("${{currentBuild.result}}: [${{env.BUILD_TAG}}|${{env.BUILD_URL}}]")
               }}
             }} //pubcloud slave

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -1,0 +1,143 @@
+- project:
+    name: "gating"
+    repo_url: "https://github.com/rcbops/rpc-gating"
+    branches:
+      - "master"
+    image:
+      - "xenial"
+    scenario:
+      - "functional"
+    action:
+      - "test"
+    jobs:
+      - 'PR_{name}-{image}-{scenario}-{action}'
+
+- job-template:
+    name: 'PR_{name}-{image}-{scenario}-{action}'
+    project-type: pipeline
+    concurrent: true
+    FLAVOR: "performance1-1"
+    IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+    properties:
+      - build-discarder:
+          num-to-keep: "30"
+      - github:
+          url: "{repo_url}"
+    parameters:
+      - rpc_gating_params
+      - instance_params:
+          IMAGE: "{IMAGE}"
+          FLAVOR: "{FLAVOR}"
+          REGIONS: "{REGIONS}"
+          FALLBACK_REGIONS: "{FALLBACK_REGIONS}"
+      - string:
+          name: STAGES
+          default: >-
+            Allocate Resources,
+            Connect Slave,
+            Cleanup,
+            Destroy Slave
+          description: |
+            Pipeline stages to run CSV. Note that this list does not influence execution order.
+            Options:
+              Allocate Resources
+              Connect Slave
+              Cleanup
+              Destroy Slave
+    triggers:
+      - github-pull-request:
+          org-list:
+            - rcbops
+          github-hooks: true
+          trigger-phrase: '.*recheck_(cit_)?all.*|.*recheck_(cit_)?{image}_{scenario}_{action}.*'
+          only-trigger-phrase: false
+          white-list-target-branches: "{branches}"
+          auth-id: "github_account_rpc_jenkins_svc"
+          status-context: 'CIT/{image}_{scenario}_{action}'
+          cancel-builds-on-update: true
+
+    dsl: |
+      library "rpc-gating@${{RPC_GATING_BRANCH}}"
+
+      // Pass details about the job parameters through
+      // to the target environment so that scripts can
+      // use them to adapt behaviour.
+      env.RE_JOB_NAME = "{name}"
+      env.RE_JOB_IMAGE = "{image}"
+      env.RE_JOB_SCENARIO = "{scenario}"
+      env.RE_JOB_ACTION = "{action}"
+      env.RE_JOB_FLAVOR = "{FLAVOR}"
+      env.RE_JOB_TRIGGER = "PR"
+
+      // Apply a global three hour timeout
+      timeout(time: 3, unit: 'HOURS'){{
+        common.shared_slave() {{
+          pubcloud.runonpubcloud {{
+
+            // Set the default environment variables used
+            // by the artifact and test result collection.
+            env.RE_HOOK_ARTIFACT_DIR="${{env.WORKSPACE}}/artifacts"
+            env.RE_HOOK_RESULT_DIR="${{env.WORKSPACE}}/results"
+
+            // Set the job result default
+            currentBuild.result="SUCCESS"
+
+            try {{
+              ansiColor('xterm') {{
+                dir("${{env.WORKSPACE}}/${{env.ghprbGhRepository}}") {{
+                  withCredentials(common.get_cloud_creds()) {{
+
+                    stage('Checkout') {{
+                      print("Triggered by PR: ${{env.ghprbPullLink}}")
+                      common.clone_with_pr_refs()
+                    }} // stage
+
+                    stage('Execute Pre-Merge Test (pre)') {{
+                      // Retry the 'pre' stage 3 times. The 'pre' stage is considered
+                      // to be preparation for the test, so let's try and make sure
+                      // it has the best chance of success possible.
+                      retry(3) {{
+                        sh """#!/bin/bash -xeu
+                        if [[ -e gating/pre_merge_test/pre ]]; then
+                          gating/pre_merge_test/pre
+                        fi
+                        """
+                      }}
+                    }} // stage
+
+                    stage('Execute Pre-Merge Test (run)') {{
+                      sh """#!/bin/bash -xeu
+                      gating/pre_merge_test/run
+                      """
+                    }} // stage
+
+                    stage('Execute Pre-Merge Test (post)') {{
+                      // We do not want the 'post' execution to fail the test,
+                      // but we do want to know if it fails so we make it only
+                      // return status.
+                      post_result = sh(
+                        returnStatus: true,
+                        script: """#!/bin/bash -xeu
+                                   if [[ -e gating/pre_merge_test/post ]]; then
+                                     gating/pre_merge_test/post
+                                   fi"""
+                      )
+                      if (post_result != 0) {{
+                        print("Pre-Merge Test (post) failed with return code ${{post_result}}")
+                      }} // if
+                    }} // stage
+
+                  }} // withCredentials
+                }} // dir
+              }} // ansiColor
+            }} catch (e) {{
+              print(e)
+              currentBuild.result="FAILURE"
+              throw e
+            }} finally {{
+              common.safe_jira_comment("${{currentBuild.result}}: [${{env.BUILD_TAG}}|${{env.BUILD_URL}}]")
+              common.archive_artifacts()
+            }} // try
+          }} // pubcloud slave
+        }} // cit node
+      }} // timeout


### PR DESCRIPTION
As documented in [1] this patch implements a standard
job for the pre_merge_test hook. It also implements
a job for the rpc-gating repository to execute it
which can replace the current Single-Use-Slave-Example
job.

The artifact publishing across all jobs now also uses
a common function - this removes the current duplication
and ensures consistency in the application. In order to
achieve this the collection of job artifacts for the
RPC-O jobs has been ranamed to be RPC-O spcific.

[1] https://rpc-openstack.atlassian.net/wiki/spaces/RE/pages/19005457/RE+for+Projects

Issue: [RE-506](https://rpc-openstack.atlassian.net/browse/RE-506)