### PR TITLE
RE-1046 Bump openstack-ansible-ops

### DIFF
--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -77,7 +77,7 @@
           default: https://github.com/openstack/openstack-ansible-ops
       - string:
           name: OSA_OPS_BRANCH
-          default: 835c2632f2b862600276d001313865605f34bdf5
+          default: 169b4751680292aa3a2f8b081cb356acbcc3a043
       - string:
           name: DEFAULT_IMAGE
           default: "{DEFAULT_IMAGE}"

--- a/scripts/mnaio_inventory_generate.py
+++ b/scripts/mnaio_inventory_generate.py
@@ -67,6 +67,7 @@ def host_ops(hostvars, hostname, num):
     hostvars.update({
       "ansible_host": "10.0.236.%s" % ip_last_octet,
       'server_hostname': hostname,
+      'server_domain_name': 'openstack_local',
       'server_vm': True,
       'server_preseed_ks': 'vm',
       'server_vm_fixed_addr': '10.0.2.%s' % ip_last_octet,


### PR DESCRIPTION
This is necessary to work around failures we're hitting as a result of
ansible 2.4.1.0 being installed.

Note that in addition to bumping the SHA, we also need to introduce a
new host var, `server_domain_name`.

Lastly, because openstack-ansible-ops now reverts to using ansible
2.3.2.0, we have to revert some of the python ansible code in
pipeline_steps/maas.groovy.  However, instead of reverting wholesale we
update it to work with both ansible < 2.4 and >= 2.4.

Issue: [RE-1046](https://rpc-openstack.atlassian.net/browse/RE-1046)