### PR TITLE
RLM-262 Disable 14.2.0-liberty job

### DIFF
--- a/rpc_jobs/multi_node_aio_leapfrog.yml
+++ b/rpc_jobs/multi_node_aio_leapfrog.yml
@@ -34,17 +34,6 @@
             glance_default_store: "swift"
             neutron_legacy_ha_tool_enabled: true
           DEPLOY_TELEGRAF: "yes"
-      - r14.2.0-liberty:
-          UPGRADE_FROM_REF: "liberty"
-          branch: "r14.2.0"
-          branches: "r14.2.0"
-          KIBANA_SELENIUM_BRANCH: "newton"
-          SERIES_USER_VARS: |
-            tempest_test_sets: 'all'
-            lxc_container_vg_name: "USE_DIR_NOT_VG"
-            glance_default_store: "swift"
-            neutron_legacy_ha_tool_enabled: true
-          DEPLOY_TELEGRAF: "yes"
     image:
       - trusty:
           DEFAULT_IMAGE: "ubuntu-14.04-amd64"

--- a/rpc_jobs/rpc_aio_leapfrog.yml
+++ b/rpc_jobs/rpc_aio_leapfrog.yml
@@ -15,10 +15,6 @@
           branch: newton
           branches: "newton"
           UPGRADE_FROM_REF: "liberty"
-      - r14.2.0-liberty:
-          branch: "r14.2.0"
-          branches: "r14.2.0"
-          UPGRADE_FROM_REF: "liberty"
     image:
       - trusty:
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"


### PR DESCRIPTION
14.2.0-liberty job won't pass as 14.2.0 does not pull in the openstack-ansible-ops fixes for liberty.  Re-enable once next release is cut.

Issue: [RLM-262](https://rpc-openstack.atlassian.net/browse/RLM-262)