### PR TITLE
RLM-228 Revert commit bfc7bcd

### DIFF
--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -84,7 +84,7 @@
           description: Version of Ubuntu image to use for VMs (14.04.5 or 16.04.2)
       - string:
           name: DEFAULT_KERNEL
-          default: "linux-image-generic"
+          default: "linux-image-4.4.0-66-generic"
           description: Ubuntu Kernel package to use for VMs (linux-image-4.4.0-66-generic, linux-image-3.13.0-34-generic, etc.)
       - bool:
           name: PARTITION_HOST


### PR DESCRIPTION
Since PR https://github.com/rcbops/rpc-gating/pull/465 set the default
VM kernel from linux-image-4.4.0-66-generic to linux-image-generic,
we've been having increased build failures on Trusty deploys.

This PR simply reverts that commit to verify that using
linux-image-4.4.0-66-generic is required.

This reverts commit bfc7bcd3cbd81622afe9231ccade08da0dcd9260.

Issue: [RLM-228](https://rpc-openstack.atlassian.net/browse/RLM-228)