### PR TITLE
RE-507 post merge job

### DIFF
--- a/gating/post_merge_test/run
+++ b/gating/post_merge_test/run
@@ -1,0 +1,14 @@
+#!/bin/bash -xeu
+
+# This script prepares the lint environment in the same way the
+# docker file does, but without the container as its running on
+# single use node.
+
+sudo apt-get update && sudo apt-get install -y \
+  groovy2 python-pip build-essential python-dev libssl-dev \
+  curl libffi-dev sudo git-core
+
+pip install -c constraints.txt -r requirements.txt
+pip install -c constraints.txt -r test-requirements.txt
+
+RPC_GATING_LINT_USE_VENV=no ./lint.sh

--- a/lint.sh
+++ b/lint.sh
@@ -47,7 +47,14 @@ check_groovy(){
          return
        }
   extract_groovy_from_jjb
-  groovy scripts/syntax.groovy pipeline_steps/*.groovy tmp_groovy/*.groovy job_dsl/*.groovy
+  # pipeline_steps/*.groovy includes pipeline_steps/NonCPS.groovy, However
+  # NonCPS must be loaded before any scripts that use it, so it's explicitly
+  # included first.
+  groovy scripts/syntax.groovy \
+    pipeline_steps/NonCPS.groovy \
+    pipeline_steps/*.groovy \
+    tmp_groovy/*.groovy \
+    job_dsl/*.groovy
 
   if [[ $? == 0 ]]
   then

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -29,7 +29,7 @@ void install_ansible(){
         ]
       ]
     )
-    sleep(time: 10, unit: "SECONDS")
+    sleep(time: 60, unit: "SECONDS")
     retry(3){
       try{
         download_venv()
@@ -335,6 +335,11 @@ def rpco_archive_artifacts(String build_type = "AIO"){
 
 def archive_artifacts(){
   stage('Compress and Publish Artifacts'){
+    if (env.RE_HOOK_RESULT_DIR != null){
+      dir(env.RE_HOOK_RESULT_DIR){
+        junit allowEmptyResults: true, testResults: '*.xml'
+      }
+    }
     pubcloud.uploadToCloudFiles(
       container: "jenkins_logs",
     )

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -1,19 +1,16 @@
 - project:
-    name: "gating-pre-merge"
-    repo_url: "https://github.com/rcbops/rpc-gating"
-    branches:
-      - "master"
-    image:
-      - "xenial"
-    scenario:
-      - "functional"
-    action:
-      - "test"
+    name:       "gating-post-merge"
+    repo_url:   "https://github.com/rcbops/rpc-gating"
+    branch:     "master"
+    image:      "xenial"
+    scenario:   "functional"
+    action:     "test"
+    jira_project_key: "RE"
     jobs:
-      - 'PR_{name}-{image}-{scenario}-{action}'
+      - 'PM_{name}-{branch}-{image}-{scenario}-{action}'
 
 - job-template:
-    name: 'PR_{name}-{image}-{scenario}-{action}'
+    name: 'PM_{name}-{branch}-{image}-{scenario}-{action}'
     project-type: pipeline
     concurrent: true
     FLAVOR: "performance1-1"
@@ -31,33 +28,21 @@
           REGIONS: "{REGIONS}"
           FALLBACK_REGIONS: "{FALLBACK_REGIONS}"
       - string:
-          name: STAGES
-          default: >-
-            Allocate Resources,
-            Connect Slave,
-            Cleanup,
-            Destroy Slave
-          description: |
-            Pipeline stages to run CSV. Note that this list does not influence execution order.
-            Options:
-              Allocate Resources
-              Connect Slave
-              Cleanup
-              Destroy Slave
+          name: REPO_URL
+          default: "{repo_url}"
+          description: Url of the repo under test
+      - string:
+          name: BRANCH
+          default: "{branch}"
+          description: Branch of the repo under test
     triggers:
-      - github-pull-request:
-          org-list:
-            - rcbops
-          github-hooks: true
-          trigger-phrase: '.*recheck_(cit_)?all.*|.*recheck_(cit_)?{image}_{scenario}_{action}.*'
-          only-trigger-phrase: false
-          white-list-target-branches: "{branches}"
-          auth-id: "github_account_rpc_jenkins_svc"
-          status-context: 'CIT/{image}_{scenario}_{action}'
-          cancel-builds-on-update: true
+      - timed: "@daily"
 
     dsl: |
       library "rpc-gating@${{RPC_GATING_BRANCH}}"
+      properties([pipelineTriggers([githubPush()])])
+
+      env.STAGES="Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
 
       // Pass details about the job parameters through
       // to the target environment so that scripts can
@@ -67,13 +52,16 @@
       env.RE_JOB_SCENARIO = "{scenario}"
       env.RE_JOB_ACTION = "{action}"
       env.RE_JOB_FLAVOR = "{FLAVOR}"
-      env.RE_JOB_TRIGGER = "PR"
+      env.RE_JOB_TRIGGER = "PM"
+      env.RE_JOB_BRANCH = "{branch}"
 
-      // Apply a global three hour timeout
-      timeout(time: 3, unit: 'HOURS'){{
+      // Not part of the published interface, used by this job later on
+      // to create failure tickets in the correct project.
+      JIRA_PROJECT_KEY = "{jira_project_key}"
+
+      timeout(time: 6, unit: 'HOURS'){{
         common.shared_slave() {{
           pubcloud.runonpubcloud {{
-
             // Set the default environment variables used
             // by the artifact and test result collection.
             env.RE_HOOK_ARTIFACT_DIR="${{env.WORKSPACE}}/artifacts"
@@ -88,8 +76,7 @@
                   withCredentials(common.get_cloud_creds()) {{
 
                     stage('Checkout') {{
-                      print("Triggered by PR: ${{env.ghprbPullLink}}")
-                      common.clone_with_pr_refs()
+                      git branch: env.BRANCH, url: env.REPO_URL
                     }} // stage
 
                     stage('Execute Pre Script') {{
@@ -98,9 +85,9 @@
                       // it has the best chance of success possible.
                       retry(3) {{
                         sh """#!/bin/bash -xeu
-                        if [[ -e gating/pre_merge_test/pre ]]; then
-                          gating/pre_merge_test/pre
-                        fi
+                          if [[ -e gating/post_merge_test/pre ]]; then
+                            gating/post_merge_test/pre
+                          fi
                         """
                       }}
                     }} // stage
@@ -108,16 +95,10 @@
                     try{{
                       stage('Execute Run Script') {{
                         sh """#!/bin/bash -xeu
-                        gating/pre_merge_test/run
+                          gating/post_merge_test/run
                         """
                       }} // stage
                     }} finally {{
-
-                      // We implement the post script execution in a finally
-                      // block to ensure that it always executes as it is
-                      // typically used to collect logs and this needs to
-                      // happen whether the run script succeeds or fails.
-
                       stage('Execute Post Script') {{
                         // We do not want the 'post' execution to fail the test,
                         // but we do want to know if it fails so we make it only
@@ -125,25 +106,24 @@
                         post_result = sh(
                           returnStatus: true,
                           script: """#!/bin/bash -xeu
-                                     if [[ -e gating/pre_merge_test/post ]]; then
-                                       gating/pre_merge_test/post
+                                     if [[ -e gating/post_merge_test/post ]]; then
+                                       gating/post_merge_test/post
                                      fi"""
                         )
                         if (post_result != 0) {{
-                          print("Pre-Merge Test (post) failed with return code ${{post_result}}")
+                          print("Post-Merge Test (post) failed with return code ${{post_result}}")
                         }} // if
-                      }} // stage
-
-                    }} // inner try
+                      }} // inner try
+                    }} // stage
                   }} // withCredentials
                 }} // dir
               }} // ansiColor
             }} catch (e) {{
-              print(e)
-              currentBuild.result="FAILURE"
-              throw e
+              common.create_jira_issue(JIRA_PROJECT_KEY,
+                                       env.BUILD_TAG,
+                                       env.BUILD_URL,
+                                       "Task")
             }} finally {{
-              common.safe_jira_comment("${{currentBuild.result}}: [${{env.BUILD_TAG}}|${{env.BUILD_URL}}]")
               common.archive_artifacts()
             }} // try
           }} // pubcloud slave


### PR DESCRIPTION
This commit implements the standard job for periodics.
It will also be the basis for merge triggered jobs, though that will
likely require a separate free-style job that triggers this one.

This commit also includes an implementation of the post_merge_test hook
for rpc-gating. That will create a periodic job that runs the lint
tests. That job can be used as an example for other projects.

Issue: [RE-507](https://rpc-openstack.atlassian.net/browse/RE-507)