### PR TITLE
RE-1116 Correctly fail build when failure occurs

### DIFF
--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -122,10 +122,13 @@
                 }} // dir
               }} // ansiColor
             }} catch (e) {{
+              print(e)
+              currentBuild.result="FAILURE"
               common.create_jira_issue(JIRA_PROJECT_KEY,
                                        env.BUILD_TAG,
                                        env.BUILD_URL,
                                        "Task")
+              throw e
             }} finally {{
               common.archive_artifacts()
             }} // try


### PR DESCRIPTION
Currently, builds that fail in the `Execute Run Script` stage do not
fail the build.  This commit sets the build to `FAILURE` in the catch
and re-throws the exception.  This is a similar pattern that exists in
standard_job_premerge.yml.

Issue: [RE-1116](https://rpc-openstack.atlassian.net/browse/RE-1116)