### PR TITLE
RE-784 Disable remaining periodic deploy jobs

### DIFF
--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -158,6 +158,18 @@
       - series: master
         ztrigger: periodic
         action: deploy
+      - series: newton
+        ztrigger: periodic
+        action: deploy
+      - series: mitaka
+        ztrigger: periodic
+        action: deploy
+      - series: liberty
+        ztrigger: periodic
+        action: deploy
+      - series: kilo
+        ztrigger: periodic
+        action: deploy
     jobs:
       - 'RPC-AIO_{series}-{image}-{action}-{scenario}-{ztrigger}'
 


### PR DESCRIPTION
PRs [1] [2] [3] [4] have been created to move rpc-openstack periodic
deploy testing in-repo, meaning we can exclude these jobs in
rpc_aio.yml once the associated PRs have merged.

[1] https://github.com/rcbops/rpc-openstack/pull/2612
[2] https://github.com/rcbops/rpc-openstack/pull/2613
[3] https://github.com/rcbops/rpc-openstack/pull/2614
[4] https://github.com/rcbops/rpc-openstack/pull/2615

Issue: [RE-784](https://rpc-openstack.atlassian.net/browse/RE-784)