### PR TITLE
RE-621 Publish tag before generating release notes

### DIFF
--- a/job_dsl/release.groovy
+++ b/job_dsl/release.groovy
@@ -18,10 +18,12 @@ common.shared_slave(){
         variable: 'MAILGUN_API_KEY'
       )
     ]){
-      sh """#!/bin/bash -xe
-        set +x; . .venv/bin/activate; set -x
-        ${env.COMMAND}
-      """
+      sshagent (credentials:['rpc-jenkins-svc-github-ssh-key']){
+        sh """#!/bin/bash -xe
+          set +x; . .venv/bin/activate; set -x
+          ${env.COMMAND}
+        """
+      }
     }
   }
 }

--- a/rpc_jobs/release.yml
+++ b/rpc_jobs/release.yml
@@ -53,6 +53,8 @@
                 --repo "$REPO" \
                 clone \
                   --ref $RC_BRANCH \
+                publish_tag \
+                    --version "${VERSION}" \
                 generate_release_notes \
                     --script "optional:gating/generate_release_notes/pre" \
                     --script "gating/generate_release_notes/run" \
@@ -60,7 +62,6 @@
                     --prev-version "${PREVIOUS_VERSION}" \
                     --out-file "${RELEASE_NOTES_FILE}" \
                 create_release \
-                    --version "${VERSION}" \
                     --bodyfile "${RELEASE_NOTES_FILE}" \
                 update_rc_branch \
                     --mainline "${MAINLINE}" \
@@ -93,14 +94,18 @@
                                      optional:/opt/myscript<br>
                 --file TEXT          Read release notes from this file.<br>
                 --text TEXT          Text of the release notes.<br>
-                --ref TEXT           Ref that will be released. Release notes scripts<br>
-                                     compare from --prev-version to --ref. May be omitted if<br>
-                                     --ref has already been supplied to clone<br>
+                --version TEXT       Symbolic name of Release (eg r14.1.99)  [required]<br>
                 --prev-version TEXT  Last released version. Release notes scripts should<br>
-                                     compare prev-version to ref  [required]<br>
+                                     compare prev-version to version  [required]<br>
                 --clone-dir TEXT     Root of the repo dir. May be omitted if clone was used<br>
                                      earlier in the chain.<br>
                 --out-file TEXT      Release notes will be written to this file  [required]<br>
+                --help               Show this message and exit.<br>
+              <br>publish_tag:<br>
+                --clone-dir TEXT     Root of the repo dir. May be omitted if clone was used<br>
+                                     earlier in the chain.<br>
+                --ref TEXT           ref to checkout<br>
+                --version TEXT       Symbolic name of Release (eg r14.1.99)  [required]<br>
                 --help               Show this message and exit.<br>
               <br>add_issue_url_to_pr:<br>
                 --pull-request-number TEXT  Pull request to update  [required]<br>
@@ -130,9 +135,7 @@
                                  --ref supplied to clone<br>
                 --help           Show this message and exit.<br>
               <br>create_release:<br>
-                --version TEXT   Symbolic name of Release (eg r14.1.99)  [required]<br>
-                --ref TEXT       Reference to create release from (branch, SHA etc) May be<br>
-                                 omitted if supplied to clone earlier in the chain.<br>
+                --version TEXT   Symbolic name of Release (eg r14.1.99)<br>
                 --bodyfile TEXT  File containing release message body  [required]<br>
                 --help           Show this message and exit.<br>
               <br>mail:<br>

--- a/scripts/ghutils.py
+++ b/scripts/ghutils.py
@@ -231,13 +231,7 @@ def update_rc_branch(ctx, mainline, rc):
 @click.pass_obj
 @click.option(
     '--version',
-    required=True,
     help="Symbolic name of Release (eg r14.1.99)"
-)
-@click.option(
-    '--ref',
-    help="Reference to create release from (branch, SHA etc)"
-         " May be omitted if supplied to clone earlier in the chain."
 )
 @click.option(
     '--bodyfile',
@@ -245,7 +239,7 @@ def update_rc_branch(ctx, mainline, rc):
     required=True
     # Can't use type=click.File because the file may not exist on startup
 )
-def create_release(repo, version, ref, bodyfile):
+def create_release(repo, version, bodyfile):
     ctx_obj = click.get_current_context().obj
     # Attempt to read release_notes from context
     # They may have been set by release.generate_release_notes
@@ -258,7 +252,7 @@ def create_release(repo, version, ref, bodyfile):
         ))
         click.get_current_context().exit(-1)
 
-    ref = try_context(ctx_obj, ref, "ref", "rc_ref")
+    version = try_context(ctx_obj, version, "version", "version")
     # Store version in context for use in notifications
     ctx_obj.version = version
     # Create a subject for use by notifications
@@ -269,10 +263,9 @@ def create_release(repo, version, ref, bodyfile):
     )
     try:
         repo.create_release(
-            version,            # tag name
-            ref,                # tag reference
-            version,            # release name
-            release_notes       # release body
+            tag_name=version,
+            name=version,
+            body=release_notes,
         )
         logger.info("Release {} created.".format(version))
     except github3.models.GitHubError as e:
@@ -301,7 +294,7 @@ def create_release(repo, version, ref, bodyfile):
             "+refs/heads/*:refs/heads/*")
 def clone(url, ref, refspec):
     ctx_obj = click.get_current_context().obj
-    url = try_context(ctx_obj, url, "url", "clone_url")
+    url = try_context(ctx_obj, url, "url", "ssh_url")
     ctx_obj.rc_ref = ref
     clone_dir = "{o}/{r}".format(
         o=ctx_obj.owner.login,


### PR DESCRIPTION
This change addresses some issues with generating release notes:
- notes were being generated from a ref (branch), there was nothing to
  guarantee this did not change when running the release code
- rpc-differ, and reno when support is added in rpc-openstack, require
  the tag name to produce correctly worded notes

To ensure the tag is created at the start of the process, a new
function `publish_tag` is added to handle pushing the tag to the
repository. This removes that burden from `create_release` with the
added benefit that new tags are annotated (GitHub only creates
lightweight tags).

To enable the tag to be pushed the job now provides access to the
Jenkins GitHub SSH key.

`generate_release_notes` now sets `RE_HOOK_VERSION` to be the version
and not the ref, this is both more intuitive and means that the tag is
now available to the consumer project scripts.

Test release: https://github.com/wherenoworg/rpc-openstack/releases/tag/gh.6
Associated build: https://rpc.jenkins.cit.rackspace.net/job/RE-Release/79

Issue: [RE-621](https://rpc-openstack.atlassian.net/browse/RE-621)