### PR TITLE
RE-784 Add RE_JOB_REPO_NAME to pre merge template

### DIFF
--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -75,6 +75,7 @@
       env.RE_JOB_ACTION = "{action}"
       env.RE_JOB_FLAVOR = "{FLAVOR}"
       env.RE_JOB_TRIGGER = "PR"
+      env.RE_JOB_REPO_NAME = "{repo_name}"
 
       // Apply a global three hour timeout
       timeout(time: 3, unit: 'HOURS'){{


### PR DESCRIPTION
In https://github.com/rcbops/rpc-gating/pull/492, we made the
environment variable RE_JOB_REPO_NAME accessible to jobs using the
post merge template.  This commit makes this variable accessible to
jobs using the pre merge template also.

Issue: [RE-784](https://rpc-openstack.atlassian.net/browse/RE-784)