### PR TITLE
RLM-261 Bump to latest OSA_OPS for MNAIO fixes

### DIFF
--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -77,7 +77,7 @@
           default: https://github.com/openstack/openstack-ansible-ops
       - string:
           name: OSA_OPS_BRANCH
-          default: 37ff5563ec7a5a1008211ff6c7231dda1244db63
+          default: 835c2632f2b862600276d001313865605f34bdf5
       - string:
           name: DEFAULT_IMAGE
           default: "{DEFAULT_IMAGE}"


### PR DESCRIPTION
Bumps to head of master on https://github.com/openstack/openstack-ansible-ops/commit/835c2632f2b862600276d001313865605f34bdf5

MNAIO jobs needs the fix from https://github.com/openstack/openstack-ansible-ops/commit/d0cb21c139381fad1a526a29a9d3eb94bbe693de that provides more storage for the /var/lib/nova mount.

Issue: [RLM-261](https://rpc-openstack.atlassian.net/browse/RLM-261)