### PR TITLE
Fix hardening job

### DIFF
--- a/rpc_jobs/hardening.yml
+++ b/rpc_jobs/hardening.yml
@@ -2,7 +2,7 @@
     name: 'RPC-Hardening-Jobs'
     series:
       - master:
-          branch: master
+          branch: newton
           USER_VARS: |
             tempest_test_sets: 'scenario'
     context:


### PR DESCRIPTION
The hardening job has been failing for some time since the mnaio cannot
deploy rpco's master branch due to removal of openstack-ansible as a
submodule.  It also probably makes more sense to run this job against
a more stable branch of rpco (like newton).