### PR TITLE
RE-1134 Enable config-drive for user-data

### DIFF
--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -44,6 +44,7 @@
         image: "{{ image }}"
         key_name: "{{ keyname }}"
         userdata: "{{ lookup('file', user_data_path) }}"
+        config_drive: yes
         meta:
           build_config: core
         wait: yes


### PR DESCRIPTION
With the switch from ansible rax module to os_server, we now need to
explicitly enable config-drive in order for our user-data scripts to
run.  This commit simply flips it on in the `Provision a cloud
instance` task.

Issue: [RE-1134](https://rpc-openstack.atlassian.net/browse/RE-1134)