### PR TITLE
RLM-275 Install python-minimal on xenial hosts for ansible

### DIFF
--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -106,6 +106,7 @@ String getPubCloudSlave(Map args){
           env.RAX_CREDS_FILE = pyrax_cfg
           common.venvPlaybook(
             playbooks: ["allocate_pubcloud.yml",
+                        "instance_prep.yml",
                         "drop_ssh_auth_keys.yml"],
             args: [
               "-i inventory",

--- a/playbooks/instance_prep.yml
+++ b/playbooks/instance_prep.yml
@@ -1,0 +1,6 @@
+- hosts: job_nodes
+  remote_user: root
+  gather_facts: False
+  tasks:
+    - name: RLM-275 Adds python packages if python is not present
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal python-yaml)


### PR DESCRIPTION
Ansible bombs without this in place on the OnMetal Xenial image as python 2.x isn't installed by default.  This leverages cloud-init to install the package.  Could also load this via the first ansible playbook as the first option we run using the raw module but this seems a bit cleaner.

python-yaml is installed at this time too since mnaio_inventory_generate.py fires early.

I could also maybe drop the apt-get update, but wasn't sure if a cache exists or not on these images.

Issue: [RLM-275](https://rpc-openstack.atlassian.net/browse/RLM-275)