### PR TITLE
RE-1121 Use correct inventory

### DIFF
--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -59,7 +59,7 @@ def savePubCloudSlave(Map args){
           common.venvPlaybook(
             playbooks: ['save_pubcloud.yml'],
             args: [
-              "-i inventory",
+              "-i ${args.inventory}",
               "--private-key=\"${env.JENKINS_SSH_PRIVKEY}\"",
             ],
             vars: args
@@ -109,7 +109,7 @@ String getPubCloudSlave(Map args){
                         "instance_prep.yml",
                         "drop_ssh_auth_keys.yml"],
             args: [
-              "-i inventory",
+              "-i ${args.inventory}",
               "--private-key=\"${env.JENKINS_SSH_PRIVKEY}\""
             ],
             vars: args


### PR DESCRIPTION
This commit updates pubcloud.groovy to use the correct inventory passed
in through args.  Currently, we assume an inventory `inventory` which
is incorrect.

Issue: [RE-1121](https://rpc-openstack.atlassian.net/browse/RE-1121)