### PR TITLE
RLM-352 Bump timeout to 6 hours

### DIFF
--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -78,8 +78,8 @@
       env.RE_JOB_TRIGGER = "PR"
       env.RE_JOB_REPO_NAME = "{repo_name}"
 
-      // Apply a global three hour timeout
-      timeout(time: 3, unit: 'HOURS'){{
+      // Apply a global six hour timeout
+      timeout(time: 6, unit: 'HOURS'){{
         common.shared_slave() {{
           pubcloud.runonpubcloud {{
 


### PR DESCRIPTION
Leap PM jobs seem to run around 4 hours so the PR
jobs should be similar.  Adding an extra hour for
buffer.

Issue: [RLM-352](https://rpc-openstack.atlassian.net/browse/RLM-352)