### PR TITLE
RLM-264 Move Leapfrog Upgrade before tests on MNAIO

### DIFF
--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -238,20 +238,17 @@
               deploy.deploy_sh(
                 environment_vars: environment_vars
               ) // deploy_sh
+              if (env.STAGES.contains("Leapfrog Upgrade")) {{
+                deploy.upgrade_leapfrog(environment_vars: environment_vars)
+              }}
               parallel(
                 "tempest": {{
                   tempest.tempest()
                 }},
                 "horizon": {{
                   horizon.horizon_integration()
-                }},
-                "kibana": {{
-                  kibana.kibana(env.KIBANA_SELENIUM_BRANCH)
                 }}
               ) // parallel
-              if (env.STAGES.contains("Leapfrog Upgrade")) {{
-                deploy.upgrade_leapfrog(environment_vars: environment_vars)
-              }}
             }} finally {{
               common.rpco_archive_artifacts("MNAIO")
             }}


### PR DESCRIPTION
Leapfrog was currently running after all tests.
This moves leapfrog to after deploy and before tests.
Also drops Kibana tests for now until we have a maintainer.

Issue: [RLM-264](https://rpc-openstack.atlassian.net/browse/RLM-264)