### PR TITLE
RLM-232 Don't deploy Telegraf on AIO installs

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -6,7 +6,6 @@
       - kilo:
           branch: kilo
           branches: "kilo.*"
-          DEPLOY_TELEGRAF: "yes"
       - liberty:
           branch: liberty
           branches: "liberty.*"
@@ -18,11 +17,9 @@
           branch: newton
           branches: "newton.*"
           UPGRADE_FROM_REF: "kilo"
-          DEPLOY_TELEGRAF: "yes"
       - master:
           branch: master
           branches: "master"
-          DEPLOY_TELEGRAF: "yes"
     image:
       - trusty:
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"

--- a/rpc_jobs/rpc_aio_leapfrog.yml
+++ b/rpc_jobs/rpc_aio_leapfrog.yml
@@ -7,22 +7,18 @@
           branch: newton
           branches: "newton"
           UPGRADE_FROM_REF: "kilo"
-          DEPLOY_TELEGRAF: "yes"
       - r14.2.0-kilo:
           branch: "r14.2.0"
           branches: "r14.2.0"
           UPGRADE_FROM_REF: "kilo"
-          DEPLOY_TELEGRAF: "yes"
       - newton-liberty:
           branch: newton
           branches: "newton"
           UPGRADE_FROM_REF: "liberty"
-          DEPLOY_TELEGRAF: "yes"
       - r14.2.0-liberty:
           branch: "r14.2.0"
           branches: "r14.2.0"
           UPGRADE_FROM_REF: "liberty"
-          DEPLOY_TELEGRAF: "yes"
     image:
       - trusty:
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"


### PR DESCRIPTION
Attempts to free up resources on the AIO to allow Tempest tests to fully pass.