### PR TITLE
RE-913 Add xenial minor upgrade to rpc_upgrades

### DIFF
--- a/pipeline_steps/aio_prepare.groovy
+++ b/pipeline_steps/aio_prepare.groovy
@@ -2,8 +2,7 @@ def prepare(){
   common.conditionalStage(
     stage_name: "Prepare Deployment",
     stage: {
-      if (env.STAGES.contains("Minor Upgrade")
-          || env.STAGES.contains("Major Upgrade")
+      if (env.STAGES.contains("Major Upgrade")
           || env.STAGES.contains("Leapfrog Upgrade")) {
         common.prepareRpcGit(env.UPGRADE_FROM_REF)
       } else {

--- a/pipeline_steps/deploy.groovy
+++ b/pipeline_steps/deploy.groovy
@@ -70,10 +70,6 @@ def upgrade(String stage_name, String upgrade_script, List env_vars,
   ) // conditionalStage
 }
 
-def upgrade_minor(Map args) {
-  upgrade("Minor Upgrade", "deploy.sh", args.environment_vars)
-}
-
 def upgrade_major(Map args) {
   // Required to run first for major upgrade resource generation
   tempest.tempest_install()

--- a/rpc_jobs/rpc_aio.yml
+++ b/rpc_jobs/rpc_aio.yml
@@ -31,17 +31,6 @@
             Tempest Tests,
             Prepare Kibana Selenium,
             Kibana Tests
-      # A minimum set of stages is chosen deliberately
-      # to test the convergance of the upgrade itself
-      # without additional complexity. Once this is
-      # working well, additional stages may be added.
-      - minorupgrade:
-          ACTION_STAGES: >-
-            Minor Upgrade
-          # NOTE: Once the newton stabilization branch has been created
-          #       (newton-14.2 or similar), we'll need to find a way to
-          #       set this differently depending on the newton series.
-          UPGRADE_FROM_REF: "r14.1.0"
     scenario:
       - swift
       - ceph:
@@ -66,23 +55,6 @@
           branches: "do_not_build_on_pr"
           NUM_TO_KEEP: 10
     exclude:
-      # Minor upgrades are only being executed
-      # for r14.1.0->newton for now until
-      # the minor upgrade testing process is
-      # stabilised.
-      - series: kilo
-        action: minorupgrade
-      - series: liberty
-        action: minorupgrade
-      - series: mitaka
-        action: minorupgrade
-      - series: master
-        action: minorupgrade
-      # Minorupgrades are only being executed
-      # as periodics for now due to the length
-      # of time they take to execute.
-      - action: minorupgrade
-        ztrigger: pr
       # Xenial builds are run for newton and above
       # as it is not supported distro before newton.
       - series: kilo
@@ -103,12 +75,6 @@
       # consume the cluster, not deploy it. At that
       # time the scenario can be added back again.
       - series: newton
-        scenario: ceph
-      # Ceph builds are not tested for minor upgrades
-      # at this time due to the minor upgrades only being
-      # targeted at newton or above, which do not support
-      # the ceph scenario.
-      - action: minorupgrade
         scenario: ceph
       # Ceph builds are not run for Xenial at this time
       # as ceph cluster deployment is not supported for
@@ -254,7 +220,6 @@
               Tempest Tests
               Prepare Kibana Selenium
               Kibana Tests
-              Minor Upgrade
               Major Upgrade
               Leapfrog Upgrade
               Pause (use to hold instance for investigation before cleanup)
@@ -328,9 +293,7 @@
                   ]
                 aio_prepare.prepare()
                 deploy.deploy_sh(environment_vars: environment_vars)
-                if (env.STAGES.contains("Minor Upgrade")) {{
-                  deploy.upgrade_minor(environment_vars: environment_vars)
-                }} else if (env.STAGES.contains("Major Upgrade")) {{
+                if (env.STAGES.contains("Major Upgrade")) {{
                   deploy.upgrade_major(environment_vars: environment_vars)
                 }} else if (env.STAGES.contains("Leapfrog Upgrade")) {{
                   deploy.upgrade_leapfrog(environment_vars: environment_vars)

--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -7,9 +7,12 @@
     branches:
      - "master"
     image:
-      - aio:
+      - trusty_aio:
           FLAVOR: "performance2-15"
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+      - xenial_aio:
+          FLAVOR: "performance2-15"
+          IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
     scenario:
       - "swift"
     action:
@@ -24,6 +27,14 @@
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+    exclude:
+      - image: "xenial_aio"
+        action: "liberty_to_newton_leap"
+        action: "r12.2.8_to_newton_leap"
+        action: "r12.2.5_to_newton_leap"
+        action: "r12.2.2_to_newton_leap"
+        action: "r12.1.2_to_newton_leap"
+        action: "kilo_to_newton_leap"
 
 - project:
     name: "rpc-upgrades-aio-newton-release"


### PR DESCRIPTION
This commit adds an additional minor upgrade job to rpc_upgrades so that
newton minor upgrades are tested on both trusty and xenial.

The rpc_aio code for testing minor upgrades is removed given this
testing is now the responsibility of rpc_upgrades.

Issue: [RE-913](https://rpc-openstack.atlassian.net/browse/RE-913)