### PR TITLE
Add more time to the IRR jobs

### DIFF
--- a/rpc_jobs/irr_role_test.yml
+++ b/rpc_jobs/irr_role_test.yml
@@ -182,7 +182,7 @@
 
     dsl: |
       library "rpc-gating@${{RPC_GATING_BRANCH}}"
-      timeout(time: 3, unit: 'HOURS'){{
+      timeout(time: 5, unit: 'HOURS'){{
         common.shared_slave() {{
             irr_role_tests.run_irr_tests()
         }} // cit node


### PR DESCRIPTION
The rpc-upgrades jobs take longer than three hours. This change
adds two hours to the gate job so that it has enough time to
complete.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>