### PR TITLE
RO-2781 Remove the Kibana work from the gate

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -337,7 +337,8 @@
                   deploy.upgrade_leapfrog(environment_vars: environment_vars)
                 }}
                 tempest.tempest()
-                kibana.kibana(env.KIBANA_SELENIUM_BRANCH)
+                // See Issue: RO-2781 
+                // kibana.kibana(env.KIBANA_SELENIUM_BRANCH)
               }} catch (e) {{
                 print(e)
                 currentBuild.result = 'FAILURE'


### PR DESCRIPTION
Kibana is unmaintained at this time and blocking forward progress within
the repo. This change comments out the Kibana tests. Once we have a
maintainer for this effort we can re-instate the Kibana tests assuming
they're able to be fixed.

Signed-off-by: Kevin Carter kevin.carter@rackspace.com

Issue: [RO-2781](https://rpc-openstack.atlassian.net/browse/RO-2781)