### PR TITLE
RE-613 Fix env var spelling

### DIFF
--- a/pipeline_steps/irr_role_tests.groovy
+++ b/pipeline_steps/irr_role_tests.groovy
@@ -13,7 +13,7 @@ def run_irr_tests() {
           stage('Execute ./run_tests.sh'){
             withCredentials(common.get_cloud_creds()) {
               sh """#!/bin/bash
-              mkdir -p "${RE_HOOK_RESULTS_DIR}"
+              mkdir -p "${RE_HOOK_RESULT_DIR}"
               mkdir -p "${RE_HOOK_ARTIFACT_DIR}"
               bash ./run_tests.sh
               """


### PR DESCRIPTION
The right env var is defined in https://rpc-openstack.atlassian.net/wiki/spaces/RE/pages/19005457/RE+for+Projects

Issue: [RE-613](https://rpc-openstack.atlassian.net/browse/RE-613)