### PR TITLE
RE-590 Include all newton.* branches for PR tests

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -16,7 +16,7 @@
           UPGRADE_FROM_REF: "liberty"
       - newton:
           branch: newton
-          branches: "newton"
+          branches: "newton.*"
           UPGRADE_FROM_REF: "kilo"
           DEPLOY_TELEGRAF: "yes"
       - master:
@@ -145,7 +145,7 @@
     series:
       - newton:
           branch: newton
-          branches: "newton"
+          branches: "newton.*"
       - master:
           branch: master
           branches: "master"


### PR DESCRIPTION
Currently only the 'newton' branch is tested, leaving
out the 'newton-rc' branch. This patch updates the job
definition to ensure that the PR tests also run against
the 'newton-rc' branch or any other newton prefixed
name.

Issue: [RE-590](https://rpc-openstack.atlassian.net/browse/RE-590)