### PR TITLE
RE-617 Update standard_job_premerge_release.yml

### DIFF
--- a/rpc_jobs/standard_job_premerge_release.yml
+++ b/rpc_jobs/standard_job_premerge_release.yml
@@ -51,7 +51,7 @@
           name: "BRANCH"
           description: Branch of the repo to be release tested
           default: "{BRANCH}"
-      - string:
+      - text:
           name: "COMMAND"
           description: |
             # ORG - Owner of the repo
@@ -69,17 +69,17 @@
             # the contexts of the PR are included in the releasenotes
             # generation. As such this environment variable is set in
             # job_dsl/release.groovy instead of here.
-          default: >-
-            python rpc-gating/scripts/release.py
-                --debug
-                --org "${{ORG}}"
-                --repo "${{REPO}}"
-                clone
-                  --ref "${{RC_BRANCH}}"
-                generate_release_notes
-                    --script "optional:gating/generate_release_notes/pre"
-                    --script "gating/generate_release_notes/run"
-                    --script "optional:gating/generate_release_notes/post"
-                    --prev-version "{BRANCH}"
-                    --version "${{RC_BRANCH}}"
+          default: |
+            python rpc-gating/scripts/release.py \
+                --debug \
+                --org "${{ORG}}" \
+                --repo "${{REPO}}" \
+                clone \
+                  --ref "${{RC_BRANCH}}" \
+                generate_release_notes \
+                    --script "optional:gating/generate_release_notes/pre" \
+                    --script "gating/generate_release_notes/run" \
+                    --script "optional:gating/generate_release_notes/post" \
+                    --prev-version "{BRANCH}" \
+                    --version "${{RC_BRANCH}}" \
                     --out-file "${{WORKSPACE}}/artifacts/release_notes"


### PR DESCRIPTION
This job template seems problematic in that jobs are currently failing
with:

```
+ python rpc-gating/scripts/release.py
Usage: release.py [OPTIONS] COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...

Options:
  --org TEXT            Github Organisation that owns the target repo
                        [required]
  --repo TEXT           Name of target repo  [required]
  --pat TEXT            Github Personal Access Token  [required]
  --debug / --no-debug
  --help                Show this message and exit.

Commands:
  add_issue_url_to_pr
  clone
  create_issue
  create_pr
  create_release
  generate_release_notes
  mail                    Send mail via local MTA
  mailgun                 Send mail via mailgun api.
  publish_tag
  update_rc_branch        Update rc branch.
  usage
+ --debug
```

While the `COMMAND` parameter YAML looks correct (>- to unfold the
lines, removing newline at the end), viewing the long `COMMAND` string
in the Jenkins UI is difficult when the field is a `string`.

This commit simply updates `COMMAND` to be a text, changes the >- to
|, and appends each line with a slash.  This is the format currently
used in rpc_jobs/release.yml.

Issue: [RE-617](https://rpc-openstack.atlassian.net/browse/RE-617)