### PR TITLE
RO-2796 Use workspace for apt artifact checkout

### DIFF
--- a/pipeline_steps/artifact_build.groovy
+++ b/pipeline_steps/artifact_build.groovy
@@ -30,9 +30,9 @@ def get_rpc_repo_creds(){
 def apt() {
   common.use_node('ArtifactBuilder2') {
     withCredentials(get_rpc_repo_creds()) {
-      common.prepareRpcGit()
+      common.prepareRpcGit("auto", env.WORKSPACE)
       ansiColor('xterm') {
-        dir("/opt/rpc-openstack/") {
+        dir("${env.WORKSPACE}/rpc-openstack") {
           sh """#!/bin/bash
           scripts/artifacts-building/apt/build-apt-artifacts.sh
           """


### PR DESCRIPTION
As the apt artifacts are built using a long-lived
node, the jenkins workspace should be used for the
git checkout the job does to prevent the constant
back-and-forth switching between branches from
interfering with each other.

The script being executed from rpc-openstack does
a symlink from the current directory to the expected
path of /opt/rpc-openstack so everything else should
continue to work as expected.

Issue: [RO-2796](https://rpc-openstack.atlassian.net/browse/RO-2796)