### PR TITLE
HUM-330 add ceph job for rpc-maas 

### DIFF
--- a/rpc_jobs/irr_role_test.yml
+++ b/rpc_jobs/irr_role_test.yml
@@ -20,6 +20,7 @@
       - mitaka
       - liberty
       - kilo
+      - ceph
     exclude:
       # NOTE(cloudnull): The image context is only applied to certain releases.
       - image: trusty
@@ -34,6 +35,8 @@
         context: liberty
       - image: xenial
         context: kilo
+      - image: trusty
+        context: ceph
     jobs:
       - 'RPC-IRR_{repo}-{series}-{image}-{context}'
 


### PR DESCRIPTION
This axis will be used for the MaaS jobs to deploy with ceph
or no additional storage backend.

Note that this commit does not implement a ceph deploy for rpc-maas,
it provides a new environment variable (IRR_SCENARIO=deploy/ceph)
which rpc-maas/run_tests.sh can use to deploy and test the correct
scenario. This variable will also be provided to all the other IRR
jobs, but they can safely ignore it until they need multiple scenarios.

Issue: [HUM-330](https://rpc-openstack.atlassian.net/browse/HUM-330)