### PR TITLE
RE-678 Add merge trigger job for post merge job

### DIFF
--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -2,14 +2,36 @@
     name:       "gating-post-merge"
     repo_name:  "rpc-gating"
     repo_url:   "https://github.com/rcbops/rpc-gating"
-    # `branch` defaults to `master` and can be omitted.
-    #branch:     "master"
+    branch:     "master"
     image:      "xenial"
     scenario:   "functional"
     action:     "test"
     jira_project_key: "RE"
+    trigger_build: "PM_{repo_name}-{branch}-{image}-{scenario}-{action}"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+      - 'PM-push-trigger_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+# This job is specified as `freestyle` as using a pipeline job with github
+# trigger causes the job to be triggered irrespective of which branch was
+# pushed to.
+- job-template:
+    name: "PM-push-trigger_{repo_name}-{branch}-{image}-{scenario}-{action}"
+    project-type: freestyle
+    scm:
+      - git:
+          url: "{repo_url}"
+          branches:
+           - "{branch}"
+    properties:
+      - build-discarder:
+          num-to-keep: 30
+    triggers:
+        - github
+    builders:
+      - trigger-builds:
+        - project:
+            - "{trigger_build}"
 
 - job-template:
     name: 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'


### PR DESCRIPTION
Currently the post merge standard job is triggered by cron/timer only.
This commit adds a freestyle job which is triggered by pushes to github
which in turn triggers the post merge standard job.

The reason for this is that github push trigger is not reliable with
pipeline jobs (unless using orgfolder/multibranch pipeline which we
aren't).

Each project that wants to use a push trigger, will create a JJB
project to instantiate the job for their repo. Re-For-Projects
will be updated with instructions.

⚠️  Please also review the [documentation](https://rpc-openstack.atlassian.net/wiki/pages/diffpagesbyversion.action?pageId=19005457&selectedPageVersions=49&selectedPageVersions=47) when reviewing this PR.
- [x] doc review 1
- [ ] doc review 2 

Issue: [RE-678](https://rpc-openstack.atlassian.net/browse/RE-678)