### PR TITLE
RE-808 Update master mnaio jobs

### DIFF
--- a/rpc_jobs/hardening.yml
+++ b/rpc_jobs/hardening.yml
@@ -1,8 +1,8 @@
 - project:
     name: 'RPC-Hardening-Jobs'
     series:
-      - master:
-          branch: master
+      - newton:
+          branch: newton
           USER_VARS: |
             tempest_test_sets: 'scenario'
     context:

--- a/rpc_jobs/multi_node_aio.yml
+++ b/rpc_jobs/multi_node_aio.yml
@@ -31,11 +31,14 @@
             neutron_legacy_ha_tool_enabled: true
           UPGRADE_FROM_REF: "kilo"
           DEPLOY_TELEGRAF: "yes"
-      - master:
-          branch: master
-          SERIES_USER_VARS: |
-            tempest_test_sets: 'all'
-          DEPLOY_TELEGRAF: "yes"
+      # NOTE(mattt): master builds are currently failing since rpco no longer
+      #              uses submodules.  Disabling temporarily since no one is
+      #              relying on these builds at present.
+      #- master:
+      #    branch: master
+      #    SERIES_USER_VARS: |
+      #      tempest_test_sets: 'all'
+      #    DEPLOY_TELEGRAF: "yes"
     image:
       - xenial:
           DEFAULT_IMAGE: "ubuntu-16.04-amd64"


### PR DESCRIPTION
All mnaio jobs are currently failing since rpco no longer uses
submodules and mnaio rpc-gating code assumes we're checking out a
submodule.

This commit updates the hardening job to use newton branch instead, and
comments out the master jobs in multi_node_aio.yml until we're able to
deploy mnaios with and without submodules.

Issue: [RE-808](https://rpc-openstack.atlassian.net/browse/RE-808)