### PR TITLE
RE-1019 Fix fallback region split

### DIFF
--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -28,7 +28,7 @@
 
     - name: Create fallback region list
       set_fact:
-        fallback_regions_shuff: "{{ (fallback_regions|replace(',', ' ')).split(',')|map('trim')|map('upper')|select|difference(regions)|shuffle }}"
+        fallback_regions_shuff: "{{ (fallback_regions|replace(',', ' ')).split()|map('trim')|map('upper')|select|difference(regions)|shuffle }}"
 
       # As this is a with_items loop not, do-until, we have to use
       # failed_when: false. Otherwise the loop would exit after


### PR DESCRIPTION
Commas in the fallback region string are replaced with spaces, but then
the string is split on commas to form a list. Consequently the string
is not split and a single item list is produced. This list is not a
valid region, so attempts to use the fallback region fail.

This commit changes the allocate_pubcloud playbook to split the
fallback region list on spaces rather than commas to avoid the above
problem.

Issue: [RE-1019](https://rpc-openstack.atlassian.net/browse/RE-1019)