### PR TITLE
RE-197 Add dep update job for rpco/newton

### DIFF
--- a/rpc_jobs/dep_update.yml
+++ b/rpc_jobs/dep_update.yml
@@ -5,7 +5,11 @@
           URL: "https://github.com/rcbops/rpc-openstack"
           BRANCH: "master"
           #CRON: "@weekly" <-- commented as inherits default
-          #JIRA_ISSUE_TYPE: "task"
+          #JIRA_ISSUE_TYPE: "Task"
+          JIRA_PROJECT_KEY: "RO"
+      - rpc-openstack:
+          URL: "https://github.com/rcbops/rpc-openstack"
+          BRANCH: "newton"
           JIRA_PROJECT_KEY: "RO"
     jobs:
       - 'Dep-Update_{repo}-{BRANCH}'


### PR DESCRIPTION
The template was implemented in a previous PR, this commit introduces
a job for the newton branch.

Issue: [RE-197](https://rpc-openstack.atlassian.net/browse/RE-197)