### PR TITLE
RE-913 Fix xenial excludes in rpc_upgrades

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -30,10 +30,15 @@
     exclude:
       - image: "xenial_aio"
         action: "liberty_to_newton_leap"
+      - image: "xenial_aio"
         action: "r12.2.8_to_newton_leap"
+      - image: "xenial_aio"
         action: "r12.2.5_to_newton_leap"
+      - image: "xenial_aio"
         action: "r12.2.2_to_newton_leap"
+      - image: "xenial_aio"
         action: "r12.1.2_to_newton_leap"
+      - image: "xenial_aio"
         action: "kilo_to_newton_leap"
 
 - project:


### PR DESCRIPTION
Xenial should only be used as the base image for Newton deployments and
onwards. This change fixes the exclude to properly prevent pre-Newton
jobs using Xenial.

Issue: [RE-913](https://rpc-openstack.atlassian.net/browse/RE-913)