### PR TITLE
RO-2781 Remove Kibana stages from AIO jobs

### DIFF
--- a/rpc_jobs/rpc_aio_leapfrog.yml
+++ b/rpc_jobs/rpc_aio_leapfrog.yml
@@ -27,9 +27,7 @@
           ACTION_STAGES: >-
             Leapfrog Upgrade,
             Install Tempest,
-            Tempest Tests,
-            Prepare Kibana Selenium,
-            Kibana Tests
+            Tempest Tests
           GENERATE_TEST_NETWORKS: "6"
           GENERATE_TEST_SERVERS: "4"
           GENERATE_TEST_VOLUMES: "12"


### PR DESCRIPTION
Kibana is currently unmaintained and is causing
intermittent failures.  Remove the Kibana stages
from the gate jobs until we can find a maintainer
or correct the issues.

Issue: [RO-2781](https://rpc-openstack.atlassian.net/browse/RO-2781)