### PR TITLE
RLM-290 Adds new RE style jobs for rpc-upgrades

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -3,7 +3,7 @@
     name: "rpc-upgrades-aio-newton-head"
     repo_name: "rpc-upgrades"
     repo_url: "http://github.com/rcbops/rpc-upgrades"
-    series: "newton"
+    series: "master"
     branches:
      - "master"
     image:
@@ -11,14 +11,14 @@
           FLAVOR: "performance2-15"
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
     scenario:
-      - "newton"
+      - "swift"
     action:
-      - "liberty"
-#      - "r12.2.8"
-#      - "r12.2.5"
-#      - "r12.2.2"
-#      - "r12.1.2"
-#      - "kilo" 
+      - "liberty_to_newton_leap"
+      - "r12.2.8_to_newton_leap"
+#      - "r12.2.5_to_newton_leap"
+#      - "r12.2.2_to_newton_leap"
+#      - "r12.1.2_to_newton_leap"
+#      - "kilo_to_newton_leap" 
     jira_project_key: "RLM"
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
@@ -28,7 +28,7 @@
     name: "rpc-upgrades-aio-newton-release"
     repo_name: "rpc-upgrades"
     repo_url: "http://github.com/rcbops/rpc-upgrades"
-    series: "r14.4.1"
+    series: "master"
     branches:
      - "master"
     image:
@@ -36,41 +36,42 @@
           FLAVOR: "performance2-15"
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
     scenario:
-      - "r14.4.1"
+      - "swift"
     action:
-      - "liberty"
-#      - "r12.2.8"
-#      - "r12.2.5"
-#      - "r12.2.2"
-#      - "r12.1.2"
-#      - "kilo"
+      - "liberty_to_r14.4.1_leap"
+#      - "r12.2.8_to_r14.4.1_leap"
+#      - "r12.2.5_to_r14.4.1_leap"
+#      - "r12.2.2_to_r14.4.1_leap"
+#      - "r12.1.2_to_r14.4.1_leap"
+#      - "kilo_to_r14.4.1_leap"
+      - "r11.1.6_to_r14.4.1_leap"
     jira_project_key: "RLM"
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
-#- project:
-#    name: "rpc-upgrades-mnaio-newton-head"
-#    repo_name: "rpc-upgrades"
-#    repo_url: "http://github.com/rcbops/rpc-upgrades"
-#    branches:
-#     - "master"
-#    image:
-#      - mnaio:
-#          FLAVOR: "onmetal-io1"
-#          IMAGE: "OnMetal - Ubuntu 14.04 LTS (Trusty Tahr)"
-#    scenario:
-#      - "newton"
-#    action:
-#      - "liberty"
-#      - "r12.2.8"
-#      - "r12.2.5"
-#      - "r12.2.2"
-#      - "r12.1.2"
-#      - "kilo"
-#    jira_project_key: "RLM"
-#    jobs:
-#      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+- project:
+    name: "rpc-upgrades-mnaio-newton-head"
+    repo_name: "rpc-upgrades"
+    repo_url: "http://github.com/rcbops/rpc-upgrades"
+    branches:
+     - "master"
+    image:
+      - mnaio:
+          FLAVOR: "onmetal-io1"
+          IMAGE: "OnMetal - Ubuntu 14.04 LTS (Trusty Tahr)"
+    scenario:
+      - "swift"
+    action:
+      - "liberty_to_newton_leap"
+#      - "r12.2.8_to_newton_leap"
+#      - "r12.2.5_to_newton_leap"
+#      - "r12.2.2_to_newton_leap"
+#      - "r12.1.2_to_newton_leap"
+#      - "kilo_to_newton_leap"
+    jira_project_key: "RLM"
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
 #- project:
 #    name: "rpc-upgrades-mnaio-newton-release"
@@ -83,14 +84,14 @@
 #          FLAVOR: "onmetal-io1"
 #          IMAGE: "OnMetal - Ubuntu 14.04 LTS (Trusty Tahr)"
 #    scenario:
-#      - "r14.4.1"
+#      - "swift"
 #    action:
-#      - "liberty"
-#      - "r12.2.8"
-#      - "r12.2.5"
-#      - "r12.2.2"
-#      - "r12.1.2"
-#      - "kilo"
+#      - "liberty_to_r14.4.1_leap"
+#      - "r12.2.8_to_r14.4.1_leap"
+#      - "r12.2.5_to_r14.4.1_leap"
+#      - "r12.2.2_to_r14.4.1_leap"
+#      - "r12.1.2_to_r14.4.1_leap"
+#      - "kilo_to_r14.4.1_leap"
 #    jira_project_key: "RLM"
 #    jobs:
 #      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'

--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -1,0 +1,96 @@
+### tests rpc-upgrades to <scenario> leaped from <action>
+- project:
+    name: "rpc-upgrades-aio-newton-head"
+    repo_name: "rpc-upgrades"
+    repo_url: "http://github.com/rcbops/rpc-upgrades"
+    series: "newton"
+    branches:
+     - "master"
+    image:
+      - aio:
+          FLAVOR: "performance2-15"
+          IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+    scenario:
+      - "newton"
+    action:
+      - "liberty"
+#      - "r12.2.8"
+#      - "r12.2.5"
+#      - "r12.2.2"
+#      - "r12.1.2"
+#      - "kilo" 
+    jira_project_key: "RLM"
+    jobs:
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+- project:
+    name: "rpc-upgrades-aio-newton-release"
+    repo_name: "rpc-upgrades"
+    repo_url: "http://github.com/rcbops/rpc-upgrades"
+    series: "r14.4.1"
+    branches:
+     - "master"
+    image:
+      - aio:
+          FLAVOR: "performance2-15"
+          IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+    scenario:
+      - "r14.4.1"
+    action:
+      - "liberty"
+#      - "r12.2.8"
+#      - "r12.2.5"
+#      - "r12.2.2"
+#      - "r12.1.2"
+#      - "kilo"
+    jira_project_key: "RLM"
+    jobs:
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+#- project:
+#    name: "rpc-upgrades-mnaio-newton-head"
+#    repo_name: "rpc-upgrades"
+#    repo_url: "http://github.com/rcbops/rpc-upgrades"
+#    branches:
+#     - "master"
+#    image:
+#      - mnaio:
+#          FLAVOR: "onmetal-io1"
+#          IMAGE: "OnMetal - Ubuntu 14.04 LTS (Trusty Tahr)"
+#    scenario:
+#      - "newton"
+#    action:
+#      - "liberty"
+#      - "r12.2.8"
+#      - "r12.2.5"
+#      - "r12.2.2"
+#      - "r12.1.2"
+#      - "kilo"
+#    jira_project_key: "RLM"
+#    jobs:
+#      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+#- project:
+#    name: "rpc-upgrades-mnaio-newton-release"
+#    repo_name: "rpc-upgrades"
+#    repo_url: "http://github.com/rcbops/rpc-upgrades"
+#    branches:
+#     - "master"
+#    image:
+#      - mnaio:
+#          FLAVOR: "onmetal-io1"
+#          IMAGE: "OnMetal - Ubuntu 14.04 LTS (Trusty Tahr)"
+#    scenario:
+#      - "r14.4.1"
+#    action:
+#      - "liberty"
+#      - "r12.2.8"
+#      - "r12.2.5"
+#      - "r12.2.2"
+#      - "r12.1.2"
+#      - "kilo"
+#    jira_project_key: "RLM"
+#    jobs:
+#      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'


### PR DESCRIPTION
Taking a first shot at making the new style RE jobs:

Adds AIO jobs for testing rpc-upgrades on PR and Post Merge (periodic):
- Tests AIO leaps to newton head from kilo/liberty/liberty releases
- Tests AIO leaps to newton release from kilo/liberty/liberty releases

Adds MNAIO jobs for testing rpc-upgrades on Post Merge (periodic):
- Tests MNAIO leaps to newton head from kilo head /liberty head/liberty releases
- Tests MNAIO leaps to newton release from kilo head/liberty head/liberty releases

Actions are set as the "UPGRADE_FROM_REF" and series is utilized as the destination leap version.  Open to suggestions and improvements on how to shim this into the existing layout as it's a bit different.  Most of the actions are commented out for now except for liberty while implementing the jobs in rpc-upgrades and if we can get this going we can probably eliminate the existing jobs as well as IRR.

Issue: [RLM-290](https://rpc-openstack.atlassian.net/browse/RLM-290)