### PR TITLE
RLM-227 Remove minorupgrades tests from PR's

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -86,6 +86,11 @@
         action: minorupgrade
       - series: master
         action: minorupgrade
+      # Minorupgrades are only being executed
+      # as periodics for now due to the length
+      # of time they take to execute.
+      - action: minorupgrade
+        ztrigger: pr
       # Major upgrades are only run for mitaka
       # for the moment as no other major upgrade
       # testing or tooling has been implemented.


### PR DESCRIPTION
Currently the minorupgrade tests are extending
test time for PR's and due to their non-voting
nature they're not being properly reviewed
anyway. This removes them from PR tests and
leaves them in place for periodics only.

Issue: [RLM-227](https://rpc-openstack.atlassian.net/browse/RLM-227)