### PR TITLE
RE-1103 Update PM to use clone_with_pr_refs

### DIFF
--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -79,7 +79,7 @@
                   withCredentials(common.get_cloud_creds()) {{
 
                     stage('Checkout') {{
-                      git branch: env.BRANCH, url: env.REPO_URL
+                      common.clone_with_pr_refs(env.REPO_URL, env.BRANCH)
                     }} // stage
 
                     stage('Execute Pre Script') {{


### PR DESCRIPTION
Currently, the PM template is using the `git` pipeline step but this
isn't initialising submodules, which is necessary by rpc-openstack.
This commit switches to the helper `clone_with_pr_refs` instead.

Issue: [RE-1103](https://rpc-openstack.atlassian.net/browse/RE-1103)