### PR TITLE
RE-652 Correct stashing

### DIFF
--- a/pipeline_steps/multi_node_aio_prepare.groovy
+++ b/pipeline_steps/multi_node_aio_prepare.groovy
@@ -112,7 +112,7 @@ def connect_deploy_node(name, instance_ip) {
   dir("rpc-gating/playbooks"){
     stash (
       name: inventory_name,
-      include: inventory_path
+      includes: "${inventory_name}/hosts"
     )
   }
   ssh_slave.connect(port: 2222, inventory: inventory_name)

--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -66,7 +66,7 @@ def savePubCloudSlave(Map args){
           )
           stash (
             name: args.inventory,
-            include: "${args.inventory}/hosts"
+            includes: "${args.inventory}/hosts"
           )
         } // dir
       } //withCredentials
@@ -116,7 +116,7 @@ String getPubCloudSlave(Map args){
           )
           stash (
             name: args.inventory,
-            include: "${args.inventory}/hosts"
+            includes: "${args.inventory}/hosts"
           )
         }
       }


### PR DESCRIPTION
Currently, we're using `include` when we stash instead of `includes`,
and this is including far too many files.

This commit simply corrects each stash to refer to `includes` instead.
Note that in multi_node_aio_prepare.groovy, we also update the stash to
point to the specific inventory file relative to the working directory,
rather than referring to `inventory_path`, which didn't seem to work.

Issue: [RE-652](https://rpc-openstack.atlassian.net/browse/RE-652)