### PR TITLE
RLM-228 Change kernel to linux-image-generic

### DIFF
--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -84,7 +84,7 @@
           description: Version of Ubuntu image to use for VMs (14.04.5 or 16.04.2)
       - string:
           name: DEFAULT_KERNEL
-          default: "linux-image-4.4.0-66-generic"
+          default: "linux-image-generic"
           description: Ubuntu Kernel package to use for VMs (linux-image-4.4.0-66-generic, linux-image-3.13.0-34-generic, etc.)
       - bool:
           name: PARTITION_HOST


### PR DESCRIPTION
The package, linux-image-generic, should be used by the MNAIO to ensure
we're testing with the supported LTS kernel for the distro being
deployed.

Upstream:

https://github.com/openstack/openstack-ansible-ops/commit/cc9294bb0d4191bf6a78ef15b02bcaed86cdd709

Issue: [RLM-228](https://rpc-openstack.atlassian.net/browse/RLM-228)