### PR TITLE
Use standard pre_merge_test hook for RPC-O

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -139,6 +139,8 @@
       # defined in rpc_openstack.yml
       - series: master
         ztrigger: pr
+      - series: newton
+        ztrigger: pr
     jobs:
       - 'RPC-AIO_{series}-{image}-{action}-{scenario}-{ztrigger}'
 

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -145,6 +145,8 @@
         ztrigger: pr
       - series: liberty
         ztrigger: pr
+      - series: kilo
+        ztrigger: pr
     jobs:
       - 'RPC-AIO_{series}-{image}-{action}-{scenario}-{ztrigger}'
 

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -141,6 +141,8 @@
         ztrigger: pr
       - series: newton
         ztrigger: pr
+      - series: mitaka
+        ztrigger: pr
     jobs:
       - 'RPC-AIO_{series}-{image}-{action}-{scenario}-{ztrigger}'
 

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -134,6 +134,11 @@
       # Ocata onwards.
       - series: master
         image: trusty
+      # The PR tests for the following series are now
+      # handled by the standard pre_merge_test jobs
+      # defined in rpc_openstack.yml
+      - series: master
+        ztrigger: pr
     jobs:
       - 'RPC-AIO_{series}-{image}-{action}-{scenario}-{ztrigger}'
 

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -143,6 +143,8 @@
         ztrigger: pr
       - series: mitaka
         ztrigger: pr
+      - series: liberty
+        ztrigger: pr
     jobs:
       - 'RPC-AIO_{series}-{image}-{action}-{scenario}-{ztrigger}'
 

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -1,0 +1,18 @@
+- project:
+    name: "rpc-openstack"
+    repo_url: "https://github.com/rcbops/rpc-openstack"
+    branches:
+      - "master"
+    image:
+      - xenial:
+          IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
+          FLAVOR: "performance2-15"
+          REGIONS: "DFW"
+          FALLBACK_REGIONS: "IAD"
+    scenario:
+      - "ironic"
+      - "swift"
+    action:
+      - "deploy"
+    jobs:
+      - 'PR_{name}-{image}-{scenario}-{action}'

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -75,3 +75,21 @@
           FALLBACK_REGIONS: "IAD"
     jobs:
       - 'PR_{name}-{image}-{scenario}-{action}'
+
+- project:
+    name: "rpc-openstack-kilo"
+    repo_url: "https://github.com/rcbops/rpc-openstack"
+    branches:
+      - "kilo.*"
+    image:
+      - trusty:
+          IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+    scenario:
+      - "swift"
+    action:
+      - deploy:
+          FLAVOR: "performance2-15"
+          REGIONS: "DFW"
+          FALLBACK_REGIONS: "IAD"
+    jobs:
+      - 'PR_{name}-{image}-{scenario}-{action}'

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -56,3 +56,22 @@
           FALLBACK_REGIONS: "IAD"
     jobs:
       - 'PR_{name}-{image}-{scenario}-{action}'
+
+- project:
+    name: "rpc-openstack-liberty"
+    repo_url: "https://github.com/rcbops/rpc-openstack"
+    branches:
+      - "liberty.*"
+    image:
+      - trusty:
+          IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+    scenario:
+      - "ceph"
+      - "swift"
+    action:
+      - deploy:
+          FLAVOR: "performance2-15"
+          REGIONS: "DFW"
+          FALLBACK_REGIONS: "IAD"
+    jobs:
+      - 'PR_{name}-{image}-{scenario}-{action}'

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -7,7 +7,8 @@
       - xenial:
           IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
     scenario:
-      - "ironic"
+      - ironic:
+          TRIGGER_PR_PHRASE_ONLY: true
       - "swift"
     action:
       - deploy:
@@ -28,7 +29,8 @@
       - xenial:
           IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
     scenario:
-      - "ironic"
+      - ironic:
+          TRIGGER_PR_PHRASE_ONLY: true
       - "swift"
     action:
       - deploy:

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -6,13 +6,34 @@
     image:
       - xenial:
           IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
-          FLAVOR: "performance2-15"
-          REGIONS: "DFW"
-          FALLBACK_REGIONS: "IAD"
     scenario:
       - "ironic"
       - "swift"
     action:
-      - "deploy"
+      - deploy:
+          FLAVOR: "performance2-15"
+          REGIONS: "DFW"
+          FALLBACK_REGIONS: "IAD"
+    jobs:
+      - 'PR_{name}-{image}-{scenario}-{action}'
+
+- project:
+    name: "rpc-openstack-newton"
+    repo_url: "https://github.com/rcbops/rpc-openstack"
+    branches:
+      - "newton.*"
+    image:
+      - trusty:
+          IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+      - xenial:
+          IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
+    scenario:
+      - "ironic"
+      - "swift"
+    action:
+      - deploy:
+          FLAVOR: "performance2-15"
+          REGIONS: "DFW"
+          FALLBACK_REGIONS: "IAD"
     jobs:
       - 'PR_{name}-{image}-{scenario}-{action}'

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -37,3 +37,22 @@
           FALLBACK_REGIONS: "IAD"
     jobs:
       - 'PR_{name}-{image}-{scenario}-{action}'
+
+- project:
+    name: "rpc-openstack-mitaka"
+    repo_url: "https://github.com/rcbops/rpc-openstack"
+    branches:
+      - "mitaka.*"
+    image:
+      - trusty:
+          IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+    scenario:
+      - "ceph"
+      - "swift"
+    action:
+      - deploy:
+          FLAVOR: "performance2-15"
+          REGIONS: "DFW"
+          FALLBACK_REGIONS: "IAD"
+    jobs:
+      - 'PR_{name}-{image}-{scenario}-{action}'

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -18,6 +18,7 @@
     concurrent: true
     FLAVOR: "performance1-1"
     IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+    TRIGGER_PR_PHRASE_ONLY: false
     properties:
       - build-discarder:
           num-to-keep: "30"
@@ -50,7 +51,7 @@
             - rcbops
           github-hooks: true
           trigger-phrase: '.*recheck_(cit_)?all.*|.*recheck_(cit_)?{image}_{scenario}_{action}.*'
-          only-trigger-phrase: false
+          only-trigger-phrase: "{obj:TRIGGER_PR_PHRASE_ONLY}"
           white-list-target-branches: "{branches}"
           auth-id: "github_account_rpc_jenkins_svc"
           status-context: 'CIT/{image}_{scenario}_{action}'


### PR DESCRIPTION
This implements the standard pre_merge_hook for RPC-O.

Required merges for the jobs to work:

master: https://github.com/rcbops/rpc-openstack/pull/2582
newton: https://github.com/rcbops/rpc-openstack/pull/2586
mitaka: https://github.com/rcbops/rpc-openstack/pull/2588
liberty: https://github.com/rcbops/rpc-openstack/pull/2590
kilo: https://github.com/rcbops/rpc-openstack/pull/2591

Upgrade tests have been removed from PR tests as they will be replaced
by post merge tests due to the length of time they take to execute.

Issue: [RE-87](https://rpc-openstack.atlassian.net/browse/RE-87)

Issue: [RE-721](https://rpc-openstack.atlassian.net/browse/RE-721)

Issue: [RE-722](https://rpc-openstack.atlassian.net/browse/RE-722)

Issue: [RE-723](https://rpc-openstack.atlassian.net/browse/RE-723)

Issue: [RE-724](https://rpc-openstack.atlassian.net/browse/RE-724)