### PR TITLE
RE-784 Standardise pre and post job names

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -152,6 +152,12 @@
         ztrigger: pr
       - series: kilo
         ztrigger: pr
+      # The periodic tests for the following are now
+      # handled by the standard postmerge jobs
+      # defined in rpc_openstack.yml
+      - series: master
+        ztrigger: periodic
+        action: deploy
     jobs:
       - 'RPC-AIO_{series}-{image}-{action}-{scenario}-{ztrigger}'
 

--- a/rpc_jobs/rpc_octavia.yml
+++ b/rpc_jobs/rpc_octavia.yml
@@ -1,6 +1,7 @@
  - project:
     name: "rpc-octavia"
 
+    repo_name: "rpc-octavia"
     # URL of the rpc-octavia repository
     repo_url: "https://github.com/rcbops/rpc-octavia"
 
@@ -26,5 +27,5 @@
 
     # Link to the standard pre-merge-template
     jobs:
-      - 'PR_{name}-{image}-{scenario}-{action}'
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
     # add post_merge whe available

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -1,6 +1,8 @@
 - project:
-    name: "rpc-openstack"
+    name: "rpc-openstack-master-premerge"
+    repo_name: "rpc-openstack"
     repo_url: "https://github.com/rcbops/rpc-openstack"
+    series: "master"
     branches:
       - "master"
     image:
@@ -16,11 +18,13 @@
           REGIONS: "DFW"
           FALLBACK_REGIONS: "IAD"
     jobs:
-      - 'PR_{name}-{image}-{scenario}-{action}'
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
 - project:
-    name: "rpc-openstack-newton"
+    name: "rpc-openstack-newton-premerge"
+    repo_name: "rpc-openstack"
     repo_url: "https://github.com/rcbops/rpc-openstack"
+    series: "newton"
     branches:
       - "newton.*"
     image:
@@ -38,11 +42,13 @@
           REGIONS: "DFW"
           FALLBACK_REGIONS: "IAD"
     jobs:
-      - 'PR_{name}-{image}-{scenario}-{action}'
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
 - project:
-    name: "rpc-openstack-mitaka"
+    name: "rpc-openstack-mitaka-premerge"
+    repo_name: "rpc-openstack"
     repo_url: "https://github.com/rcbops/rpc-openstack"
+    series: "mitaka"
     branches:
       - "mitaka.*"
     image:
@@ -57,11 +63,13 @@
           REGIONS: "DFW"
           FALLBACK_REGIONS: "IAD"
     jobs:
-      - 'PR_{name}-{image}-{scenario}-{action}'
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
 - project:
-    name: "rpc-openstack-liberty"
+    name: "rpc-openstack-liberty-premerge"
+    repo_name: "rpc-openstack"
     repo_url: "https://github.com/rcbops/rpc-openstack"
+    series: "liberty"
     branches:
       - "liberty.*"
     image:
@@ -76,11 +84,13 @@
           REGIONS: "DFW"
           FALLBACK_REGIONS: "IAD"
     jobs:
-      - 'PR_{name}-{image}-{scenario}-{action}'
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
 - project:
-    name: "rpc-openstack-kilo"
+    name: "rpc-openstack-kilo-premerge"
+    repo_name: "rpc-openstack"
     repo_url: "https://github.com/rcbops/rpc-openstack"
+    series: "kilo"
     branches:
       - "kilo.*"
     image:
@@ -94,4 +104,23 @@
           REGIONS: "DFW"
           FALLBACK_REGIONS: "IAD"
     jobs:
-      - 'PR_{name}-{image}-{scenario}-{action}'
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
+
+- project:
+    name: "rpc-openstack-master-postmerge"
+    repo_name: "rpc-openstack"
+    repo_url: "https://github.com/rcbops/rpc-openstack"
+    branch: "master"
+    jira_project_key: "RO"
+    image:
+      - xenial:
+          IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
+    scenario:
+      - "swift"
+    action:
+      - deploy:
+          FLAVOR: "performance2-15"
+          REGIONS: "DFW"
+          FALLBACK_REGIONS: "IAD"
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -1,16 +1,19 @@
 - project:
     name:       "gating-post-merge"
+    repo_name:  "rpc-gating"
     repo_url:   "https://github.com/rcbops/rpc-gating"
-    branch:     "master"
+    # `branch` defaults to `master` and can be omitted.
+    #branch:     "master"
     image:      "xenial"
     scenario:   "functional"
     action:     "test"
     jira_project_key: "RE"
     jobs:
-      - 'PM_{name}-{branch}-{image}-{scenario}-{action}'
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
 - job-template:
-    name: 'PM_{name}-{branch}-{image}-{scenario}-{action}'
+    name: 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+    branch: "master"
     project-type: pipeline
     concurrent: true
     FLAVOR: "performance1-1"
@@ -40,7 +43,6 @@
 
     dsl: |
       library "rpc-gating@${{RPC_GATING_BRANCH}}"
-      properties([pipelineTriggers([githubPush()])])
 
       env.STAGES="Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
 
@@ -53,6 +55,7 @@
       env.RE_JOB_ACTION = "{action}"
       env.RE_JOB_FLAVOR = "{FLAVOR}"
       env.RE_JOB_TRIGGER = "PM"
+      env.RE_JOB_REPO_NAME = "{repo_name}"
       env.RE_JOB_BRANCH = "{branch}"
 
       // Not part of the published interface, used by this job later on
@@ -72,8 +75,7 @@
 
             try {{
               ansiColor('xterm') {{
-                String repo_name = env.REPO_URL.split('/')[-1]
-                dir("${{env.WORKSPACE}}/${{repo_name}}") {{
+                dir("${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}") {{
                   withCredentials(common.get_cloud_creds()) {{
 
                     stage('Checkout') {{

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -1,6 +1,11 @@
 - project:
     name: "gating-pre-merge"
+    repo_name: "rpc-gating"
     repo_url: "https://github.com/rcbops/rpc-gating"
+    # `series` defaults to `master` and can be omitted.  Note that `series` is
+    # only used in the job name and does not necessarily need to map to a
+    # branch name (thought in most cases it will).
+    #series: "master"
     branches:
       - "master"
     image:
@@ -10,10 +15,11 @@
     action:
       - "test"
     jobs:
-      - 'PR_{name}-{image}-{scenario}-{action}'
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
 - job-template:
-    name: 'PR_{name}-{image}-{scenario}-{action}'
+    name: 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
+    series: "master"
     project-type: pipeline
     concurrent: true
     FLAVOR: "performance1-1"

--- a/scripts/lint_naming_conventions.py
+++ b/scripts/lint_naming_conventions.py
@@ -65,7 +65,7 @@ def parse_jjb_file(in_dir, in_file):
 
 
 def parse_job_name(job_name, file_name):
-    regex = '^([a-zA-Z0-9]+-?)+([_]([{][a-zA-Z0-9]+[}]-?)+)?$'
+    regex = '^([a-zA-Z0-9]+-?)+([_]([{][a-zA-Z0-9_]+[}]-?)+)?$'
     match = re.match(regex, job_name)
     if not match:
         out = "Lint error: Job name \"%s\" in \"%s\"" % (job_name, file_name)


### PR DESCRIPTION
Currently, standard_job_postmerge.yml and standard_job_premerge.yml use
the project name in the job template name.  For rpc_openstack.yml as it
stands, this worked fine.  However, as we go to add post merge jobs into
that file we run into a problem where we cannot use duplicate project
names and need to start injecting additional identifiers into the
project names to avoid collision.  The downside here is that these
names are injected into the job names meaning we'll end up with a slew
of job names that are inconsistent and contain potentially redundant
information.

To address, this commit does the following:

1. Changes the job template name in standard_job_postmerge.yml to
   `PM_{repo_name}-{branch}-{image}-{scenario}-{action}`.  The idea
   here is that we specify a `repo_name` in each project, leaving the
   project's name to be descriptive for the purpose of the project and
   not used in the job name at all.
2. Defaults `branch` in standard_job_postmerge.yml to `master` so that
   this variable can be left out if the project is testing their master
   branch.
3. Similarily, we update standard_job_premerge.yml by changing the job
   template name to
   `PR_{repo_name}-{series}-{image}-{scenario}-{action}`.  In addition
   to `repo_name`, we add `series` as an identifier for the series
   being tested.  This too defaults to master and most likely won't be
   specified outside of rpc-openstack.
4. Updates all existing projects to use the updated templates.
5. Adds a new post-merge project for rpc-openstack's master branch,
   which depends on PR [1]
6. Updates the DSL in standard_job_postmerge.yml to remove the
   splitting of env.REPO_URL, since we now pass repo_name into the
   template.
7. Updates lint_naming_conventions.py since the underscore in
   `repo_name` was causing the regex to fail against
   `PM_{repo_name}-{branch}-{image}-{scenario}-{action}`.
8. Removes `properties([pipelineTriggers([githubPush()])])` from
    standard_job_postmerge.yml since this is causing PM jobs to trigger
    on GitHub pushes.
9. Add an exclusion to rpc_aio.yml so we do not run periodics for the
     master deploy job twice.

PLEASE DO NOT MERGE UNTIL [1] MERGES

[1] https://github.com/rcbops/rpc-openstack/pull/2610

Issue: [RE-784](https://rpc-openstack.atlassian.net/browse/RE-784)