### PR TITLE
Updated rpc-upgrades jobs

### DIFF
--- a/rpc_jobs/irr_role_test.yml
+++ b/rpc_jobs/irr_role_test.yml
@@ -87,7 +87,6 @@
     # Context is used to define the origin checkout prior to leaping.
     context:
       - kilo
-      - "r11.0.0"
     jobs:
       - 'RPC-IRR_{repo}-{series}-{image}-{context}'
 
@@ -107,8 +106,12 @@
           irr_flavor: "performance2-15"
     # Context is used to define the origin checkout prior to leaping.
     context:
+      - "r12.1.2"
+      - "r12.2.0"
+      - "r12.2.2"
+      - "r12.2.5"
+      - "r12.2.8"
       - liberty
-      - "r12.0.0"
     jobs:
       - 'RPC-IRR_{repo}-{series}-{image}-{context}'
 


### PR DESCRIPTION
This builds out the Liberty specific test matrix and removes
11.0.0 from kilo as its not used anywhere and of no benifit
to us at this time.

Issue: https://rpc-openstack.atlassian.net/browse/RLM-225
Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [RLM-225](https://rpc-openstack.atlassian.net/browse/RLM-225)