### PR TITLE
RE-1136 Override REGIONS in rpc_upgardes.yml

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -10,6 +10,7 @@
       - aio:
           FLAVOR: "performance2-15"
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+          REGIONS: "DFW ORD"
     scenario:
       - "swift"
     action:
@@ -35,6 +36,7 @@
       - aio:
           FLAVOR: "performance2-15"
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+          REGIONS: "DFW ORD"
     scenario:
       - "swift"
     action:
@@ -59,6 +61,7 @@
       - mnaio:
           FLAVOR: "onmetal-io1"
           IMAGE: "OnMetal - Ubuntu 14.04 LTS (Trusty Tahr)"
+          REGIONS: "IAD"
     scenario:
       - "swift"
     action:


### PR DESCRIPTION
Currently we're inherting from defaults.yml, which only has a single
region in REGIONs.  This means builds will fail when that region is
full (which it is now).

Note that the onmetal flavour we're using is only available in IAD,
so we override REGIONS w/ just that region for mnaio builds.

Issue: [RE-1136](https://rpc-openstack.atlassian.net/browse/RE-1136)