### PR TITLE
RE-613 Skip artifact upload if dir not found

### DIFF
--- a/pipeline_steps/irr_role_tests.groovy
+++ b/pipeline_steps/irr_role_tests.groovy
@@ -30,37 +30,17 @@ def run_irr_tests() {
 
 def irr_archive_artifacts(){
   stage('Compress and Publish Artefacts'){
-    try{
-      sh """#!/bin/bash
-      d="artifacts_\${BUILD_TAG}"
-      mkdir -p "${WORKSPACE}/logs"
-      pushd "${WORKSPACE}/logs"
-        touch "\$d".marker
-      popd
-      tar -C "${WORKSPACE}/logs" -cjf "${env.WORKSPACE}/\$d".tar.bz2 .
-      """
-    } catch (e){
-      print(e)
-      throw(e)
-    } finally{
-      // still worth trying to archiveArtifacts even if some part of
-      // artifact collection failed.
-      pubcloud.uploadToCloudFiles(
-        container: "jenkins_logs",
-      )
-      publishHTML(
-        allowMissing: true,
-        alwaysLinkToLastBuild: true,
-        keepAll: true,
-        reportDir: 'artifacts_report',
-        reportFiles: 'index.html',
-        reportName: 'Build Artifact Links'
-      )
-      sh """
-      rm -rf "${WORKSPACE}/logs"
-      rm -f artifacts_${env.BUILD_TAG}.tar.bz2
-      """
-    }
+    pubcloud.uploadToCloudFiles(
+      container: "jenkins_logs",
+    )
+    publishHTML(
+      allowMissing: true,
+      alwaysLinkToLastBuild: true,
+      keepAll: true,
+      reportDir: 'artifacts_report',
+      reportFiles: 'index.html',
+      reportName: 'Build Artifact Links'
+    )
   }
 }
 

--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -198,23 +198,28 @@ def runonpubcloud(Map args=[:], body){
 }
 
 def uploadToCloudFiles(Map args){
-  withCredentials(common.get_cloud_creds()) {
-    dir("rpc-gating/playbooks") {
-      pyrax_cfg = common.writePyraxCfg(
-        username: env.PUBCLOUD_USERNAME,
-        api_key: env.PUBCLOUD_API_KEY
-      )
-      withEnv(["RAX_CREDS_FILE=${pyrax_cfg}"]) {
-        common.venvPlaybook(
-          playbooks: ["upload_to_cloud_files.yml"],
-          vars: [
-            container: args.container,
-            description_file: args.description_file
-          ]
-        ) // venvPlaybook
-      } // withEnv
-    } // dir
-  } // withCredentials
+  if(fileExists("${WORKSPACE}/artifacts")){
+    print("WORKSPACE/artifacts directory found, Preparing to upload artifacts.")
+    withCredentials(common.get_cloud_creds()) {
+      dir("rpc-gating/playbooks") {
+        pyrax_cfg = common.writePyraxCfg(
+          username: env.PUBCLOUD_USERNAME,
+          api_key: env.PUBCLOUD_API_KEY
+        )
+          withEnv(["RAX_CREDS_FILE=${pyrax_cfg}"]) {
+            common.venvPlaybook(
+              playbooks: ["upload_to_cloud_files.yml"],
+              vars: [
+                container: args.container,
+                description_file: args.description_file
+              ]
+            ) // venvPlaybook
+          } // withEnv
+      } // dir
+    } // withCredentials
+  } else {
+    print("WORKSPACE/artifacts not found, skipping artifact upload")
+  }
 }
 
 return this


### PR DESCRIPTION
Currently IRR jobs are failing as they write logs to WORKSPACE/logs,
but the artifact upload playbook is expecting them in
WORKSPACE/artifacts. This commit implements the first part of the
solution which is to skip upload if WORKSPACE/artifacts doesn't
exist.

The second half is to modify IRR jobs to write artifacts into
WORKSPACE/artifacts so they are archive correctly.

This commit also removes artifact compression from the IRR job
as that is now handled in pubcloud.uploadToCloudFiles.

Issue: [RE-613](https://rpc-openstack.atlassian.net/browse/RE-613)