### PR TITLE
RE-197 Skip deploy test for non-deploy hook files

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -519,7 +519,9 @@ def is_doc_update_pr(String git_dir) {
             | egrep -v -e '.*md\$' \
                        -e '.*rst\$' \
                        -e '^releasenotes/' \
-                       -e '^gating/generate_release_notes/'
+                       -e '^gating/generate_release_notes/' \
+                       -e '^gating/post_merge' \
+                       -e '^gating/update_dependencies/'
         """,
         returnStatus: true
       )


### PR DESCRIPTION
When updating hooks for non-deploy tests the
deployment tests do not need to execute. These
files should be tested in a lint, docs or reno
specific test.

Issue: [RE-197](https://rpc-openstack.atlassian.net/browse/RE-197)