### PR TITLE
RE-97 Revert "RE-97 Add support for rpco multi-node AIO config prep"

### DIFF
--- a/pipeline_steps/multi_node_aio_prepare.groovy
+++ b/pipeline_steps/multi_node_aio_prepare.groovy
@@ -68,9 +68,7 @@ def prepare() {
       } // dir
     } //stage
   ) //conditionalStage
-}
 
-def prepare_configs(){
   common.conditionalStage(
     stage_name: 'Prepare RPC Configs',
     stage: {
@@ -80,17 +78,22 @@ def prepare_configs(){
       sh """/bin/bash
       echo "multi_node_aio_prepare.prepare/Prepare RPC Configs"
       set -xe
+      scp -r -o StrictHostKeyChecking=no /opt/rpc-openstack infra1:/opt/
+      scp -o StrictHostKeyChecking=no ${env.WORKSPACE}/user_zzz_gating_variables.yml infra1:/etc/openstack_deploy/user_zzz_gating_variables.yml
+
+      ssh -T -o StrictHostKeyChecking=no infra1 << 'EOF'
+      set -xe
       sudo cp /etc/openstack_deploy/user_variables.yml /etc/openstack_deploy/user_variables.yml.bak
       sudo cp -R /opt/rpc-openstack/openstack-ansible/etc/openstack_deploy /etc
       sudo cp /etc/openstack_deploy/user_variables.yml.bak /etc/openstack_deploy/user_variables.yml
 
       sudo cp /opt/rpc-openstack/rpcd/etc/openstack_deploy/user_*.yml /etc/openstack_deploy
       sudo cp /opt/rpc-openstack/rpcd/etc/openstack_deploy/env.d/* /etc/openstack_deploy/env.d
+EOF
       """
     } //stage
   ) //conditionalStage
 }
-
 
 def connect_deploy_node(name, instance_ip) {
   String inventory_name="deploy_vm_inventory.${common.rand_int_str()}"

--- a/playbooks/vars/onmetal.yml
+++ b/playbooks/vars/onmetal.yml
@@ -1,4 +1,5 @@
 ---
+gating_overrides_file: "{{ lookup('env', 'WORKSPACE') }}/user_zzz_gating_variables.yml"
 gating_overrides:
   apply_security_hardening: false
   maas_fqdn_extension: ".{{ lookup('env', 'NODE_NAME') }}"

--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -197,10 +197,6 @@
       library "rpc-gating@${{RPC_GATING_BRANCH}}"
       common.shared_slave(){{
         try {{
-          // pass JJB axes through to environment
-          env.TRIGGER = "{trigger}"
-          env.TARGET = "mnaio"
-          env.SERIES = "{series}"
           instance_name = common.gen_instance_name()
           deploy_node = null
           pubcloud.getPubCloudSlave(instance_name: instance_name)
@@ -215,15 +211,10 @@
 
           deploy_node = "${{instance_name}}-infra1-vm"
           multi_node_aio_prepare.connect_deploy_node(deploy_node, instance_ip)
-          maas.prepare(instance_name: deploy_node)
+          maas.prepare(instance_name: instance_name)
 
           common.use_node(deploy_node){{
             try {{
-              if (env.STAGES.contains("Leapfrog Upgrade")) {{
-                common.prepareRpcGit(env.UPGRADE_FROM_REF, "/opt")
-              }} else {{
-                common.prepareRpcGit("auto", "/opt")
-              }}
               // MNAIO prevents ANSIBLE_GIT_REPO and ANSIBLE_GIT_RELEASE from being overridden
               // Re-running bootstrap-ansible.sh to use ssh_retry
               if (env.STAGES.contains("Deploy RPC w/ Script")) {{
@@ -240,13 +231,6 @@
                 "DEPLOY_TEMPEST=no",
                 "DEPLOY_AIO=no",
               ]
-              // If this branch can prepare its own configs, then prepare during deployment
-              config_cap_file="/opt/rpc-openstack/gating/capabilities/mnaio_config"
-              if (fileExists(config_cap_file)){{
-                environment_vars = environment_vars + "CONFIGURE_MNAIO=yes"
-              }} else {{
-                multi_node_aio_prepare.prepare_configs()
-              }}
               deploy.deploy_sh(
                 environment_vars: environment_vars
               ) // deploy_sh


### PR DESCRIPTION
This reverts commit 5421edb83c78118db8db7be0ccafae318bec31ee.

This is being done as we're holding off on implementing the other half
of this work in rpc-openstack, so reverting this change to simplify
things until this code is moved entirely out of rpc-gating.

Issue: [RE-97](https://rpc-openstack.atlassian.net/browse/RE-97)