### PR TITLE
RE-1142 Add python-openstacksdk to requirements

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -41,6 +41,7 @@ netaddr==0.7.19
 netifaces==0.10.5
 nose==1.3.7
 oauthlib==2.0.3
+openstacksdk==0.9.19
 ordereddict==1.1
 os-diskconfig-python-novaclient-ext==0.1.3
 os-networksv2-python-novaclient-ext==0.26

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ jenkins-job-builder
 jenkinsapi
 jira
 jmespath
+openstacksdk
 packaging
 python-dateutil
 python-subunit


### PR DESCRIPTION
python-openstacksdk is required by the periodic clean-up job. It was
being installed as a dependency of python-ironicclient which is itself a
dependency of shade. python-ironicclient has now removed this dependency
causing jobs to fail. python-openstacksdk should be an explicit
requirement of this project and this commit makes that so.

Issue: [RE-1142](https://rpc-openstack.atlassian.net/browse/RE-1142)