### PR TITLE
RLM-221 - Disable MNAIO Metering Services

### DIFF
--- a/pipeline_steps/multi_node_aio_prepare.groovy
+++ b/pipeline_steps/multi_node_aio_prepare.groovy
@@ -34,6 +34,9 @@ def prepare() {
           # RAM to VMs -- since we have RAM to spare we double that assigned to
           # infra nodes.
           echo "infra_vm_server_ram: 16384" | sudo tee -a playbooks/group_vars/all.yml
+          # By default the MNAIO deploys metering services, so we override
+          # osa_enable_meter to prevent those services from being deployed.
+          sudo sed -i 's/osa_enable_meter: true/osa_enable_meter: false/' playbooks/group_vars/all.yml
           ${WORKSPACE}/rpc-gating/scripts/mnaio_inventory_generate.py playbooks/inventory/rpc-inventory.yaml
         """
         timeout(time: 45, unit: "MINUTES") {

--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -77,7 +77,7 @@
           default: https://github.com/openstack/openstack-ansible-ops
       - string:
           name: OSA_OPS_BRANCH
-          default: 89e45170fe6043ae014c975f391cf3effc54476f
+          default: 37ff5563ec7a5a1008211ff6c7231dda1244db63
       - string:
           name: DEFAULT_IMAGE
           default: "{DEFAULT_IMAGE}"


### PR DESCRIPTION
To help alleviate memory usage on the MNAIO, disable metering services and moves to latest commit on osa_ops.

See https://github.com/rcbops/rpc-gating/pull/443/ for @mattt416 previous commit that was closed.

Issue: [RLM-221](https://rpc-openstack.atlassian.net/browse/RLM-221)