### PR TITLE
RE-633 Update mailgun creds

### DIFF
--- a/job_dsl/release.groovy
+++ b/job_dsl/release.groovy
@@ -10,11 +10,11 @@ common.shared_slave(){
         variable: 'PAT'
       ),
       string(
-        credentialsId: 'mailgun_hughsaunders_endpoint',
+        credentialsId: 'mailgun_mattt_endpoint',
         variable: 'MAILGUN_ENDPOINT'
       ),
       string(
-        credentialsId: 'mailgun_hughsaunders_api_key',
+        credentialsId: 'mailgun_mattt_api_key',
         variable: 'MAILGUN_API_KEY'
       )
     ]){


### PR DESCRIPTION
I missed the fact that we already had a mailgun account setup, and had
DNS entries created for a domain created in a new mailgun account.
Rather than move the domain to the old mailgun account (which would
require updating the previously created DNS records), I've just added
new credentials in Jenkins for the new account.  We can remove the old
credentials or just leave them around in the event that we need to flip
over to another Mailgun account.

Issue: [RE-633](https://rpc-openstack.atlassian.net/browse/RE-633)