### PR TITLE
RE-1139 Fix retry instance creation

### DIFF
--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -52,7 +52,7 @@
       register: result
       with_items: "{{ regions_shuf + fallback_regions_shuff }}"
       when:
-        - result is undefined or result.server.status != 'ACTIVE'
+        - result is undefined or 'server' not in result or result.server.status != 'ACTIVE'
       failed_when: false
 
     - name: Extract instance boot result from loop results array


### PR DESCRIPTION
The task "Provision a cloud instance" fails without trying the next
region under certain types of build failure, for example if the
requested image does not exist in the current region.

This change updates the when clause so that the next region will be
tried if no 'server' key is present in the result object.

Issue: [RE-1139](https://rpc-openstack.atlassian.net/browse/RE-1139)