### PR TITLE
Implement optional job_name_prefix

### DIFF
--- a/rpc_jobs/rpc_octavia.yml
+++ b/rpc_jobs/rpc_octavia.yml
@@ -26,5 +26,5 @@
 
     # Link to the standard pre-merge-template
     jobs:
-      - 'PR_{name}-{image}-{scenario}-{action}'
+      - 'PR_{job_name_prefix}-{image}-{scenario}-{action}'
     # add post_merge whe available

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -16,10 +16,11 @@
           REGIONS: "DFW"
           FALLBACK_REGIONS: "IAD"
     jobs:
-      - 'PR_{name}-{image}-{scenario}-{action}'
+      - 'PR_{job_name_prefix}-{image}-{scenario}-{action}'
 
 - project:
     name: "rpc-openstack-newton"
+    job_name_prefix: "rpc-openstack"
     repo_url: "https://github.com/rcbops/rpc-openstack"
     branches:
       - "newton.*"
@@ -38,10 +39,11 @@
           REGIONS: "DFW"
           FALLBACK_REGIONS: "IAD"
     jobs:
-      - 'PR_{name}-{image}-{scenario}-{action}'
+      - 'PR_{job_name_prefix}-{image}-{scenario}-{action}'
 
 - project:
     name: "rpc-openstack-mitaka"
+    job_name_prefix: "rpc-openstack"
     repo_url: "https://github.com/rcbops/rpc-openstack"
     branches:
       - "mitaka.*"
@@ -61,6 +63,7 @@
 
 - project:
     name: "rpc-openstack-liberty"
+    job_name_prefix: "rpc-openstack"
     repo_url: "https://github.com/rcbops/rpc-openstack"
     branches:
       - "liberty.*"
@@ -80,6 +83,7 @@
 
 - project:
     name: "rpc-openstack-kilo"
+    job_name_prefix: "rpc-openstack"
     repo_url: "https://github.com/rcbops/rpc-openstack"
     branches:
       - "kilo.*"

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -7,10 +7,11 @@
     action:     "test"
     jira_project_key: "RE"
     jobs:
-      - 'PM_{name}-{branch}-{image}-{scenario}-{action}'
+      - 'PM_{job_name_prefix}-{branch}-{image}-{scenario}-{action}'
 
 - job-template:
-    name: 'PM_{name}-{branch}-{image}-{scenario}-{action}'
+    name: 'PM_{job_name_prefix}-{branch}-{image}-{scenario}-{action}'
+    job_name_prefix: "{name}"
     project-type: pipeline
     concurrent: true
     FLAVOR: "performance1-1"

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -10,10 +10,11 @@
     action:
       - "test"
     jobs:
-      - 'PR_{name}-{image}-{scenario}-{action}'
+      - 'PR_{job_name_prefix}-{image}-{scenario}-{action}'
 
 - job-template:
-    name: 'PR_{name}-{image}-{scenario}-{action}'
+    name: 'PR_{job_name_prefix}-{image}-{scenario}-{action}'
+    job_name_prefix: "{name}"
     project-type: pipeline
     concurrent: true
     FLAVOR: "performance1-1"


### PR DESCRIPTION
It's common in complex job definitions to need to do
multiple projects for a single repo, but in doing so
the job names get very long because JJB projects have
to be unique.

In this patch we implement the optional 'job_name_prefix'
variable which can be set in order to allow the job name
to use a shorter prefix than the full project name.