### PR TITLE
RE-613 Set artifact environment vars in IRR jobs

### DIFF
--- a/pipeline_steps/irr_role_tests.groovy
+++ b/pipeline_steps/irr_role_tests.groovy
@@ -1,6 +1,8 @@
 def run_irr_tests() {
   pubcloud.runonpubcloud {
     currentBuild.result="SUCCESS"
+    env.RE_HOOK_ARTIFACT_DIR="${WORKSPACE}/artifacts"
+    env.RE_HOOK_RESULT_DIR="${WORKSPACE}/results"
     try {
       ansiColor('xterm') {
         dir("${env.WORKSPACE}/${env.ghprbGhRepository}") {
@@ -11,6 +13,8 @@ def run_irr_tests() {
           stage('Execute ./run_tests.sh'){
             withCredentials(common.get_cloud_creds()) {
               sh """#!/bin/bash
+              mkdir -p "${RE_HOOK_RESULTS_DIR}"
+              mkdir -p "${RE_HOOK_ARTIFACT_DIR}"
               bash ./run_tests.sh
               """
             }


### PR DESCRIPTION
Recently we standardised the artifact location to WORKSPACE/artifacts
but also decided that projects should not rely on that, instead
they should read the RE_HOOK_ARTIFACTS_DIR environment variable
in order to determine the correct place to place artifacts.

This commit ensures that the artifacts and test result env vars
are available in IRR jobs.

Issue: [RE-613](https://rpc-openstack.atlassian.net/browse/RE-613)