### PR TITLE
RE-643 Phobos <--> Webhook Proxy Tunnel

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -48,12 +48,17 @@ void install_ansible(){
     np=\${PWD}/.venv                    # New Path
     grep -ri --files-with-match \$op \
       |while read f; do sed -i.bak "s|\$op|\$np|" \$f; done
+    [[ -e .venv/lib64 ]] || {
+      pushd .venv
+        ln -s lib lib64
+      popd
+    }
     if which scl; then
       echo "CentOS node detected, copying in external python interpreter and setting PYTHONPATH in activate script"
       # CentOS 6 can take a hike, its glibc isn't new enough for python 2.7.12
       cp /opt/rh/python27/root/usr/bin/python .venv/bin/python
       # hack the selinux module into the venv
-      cp -r /usr/lib64/python2.6/site-packages/selinux .venv/lib64/python2.7/site-packages/ ||:
+      cp -r /usr/lib64/python2.6/site-packages/selinux .venv/lib/python2.7/site-packages/ ||:
       # I'm not sure why this is needed, but I assume its due to a change in python's
       # default module search paths between 2.7.8 and 2.7.12
       echo "export PYTHONPATH=${env.WORKSPACE}/.venv/lib/python2.7/site-packages" >> .venv/bin/activate

--- a/pipeline_steps/webhooks.groovy
+++ b/pipeline_steps/webhooks.groovy
@@ -11,6 +11,10 @@ def webhooks(){
             credentialsId: 'id_rsa_cloud10_jenkins_file',
             variable: 'jenkins_ssh_privkey'
           ),
+          file(
+            credentialsId: 'id_rsa_phobostunnel_pub',
+            variable: 'phobostunnel_ssh_pubkey'
+          ),
           usernamePassword(
             credentialsId: "github_webhook_proxy_basic_auth",
             usernameVariable: "webhookproxy_user",
@@ -43,7 +47,8 @@ def webhooks(){
               vars: [
                 WORKSPACE: "${env.WORKSPACE}",
                 webhookproxy_user: "${env.webhookproxy_user}",
-                webhookproxy_pass: "${env.webhookproxy_pass}"
+                webhookproxy_pass: "${env.webhookproxy_pass}",
+                phobostunnel_ssh_pubkey: "${env.phobostunnel_ssh_pubkey}"
               ]
             ) //venvPlaybook
           } //dir

--- a/playbooks/phobos_tunnel.yml
+++ b/playbooks/phobos_tunnel.yml
@@ -1,0 +1,59 @@
+# How to use this playbook..
+# 1. Make sure you can ssh to the phobos deployment host manually.
+#   Bastion config steps can be found in https://rpc-openstack.atlassian.net/browse/RE-643?focusedCommentId=170362&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-170362
+# 2. Get the private key from passwordsafe and store it in id_rsa_webhookproxy (or store it somewhere else and override deploy_host_private_key_file with -e)
+# 3. Run the playbook ansible-playbook phobostunnel.yml -i deploy_phobos.inv
+
+- name: Configure Phobos Deploy node tunnel
+  hosts: deploy-phobos
+  user: jenkins
+  vars:
+    tunnel_host: "webhookproxy.uk.rs.wherenow.org"
+    tunnel_user: phobos
+    # Remote port will be opened on tunnel host, and connections to it
+    # will be forwarded via the ssh tunnel to port 22 on the phobos deploy host
+    remote_port: 2223
+
+    # location on phobos host that the private key will be written to
+    private_key_file: "/home/jenkins/.ssh/id_rsa_webhookproxy"
+
+    # locaiton on localhost that ansible will use to read key file
+    # before writing it on the phobos host
+    deploy_host_private_key_file: id_rsa_webhookproxy
+  pre_tasks:
+    - name: Install apt packages
+      apt:
+        pkg: "{{ item }}"
+        state: installed
+        update_cache: yes
+      register: install_packages
+      until: install_packages | success
+      retries: 5
+      delay: 2
+      with_items:
+        - git-core
+        - default-jre-headless
+      become: true
+
+    - name: Read local key file
+      delegate_to: localhost
+      set_fact:
+        private_key: "{{lookup('file', deploy_host_private_key_file)}}"
+    - name: Write key file to phobos host
+      copy:
+        dest: "{{private_key_file}}"
+        content: "{{private_key}}"
+        mode: 0600
+        owner: jenkins
+    - name: Template phobostunnel service definition
+      template:
+        src: phobostunnel_service.j2
+        dest: /lib/systemd/system/phobostunnel.service
+      become: true
+    - name: Load and Enable phobostunnel systemd service
+      systemd:
+        enabled: yes
+        service: phobostunnel.service
+        daemon_reload: yes
+        state: restarted
+      become: true

--- a/playbooks/setup_jenkins_slave.yml
+++ b/playbooks/setup_jenkins_slave.yml
@@ -29,7 +29,7 @@
         PasswordAuthentication: "no"
         X11Forwarding: "no"
         PrintLastLog: "no"
-        GatewayPorts: "no"
+        GatewayPorts: "yes"
         Compression: "yes"
   tasks:
     - meta: flush_handlers

--- a/playbooks/templates/phobostunnel_service.j2
+++ b/playbooks/templates/phobostunnel_service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=Phobos Tunnel Service, used to allow connections from CIT Jenkins
+After=network.target
+
+[Service]
+StandardOutput=syslog
+StandardError=syslog
+ExecStart=/usr/bin/ssh -v -N -i {{private_key_file}} {{tunnel_user}}@{{tunnel_host}} -R {{remote_port}}:localhost:22
+Restart=always
+RestartSec=15
+
+[Install]
+WantedBy=multi-user.target

--- a/playbooks/webhooks.yml
+++ b/playbooks/webhooks.yml
@@ -33,6 +33,9 @@
     JIRA_PASSWORD: "{{ lookup('env', 'JIRA_PASS') }}"
     JIRA_PROJECT: "{{ lookup('env', 'JIRA_PROJECT') }}"
 
+    # phobostunnel_ssh_pubkey Injected by Jenkins Credential
+    PHOBOS_SSH_PORT: 2223
+
   pre_tasks:
     # used by webhooks.groovy to create the ssh tunnel script
     - name: Write ip file
@@ -107,10 +110,30 @@
         state: installed
         update_cache: yes
 
-    - name: "create htpasswd file"
+    - name: Create htpasswd file
       shell: |
         cd ~jenkins
         htpasswd -cb .htpasswd {{ webhookproxy_user }} {{ webhookproxy_pass }}
+
+    # The webhook proxy node will be used as a proxy for connections
+    # to phobos (RE-643)
+    # The deploy-phobos container will have a service that connects
+    # via ssh to the webhook proxy node using ssh remote forwarding
+    # to expose the local port
+    - name: Create phobos user
+      user:
+        name: phobos
+
+    - name: Add phobos user Authorised key
+      authorized_key:
+        user: phobos
+        key: "{{lookup('file', phobostunnel_ssh_pubkey)}}"
+
+    - name: Allow access to phobos deploy host
+      ufw:
+        rule: allow
+        port: "{{ PHOBOS_SSH_PORT }}"
+
   roles:
     - role: geerlingguy.nginx
       nginx_remove_default_vhost: true

--- a/rpc_jobs/webhook.yml
+++ b/rpc_jobs/webhook.yml
@@ -10,7 +10,7 @@
       - rpc_gating_params
       - instance_params:
           REGIONS: IAD
-          FALLBACK_REGIONS: "{FALLBACK_REGIONS}"
+          FALLBACK_REGIONS: ""
           FLAVOR: "2"
           IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
           INSTANCE_NAME: "WEBHOOK-PROXY"


### PR DESCRIPTION
As internal routing between CIT jenkins and the Phobos environment
is not possible in the short term, a tunnel is added.

The deploy-phobos container in the phobos environment will connect
to the webhook proxy node via ssh. The ssh connection will carry
a reverse port forward such that any connections to port 2223 on
the webhook proxy  node will be forwarded to port 22 on deploy-phobos.

Jenkins will ssh to webhookproxy:2223 when it requires a connection
to deploy-phobos.

Issue: [RE-643](https://rpc-openstack.atlassian.net/browse/RE-643)