### PR TITLE
RE-1111 Notify #ceph and #rpc-engineering of phobos deploys

### DIFF
--- a/rpc_jobs/phobos.yml
+++ b/rpc_jobs/phobos.yml
@@ -51,6 +51,7 @@
           slackSend(channel: "#rpc-releng", message: msg_plus_link, color: color)
           slackSend(channel: "#rpc-eng-ops", message: msg_plus_link, color: color)
           slackSend(channel: "#ceph", message: msg_plus_link, color: color)
+          slackSend(channel: "#rpc-engineering", message: msg_plus_link, color: color)
         }
       }
       void verify(){

--- a/rpc_jobs/phobos.yml
+++ b/rpc_jobs/phobos.yml
@@ -50,6 +50,7 @@
           msg_plus_link="${message} (${env.BUILD_URL})"
           slackSend(channel: "#rpc-releng", message: msg_plus_link, color: color)
           slackSend(channel: "#rpc-eng-ops", message: msg_plus_link, color: color)
+          slackSend(channel: "#ceph", message: msg_plus_link, color: color)
         }
       }
       void verify(){


### PR DESCRIPTION
This is so the storage team who are a current user of phobos
are aware of potential disruption.

Issue: [RE-1111](https://rpc-openstack.atlassian.net/browse/RE-1111)