### PR TITLE
RE-1120 Unset delete old when building subset

### DIFF
--- a/rpc_jobs/jjb_setup.yml
+++ b/rpc_jobs/jjb_setup.yml
@@ -65,7 +65,8 @@
       url=${JENKINS_URL}
       EOF
 
-                if [[ "$RPC_GATING_BRANCH" == "master" ]]; then
+                if [[ "$RPC_GATING_BRANCH" == "master" ]] && [[ "$JOBS" == "-r rpc_jobs" ]]; then
+                    echo "Setting --delete-old as RPC_GATING_BRANCH=master and JOBS='-r rpc_jobs'"
                     UPDATE_ARGS="--delete-old"
                 fi
 


### PR DESCRIPTION
JJB can be restricted to building a subset of jobs, this option
must not be used with --delete-old, as then jobs not in that
subset will be deleted.

This commit ensures --delete-old is not enabled when building
a subset of jjb jobs.

Issue: [RE-1120](https://rpc-openstack.atlassian.net/browse/RE-1120)