### PR TITLE
RE-1136 Cleanup REGIONS/FALLBACK_REGIONS params

### DIFF
--- a/rpc_jobs/defaults.yml
+++ b/rpc_jobs/defaults.yml
@@ -4,8 +4,8 @@
     IMAGE: "Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)"
     FLAVOR: "performance2-15"
     # Available Regions: IAD DFW ORD HKG SYD
-    REGIONS: "DFW"
-    FALLBACK_REGIONS: ""
+    REGIONS: "DFW ORD"
+    FALLBACK_REGIONS: "IAD"
 
     # rpc_params
     DEPLOY_SWIFT: "yes"

--- a/rpc_jobs/influx.yml
+++ b/rpc_jobs/influx.yml
@@ -12,7 +12,7 @@
           RPC_MAAS_BRANCH: master
       - instance_params:
           REGIONS: IAD
-          FALLBACK_REGIONS: "{FALLBACK_REGIONS}"
+          FALLBACK_REGIONS: ""
           FLAVOR: "general1-8"
           IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
       - string:

--- a/rpc_jobs/irr_role_test.yml
+++ b/rpc_jobs/irr_role_test.yml
@@ -99,8 +99,8 @@
       - instance_params:
           IMAGE: "{IMAGE}"
           FLAVOR: "{irr_flavor}"
-          REGIONS: "ORD"
-          FALLBACK_REGIONS: "DFW IAD ORD HKG SYD"
+          REGIONS: "{REGIONS}"
+          FALLBACK_REGIONS: "{FALLBACK_REGIONS}"
       - string:
           name: IRR_CONTEXT
           default: "{context}"

--- a/rpc_jobs/long_running_slave.yml
+++ b/rpc_jobs/long_running_slave.yml
@@ -11,7 +11,7 @@
       - instance_params:
           IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
           REGIONS: "IAD"
-          FALLBACK_REGIONS: "{FALLBACK_REGIONS}"
+          FALLBACK_REGIONS: ""
           FLAVOR: general1-8
       - jenkins_node_params:
           JENKINS_NODE_LABELS: "pubcloud_multiuse"

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -15,8 +15,6 @@
     action:
       - deploy:
           FLAVOR: "performance2-15"
-          REGIONS: "DFW"
-          FALLBACK_REGIONS: "IAD"
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
@@ -39,8 +37,6 @@
     action:
       - deploy:
           FLAVOR: "performance2-15"
-          REGIONS: "DFW"
-          FALLBACK_REGIONS: "IAD"
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
@@ -60,8 +56,6 @@
     action:
       - deploy:
           FLAVOR: "performance2-15"
-          REGIONS: "DFW"
-          FALLBACK_REGIONS: "IAD"
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
@@ -81,8 +75,6 @@
     action:
       - deploy:
           FLAVOR: "performance2-15"
-          REGIONS: "DFW"
-          FALLBACK_REGIONS: "IAD"
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
@@ -101,8 +93,6 @@
     action:
       - deploy:
           FLAVOR: "performance2-15"
-          REGIONS: "DFW"
-          FALLBACK_REGIONS: "IAD"
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
@@ -120,8 +110,6 @@
     action:
       - deploy:
           FLAVOR: "performance2-15"
-          REGIONS: "DFW"
-          FALLBACK_REGIONS: "IAD"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
@@ -141,8 +129,6 @@
     action:
       - deploy:
           FLAVOR: "performance2-15"
-          REGIONS: "DFW"
-          FALLBACK_REGIONS: "IAD"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
@@ -161,8 +147,6 @@
     action:
       - deploy:
           FLAVOR: "performance2-15"
-          REGIONS: "DFW"
-          FALLBACK_REGIONS: "IAD"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
@@ -181,8 +165,6 @@
     action:
       - deploy:
           FLAVOR: "performance2-15"
-          REGIONS: "DFW"
-          FALLBACK_REGIONS: "IAD"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
@@ -201,7 +183,5 @@
     action:
       - deploy:
           FLAVOR: "performance2-15"
-          REGIONS: "DFW"
-          FALLBACK_REGIONS: "IAD"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'

--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -10,7 +10,6 @@
       - aio:
           FLAVOR: "performance2-15"
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
-          REGIONS: "DFW ORD"
     scenario:
       - "swift"
     action:
@@ -36,7 +35,6 @@
       - aio:
           FLAVOR: "performance2-15"
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
-          REGIONS: "DFW ORD"
     scenario:
       - "swift"
     action:
@@ -62,6 +60,7 @@
           FLAVOR: "onmetal-io1"
           IMAGE: "OnMetal - Ubuntu 14.04 LTS (Trusty Tahr)"
           REGIONS: "IAD"
+          FALLBACK_REGIONS: ""
     scenario:
       - "swift"
     action:

--- a/rpc_jobs/single_use_slave_template.yml
+++ b/rpc_jobs/single_use_slave_template.yml
@@ -11,8 +11,8 @@
       - instance_params:
           IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
           FLAVOR: "performance1-1"
-          REGIONS: "ORD"
-          FALLBACK_REGIONS: "DFW IAD HKG SYD"
+          REGIONS: "{REGIONS}"
+          FALLBACK_REGIONS: "{FALLBACK_REGIONS}"
       - rpc_gating_params
       - string:
           name: STAGES


### PR DESCRIPTION
This commit sets some sane defaults for REGIONS/FALLBACK_REGIONS in
defaults.yml and then removes and updates cruft in a number of other
JJB files.  Generally speaking, we want to use DFW and ORD for most
AIO builds, and IAD exclusively for MNAIO builds (so we can leverage
the onmetal v1 capacity).  From a latency/cost perspective, HKG and
SYD have been de-listed entirely.

Issue: [RE-1136](https://rpc-openstack.atlassian.net/browse/RE-1136)