### PR TITLE
RE-759 Fix notification e-mail message

### DIFF
--- a/rpc_jobs/release.yml
+++ b/rpc_jobs/release.yml
@@ -66,8 +66,7 @@
                 update_rc_branch \
                     --mainline "${MAINLINE}" \
                 mailgun \
-                    --to "${NOTIFICATION_ADDRESS}" \
-                    --body "${RELEASE_NOTES_FILE}"
+                    --to "${NOTIFICATION_ADDRESS}"
           description: |
             Commands and available options.
               Note that options that are also used
@@ -78,10 +77,9 @@
                 --to TEXT                Must be added to authorised recipients list if<br>
                                          using a free mailgun account.  [required]<br>
                 --subject TEXT           Subject of release announcement message. May be<br>
-                                         omitted if create_release is used as that generates<br>
-                                         a subject.<br>
-                --body TEXT              Contents of release announcement message May be<br>
-                                         omitted if generate_release_notes is used.<br>
+                                         omitted if create_release is used.<br>
+                --body TEXT              Body of release announcement message. May be omitted if<br>
+                                         omitted if create_release is used.<br>
                 --mailgun-api-key TEXT   [required]<br>
                 --mailgun-endpoint TEXT  [required]<br>
                 --help                   Show this message and exit.<br>
@@ -142,7 +140,7 @@
                 Send mail via local MTA<br>
                 --to TEXT       [required]<br>
                 --subject TEXT  Subject of release announcement message. May be omitted if<br>
-                                create_release is used as that generates a subject.<br>
-                --body TEXT     Contents of release announcement message May be omitted if<br>
-                                generate_release_notes is used.<br>
+                                create_release is used.<br>
+                --body TEXT     Body of release announcement message. May be omitted if<br>
+                                create_release is used.<br>
                 --help          Show this message and exit.<br>

--- a/scripts/ghutils.py
+++ b/scripts/ghutils.py
@@ -255,14 +255,8 @@ def create_release(repo, version, bodyfile):
     version = try_context(ctx_obj, version, "version", "version")
     # Store version in context for use in notifications
     ctx_obj.version = version
-    # Create a subject for use by notifications
-    ctx_obj.release_subject = "Version {v} of {o}/{r} released".format(
-        v=version,
-        o=repo.owner.login,
-        r=repo.name
-    )
     try:
-        repo.create_release(
+        release = repo.create_release(
             tag_name=version,
             name=version,
             body=release_notes,
@@ -278,6 +272,8 @@ def create_release(repo, version, bodyfile):
             raise SystemExit(6)
         else:
             raise e
+    else:
+        ctx_obj.release_url = release.html_url
 
 
 @cli.command()


### PR DESCRIPTION
Issues:
The e-mail message body is set to the file path where the release notes
are saved. The command-line option `--body` is being incorrectly passed
the path instead of the actual text to use in the message.

In general, the sub-command `mailgun` should be run after
`generate_release_notes` and so the message body should not need to be
supplied however the click context object is not updated to include the
release notes and so the incorrectly supplied path is used instead.

Release notes should be formatted in GitHub Markdown, e-mail clients are
not guaranteed to present this in a reader-friendly format.

Change:
This change removes from `ghutils.create_release` the responsibility of
defining the message subject and consolidates all control of the e-mail
to the notifications file. To help to keep the separation of concerns,
`ghutils.create_release` now updates the context object to include the
link to the new release so it can be used in the message instead of
sending the release notes text.

`notifications.generate_message_data` is used to unify all the common
code, in `notifications.mail` and `notifications.mailgun`, that is being
used to inspect the context object and determine the sender, subject,
and body of the message.

Issue: [RE-759](https://rpc-openstack.atlassian.net/browse/RE-759)

Tested with: https://rpc.jenkins.cit.rackspace.net/job/RE-Release/107/
@hughsaunders would you mind checking the e-mail you received for this test.