### PR TITLE
RE-621 Supply project hook script with repo URL

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -67,6 +67,7 @@ def generate_release_notes(scripts, rnfile, text, ref, prev_version,
         sub_env["RE_HOOK_PREVIOUS_VERSION"] = prev_version.encode('ascii')
         sub_env["RE_HOOK_VERSION"] = ref.encode('ascii')
         sub_env["RE_HOOK_RELEASE_NOTES"] = dst_file.encode('ascii')
+        sub_env["RE_HOOK_REPO_HTTP_URL"] = ctx_obj.clone_url.encode('ascii')
         script_work_dir = "{cwd}/{clone_dir}".format(
             cwd=os.getcwd(),
             clone_dir=clone_dir


### PR DESCRIPTION
This change explicitly exposes the GitHub HTTPS URL to the
generate_release_notes project hook script. This removes the need for
the project to inspect the repo and prevents any impact if the cloned
repo configuration is changed.

Issue: [RE-621](https://rpc-openstack.atlassian.net/browse/RE-621)