### PR TITLE
RE-731 Add lock around build gating venv job

### DIFF
--- a/rpc_jobs/build_gating_venv.yml
+++ b/rpc_jobs/build_gating_venv.yml
@@ -13,97 +13,104 @@
       //common.shared_slave(){
       //can't use common.shared_slave as it calls install_ansible,
       //which calls this job.
-      node('pubcloud_multiuse'){
-        dir('rpc-gating'){
-          git branch: env.RPC_GATING_BRANCH, url: "https://github.com/rcbops/rpc-gating"
-          // run in docker to ensure all the required apt packages are available
-          container = docker.build env.BUILD_TAG.toLowerCase()
-        }
-        // Venv is build within docker as it requires extra packages
-        container.inside{
-          sh """#!/bin/bash -xeu
+      lock('build_gating_venv'){
+        node('pubcloud_multiuse'){
+          try{
+            deleteDir()
+            dir('rpc-gating'){
+              git branch: env.RPC_GATING_BRANCH, url: "https://github.com/rcbops/rpc-gating"
+              // run in docker to ensure all the required apt packages are available
+              container = docker.build env.BUILD_TAG.toLowerCase()
+            }
+            // Venv is build within docker as it requires extra packages
+            container.inside{
+              sh """#!/bin/bash -xeu
 
-          # Install virtualenv if required
-          if [[ ! -d ".venv" ]]; then
-            requirements="virtualenv==15.1.0"
-            pip install -U "\${requirements}" \
-              || pip install --isolated -U "\${requirements}"
+              # Install virtualenv if required
+              if [[ ! -d ".venv" ]]; then
+                requirements="virtualenv==15.1.0"
+                pip install -U "\${requirements}" \
+                  || pip install --isolated -U "\${requirements}"
 
-            if which scl
-            then
-              # redhat/centos
-              source /opt/rh/python27/enable
-              virtualenv --no-pip --no-setuptools --no-wheel --python=/opt/rh/python27/root/usr/bin/python .venv
-              # hack the selinux module into the venv
-              cp -r /usr/lib64/python2.6/site-packages/selinux .venv/lib64/python2.7/site-packages/ ||:
-            else
-              virtualenv --no-pip --no-setuptools --no-wheel .venv
-            fi
-          fi
+                if which scl
+                then
+                  # redhat/centos
+                  source /opt/rh/python27/enable
+                  virtualenv --no-pip --no-setuptools --no-wheel --python=/opt/rh/python27/root/usr/bin/python .venv
+                  # hack the selinux module into the venv
+                  cp -r /usr/lib64/python2.6/site-packages/selinux .venv/lib64/python2.7/site-packages/ ||:
+                else
+                  virtualenv --no-pip --no-setuptools --no-wheel .venv
+                fi
+              fi
 
-          # Install Pip
-          set +xeu
-          source .venv/bin/activate
-          set -xeu
+              # Install Pip
+              set +xeu
+              source .venv/bin/activate
+              set -xeu
 
-          # UG-613 change TMPDIR to directory with more space
-          export TMPDIR="/var/lib/jenkins/tmp"
+              # UG-613 change TMPDIR to directory with more space
+              export TMPDIR="/var/lib/jenkins/tmp"
 
-          # If the pip version we're using is not the same as the constraint then replace it
-          PIP_TARGET="\$(awk -F= '/^pip==/ {print \$3}' rpc-gating/constraints.txt)"
-          VENV_PYTHON=".venv/bin/python"
-          VENV_PIP=".venv/bin/pip"
-          if [[ "\$(\${VENV_PIP} --version)" != "pip \${PIP_TARGET}"* ]]; then
-            # Install a known version of pip, setuptools, and wheel in the venv
-            CURL_CMD="curl --silent --show-error --retry 5"
-            OUTPUT_FILE="get-pip.py"
-            \${CURL_CMD} https://bootstrap.pypa.io/get-pip.py > \${OUTPUT_FILE} \
-              || \${CURL_CMD} https://raw.githubusercontent.com/pypa/get-pip/master/get-pip.py > \${OUTPUT_FILE}
-            GETPIP_OPTIONS="pip setuptools wheel --constraint rpc-gating/constraints.txt"
-            \${VENV_PYTHON} \${OUTPUT_FILE} \${GETPIP_OPTIONS} \
-              || \${VENV_PYTHON} \${OUTPUT_FILE} --isolated \${GETPIP_OPTIONS}
-          fi
+              # If the pip version we're using is not the same as the constraint then replace it
+              PIP_TARGET="\$(awk -F= '/^pip==/ {print \$3}' rpc-gating/constraints.txt)"
+              VENV_PYTHON=".venv/bin/python"
+              VENV_PIP=".venv/bin/pip"
+              if [[ "\$(\${VENV_PIP} --version)" != "pip \${PIP_TARGET}"* ]]; then
+                # Install a known version of pip, setuptools, and wheel in the venv
+                CURL_CMD="curl --silent --show-error --retry 5"
+                OUTPUT_FILE="get-pip.py"
+                \${CURL_CMD} https://bootstrap.pypa.io/get-pip.py > \${OUTPUT_FILE} \
+                  || \${CURL_CMD} https://raw.githubusercontent.com/pypa/get-pip/master/get-pip.py > \${OUTPUT_FILE}
+                GETPIP_OPTIONS="pip setuptools wheel --constraint rpc-gating/constraints.txt"
+                \${VENV_PYTHON} \${OUTPUT_FILE} \${GETPIP_OPTIONS} \
+                  || \${VENV_PYTHON} \${OUTPUT_FILE} --isolated \${GETPIP_OPTIONS}
+              fi
 
-          # Install rpc-gating requirements
-          PIP_OPTIONS="-c rpc-gating/constraints.txt -r rpc-gating/requirements.txt"
-          \${VENV_PIP} install \${PIP_OPTIONS} \
-            || \${VENV_PIP} install --isolated \${PIP_OPTIONS}
+              # Install rpc-gating requirements
+              PIP_OPTIONS="-c rpc-gating/constraints.txt -r rpc-gating/requirements.txt"
+              \${VENV_PIP} install \${PIP_OPTIONS} \
+                || \${VENV_PIP} install --isolated \${PIP_OPTIONS}
 
-          # Install ansible roles
-          mkdir -p rpc-gating/playbooks/roles
-          ansible-galaxy install -r rpc-gating/role_requirements.yml -p rpc-gating/playbooks/roles
-          """
-        } // container
+              # Install ansible roles
+              mkdir -p rpc-gating/playbooks/roles
+              ansible-galaxy install -r rpc-gating/role_requirements.yml -p rpc-gating/playbooks/roles
+              """
+            } // container
 
-        // venv is pushed to rpc repo from outside docker container, as binding
-        // credentials files does not work within docker (used for ssh key)
-        withCredentials(artifact_build.get_rpc_repo_creds()) {
-          sh """#!/bin/bash -xeu
-            # Tar venv and roles
-            pushd rpc-gating
-              SHA=\$(git rev-parse HEAD)
-            popd
-            archive="rpcgatingvenv_\${SHA}.tbz"
-            find .venv -name \\*.pyc -delete
-            echo "\${PWD}/.venv" > .venv/original_venv_path
-            echo \$SHA > .venv/venv_sha
-            tar cjfp \$archive .venv rpc-gating/playbooks/roles
+            // venv is pushed to rpc repo from outside docker container, as binding
+            // credentials files does not work within docker (used for ssh key)
+            withCredentials(artifact_build.get_rpc_repo_creds()) {
+              sh """#!/bin/bash -xeu
+                # Tar venv and roles
+                pushd rpc-gating
+                  SHA=\$(git rev-parse HEAD)
+                popd
+                archive="rpcgatingvenv_\${SHA}.tbz"
+                find .venv -name \\*.pyc -delete
+                echo "\${PWD}/.venv" > .venv/original_venv_path
+                echo \$SHA > .venv/venv_sha
+                tar cjfp \$archive .venv rpc-gating/playbooks/roles
 
-            # Add ssh host key
-            grep "\${REPO_HOST}" ~/.ssh/known_hosts \
-              || echo "\${REPO_HOST} \$(cat \$REPO_HOST_PUBKEY)" \
-              >> ~/.ssh/known_hosts
+                # Add ssh host key
+                grep "\${REPO_HOST}" ~/.ssh/known_hosts \
+                  || echo "\${REPO_HOST} \$(cat \$REPO_HOST_PUBKEY)" \
+                  >> ~/.ssh/known_hosts
 
-            REPO_PATH="/var/www/repo/rpcgating/venvs"
+                REPO_PATH="/var/www/repo/rpcgating/venvs"
 
-            # Upload generated version
-            scp -i \$REPO_USER_KEY \$archive \$REPO_USER@\$REPO_HOST:\$REPO_PATH
+                # Upload generated version
+                scp -i \$REPO_USER_KEY \$archive \$REPO_USER@\$REPO_HOST:\$REPO_PATH
 
-            # Generate index
-            ssh -i \$REPO_USER_KEY \$REPO_USER@\$REPO_HOST "cd \$REPO_PATH; ls -1 *tbz > index"
+                # Generate index
+                ssh -i \$REPO_USER_KEY \$REPO_USER@\$REPO_HOST "cd \$REPO_PATH; ls -1 *tbz > index"
 
-            # Keep 10 newest archives, remove the rest.
-            ssh -i \$REPO_USER_KEY \$REPO_USER@\$REPO_HOST "cd \$REPO_PATH && ls -t1 *tbz |tail -n +11 |while read f; do echo "'removing \$f'"; rm "'\$f'"; done"
-          """
-        }
-      }
+                # Keep 10 newest archives, remove the rest.
+                ssh -i \$REPO_USER_KEY \$REPO_USER@\$REPO_HOST "cd \$REPO_PATH && ls -t1 *tbz |tail -n +11 |while read f; do echo "'removing \$f'"; rm "'\$f'"; done"
+              """
+            }
+          } finally {
+              deleteDir()
+          } // try
+        } // node pubcloud_multiuse
+      } // lock


### PR DESCRIPTION
This job is failing as files are changing whilst being tarred.
This should not happen as the job does not allow parallelism. Adding
a lock to debug and make serialisation explicit.

Added:
- `try(){ deleteDir() ... } finally { deleteDir()} `
- `lock('build_gating_venv')`

Other changes are indentation only

Issue: [RE-731](https://rpc-openstack.atlassian.net/browse/RE-731)