### PR TITLE
RE-1020 Introduce protected_prefix

### DIFF
--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -4,15 +4,14 @@
     parameters:
       - string:
           name: "INSTANCE_AGE_LIMIT"
-          default: "24"
+          default: "12"
           description: |
             Hours. Instances older than this will be removed.
       - string:
-          name: "INSTANCE_PREFIX"
-          default: "ra|ri|om|su"
+          name: "PROTECTED_PREFIX"
+          default: "long-running-slave|influx-|WEBHOOK-PROXY"
           description: |
-            Only instances whose names match the supplied prefix pattern will
-            be cleaned up.
+            Instances that match this prefix regex will not be cleaned up.
       - string:
           name: "REGIONS"
           default: "DFW IAD ORD HKG SYD"

--- a/scripts/jenkins_node.py
+++ b/scripts/jenkins_node.py
@@ -48,11 +48,11 @@ def delete_node(jenkins, name):
     jenkins.delete_node(nodename=name)
 
 
-def delete_inactive_nodes(jenkins, instance_prefix):
+def delete_inactive_nodes(jenkins, protected_prefix):
     for node_id, node in jenkins.get_nodes().iteritems():
         # Ignore nodes that are coming online for the first time
         # which won't have an offline cause.
-        if (re.match(instance_prefix, node_id) and not node.is_online()
+        if (not re.match(protected_prefix, node_id) and not node.is_online()
             and node.poll(tree="offlineCauseReason")
                 .get("offlineCauseReason")):
             try:

--- a/scripts/periodic_cleanup.py
+++ b/scripts/periodic_cleanup.py
@@ -106,7 +106,9 @@ class Cleanup:
 
     @log
     def cleanup_instances(self):
-        """ Delete instances if they are in an error state or are over the
+        """Cleanup Instances.
+
+        Delete instances if they are in an error state or are over the
         age defined in INSTANCE_AGE_LIMIT.
 
         Instances that don't match INSTANCE_PREFIX are ignored.
@@ -149,8 +151,7 @@ class Cleanup:
 
     @log
     def cleanup_maas_entities(self):
-        """ Remove maas entities that relate to deleted instances """
-
+        """Remove maas entities that relate to deleted instances."""
         self.cache_maas_objects()
 
         # An entity will be kept if an associated agent has connected within
@@ -263,7 +264,7 @@ class Cleanup:
 
     @log
     def cleanup_jenkins_nodes(self):
-        """ Remove offline jenkins nodes that match instance prefix """
+        """Remove offline unprotected jenkins nodes."""
         try:
             jenkins_node.delete_inactive_nodes(
                 jenkins=self.jenkins_client,


### PR DESCRIPTION
    Previously instance_prefix was used to match instances that should
    be cleaned up. The idea was that all jobs used a common prefix
    (like rpc-aio) and we could use that prefix to identify temporary
    nodes that had leaked.

    However there are now too many jobs to accurately maintain the
    prefix regex. It also failed to account for test jobs that could
    create instances that didn't match the prefix.

    This commit inverts the logic, removes instance_prefix and replaces
    it with protected_prefix. All instances that don't match the
    protected_prefix regex, will be subject to cleanup.

Issue: [RE-1020](https://rpc-openstack.atlassian.net/browse/RE-1020)