### PR TITLE
RE-1126 Update when in server provisioning task

### DIFF
--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -51,7 +51,7 @@
       register: result
       with_items: "{{ regions_shuf + fallback_regions_shuff }}"
       when:
-        - "{{ result is undefined or 'success' not in result or result.success|length != count }}"
+        - result is undefined or result.server.status != 'ACTIVE'
       failed_when: false
 
     - name: Extract instance boot result from loop results array


### PR DESCRIPTION
The when clause in the 'Provision a cloud instance' task was not updated
in the migration from rax module to os_server, and this is resulting in
an instance being created in all regions, rather than just the first.

This commit updates the when clause to work with os_server.

Co-Authored-By: git-harry <git-harry@live.co.uk>

Issue: [RE-1126](https://rpc-openstack.atlassian.net/browse/RE-1126)