### PR TITLE
RE-784 Remove env.ghprbGhRepository reference

### DIFF
--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -72,7 +72,8 @@
 
             try {{
               ansiColor('xterm') {{
-                dir("${{env.WORKSPACE}}/${{env.ghprbGhRepository}}") {{
+                String repo_name = env.REPO_URL.split('/')[-1]
+                dir("${{env.WORKSPACE}}/${{repo_name}}") {{
                   withCredentials(common.get_cloud_creds()) {{
 
                     stage('Checkout') {{


### PR DESCRIPTION
Currently, we're trying to create a directory called
env.ghprbGhRepository in the PM job, but this var is only available in
the PR jobs.  This commit slices up env.REPO_URL to determine the repo
name, and creates that instead.

Issue: [RE-784](https://rpc-openstack.atlassian.net/browse/RE-784)