### PR TITLE
RLM-219 Remove ClientAliveInterval from sshd role

### DIFF
--- a/playbooks/setup_jenkins_slave.yml
+++ b/playbooks/setup_jenkins_slave.yml
@@ -30,7 +30,6 @@
         X11Forwarding: "no"
         PrintLastLog: "no"
         GatewayPorts: "no"
-        ClientAliveInterval: 15
         Compression: "yes"
   tasks:
     - meta: flush_handlers


### PR DESCRIPTION
Was having issues with some jobs timing out
and losing their connection to the slave.
Removing the ssh role seemed to fix the problem
so I tried the ClientAliveInterval and it seemed
to help correct the issue.

15 sec is probably too low for the server to hear
back from the client, so removing this to see if
it helps get rid of the
"hudson.remoting.RequestAbortedException:
java.io.IOException: Unexpected termination of the
channel" errors

https://rpc.jenkins.cit.rackspace.net/view/Leapfrog/job/OnMetal-Multi-Node-AIO_r14.2.0-kilo-trusty-leapfrogupgrade-small-periodic/

Was failing consistently until job #11. (#9 was testing removing the sshd role)

Issue: [RLM-219](https://rpc-openstack.atlassian.net/browse/RLM-219)