### PR TITLE
RE-787 Add PR build skipping for matching files

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -516,6 +516,42 @@ def docker_cache_workaround(){
    sh "touch -t 201704100000 *.txt"
 }
 
+/* Used to check whether a pull request only includes changes
+ * to files that match the skip regex. If the regex is an
+ * empty string, that is treated as matching nothing.
+ */
+Boolean skip_build_check(String regex) {
+  print "Skipping pattern: '$regex'"
+  if (regex != "") {
+    def rc = sh(
+      script: """#!/bin/bash
+        set -xeu
+        cd ${env.WORKSPACE}/${env.RE_JOB_REPO_NAME}
+        git status
+        git show --stat=400,400 | awk '/\\|/{print \$1}' \
+            |python -c 'import re, sys; all(re.search(r"${regex}", line, re.VERBOSE) for line in sys.stdin) and sys.exit(0) or sys.exit(1)'
+        """,
+        returnStatus: true
+    )
+    if (rc==0) {
+      print "All change files match skip pattern. Skipping..."
+      return true
+    } else if(rc==1) {
+      print "One or more change files not matched by skip pattern. Continuing..."
+      return false
+    } else if(rc==128) {
+      throw new Exception("Directory is not a git repo, cannot compile changes.")
+    }
+  } else {
+    return false
+  } // if
+}
+
+/* DEPRECATED FUNCTION
+ * This function should be removed once it is no longer in use. It remains
+ * while still required by old-style jobs and has been replaced in standard
+ * jobs by `skip_build_check`.
+ */
 def is_doc_update_pr(String git_dir) {
   if (env.ghprbPullId != null) {
     dir(git_dir) {

--- a/rpc_jobs/defaults.yml
+++ b/rpc_jobs/defaults.yml
@@ -19,6 +19,7 @@
     SERIES_USER_VARS: ""
     UPGRADE_FROM_REF: ""
     credentials: ""
+    skip_pattern: ""
     # jenkins_node_params
     # See also playbooks/setup_jenkins_slave.yml where these values are
     # defaulted for jobs that don't include the relevant params.

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -5,6 +5,13 @@
     series: "master"
     branches:
       - "master"
+    skip_pattern: >-
+      \.md$
+      | \.rst$
+      | ^releasenotes/
+      | ^gating/generate_release_notes/
+      | ^gating/post_merge_test/
+      | ^gating/update_dependencies/
     image:
       - xenial:
           IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
@@ -25,6 +32,13 @@
     series: "newton"
     branches:
       - "newton.*"
+    skip_pattern: >-
+      \.md$
+      | \.rst$
+      | ^releasenotes/
+      | ^gating/generate_release_notes/
+      | ^gating/post_merge_test/
+      | ^gating/update_dependencies/
     image:
       - trusty:
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
@@ -47,6 +61,13 @@
     series: "mitaka"
     branches:
       - "mitaka.*"
+    skip_pattern: >-
+      \.md$
+      | \.rst$
+      | ^releasenotes/
+      | ^gating/generate_release_notes/
+      | ^gating/post_merge_test/
+      | ^gating/update_dependencies/
     image:
       - trusty:
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
@@ -66,6 +87,13 @@
     series: "liberty"
     branches:
       - "liberty.*"
+    skip_pattern: >-
+      \.md$
+      | \.rst$
+      | ^releasenotes/
+      | ^gating/generate_release_notes/
+      | ^gating/post_merge_test/
+      | ^gating/update_dependencies/
     image:
       - trusty:
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
@@ -85,6 +113,13 @@
     series: "kilo"
     branches:
       - "kilo.*"
+    skip_pattern: >-
+      \.md$
+      | \.rst$
+      | ^releasenotes/
+      | ^gating/generate_release_notes/
+      | ^gating/post_merge_test/
+      | ^gating/update_dependencies/
     image:
       - trusty:
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -84,80 +84,100 @@
       env.RE_JOB_REPO_NAME = "{repo_name}"
 
       String credentials = "{credentials}"
+      String skip_pattern = "{skip_pattern}"
 
-      common.standard_job_slave(env.SLAVE_TYPE) {{
-        // Set the default environment variables used
-        // by the artifact and test result collection.
-        env.RE_HOOK_ARTIFACT_DIR="${{env.WORKSPACE}}/artifacts"
-        env.RE_HOOK_RESULT_DIR="${{env.WORKSPACE}}/results"
+      Boolean run_test = true
+      // We need to checkout the repo on the CIT Slave so that
+      // we can check whether the patch only includes changes
+      // in files matching the skip pattern. If that is the case,
+      // we can skip the rest of the job execution and return success.
+      common.shared_slave() {{
+        common.withRequestedCredentials(credentials) {{
+          stage('Check PR against skip-list') {{
+            print("Triggered by PR: ${{env.ghprbPullLink}}")
+            common.clone_with_pr_refs(
+              "${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}",
+            )
+            run_test = ! common.skip_build_check(skip_pattern)
+          }} // stage
+        }} // withRequestedCredentials
+      }}
 
-        // Set the job result default
-        currentBuild.result="SUCCESS"
+      if (run_test) {{
+        common.standard_job_slave(env.SLAVE_TYPE) {{
+          // Set the default environment variables used
+          // by the artifact and test result collection.
+          env.RE_HOOK_ARTIFACT_DIR="${{env.WORKSPACE}}/artifacts"
+          env.RE_HOOK_RESULT_DIR="${{env.WORKSPACE}}/results"
 
-        try {{
-          ansiColor('xterm') {{
-            common.withRequestedCredentials(credentials) {{
-              stage('Checkout') {{
-                print("Triggered by PR: ${{env.ghprbPullLink}}")
-                common.clone_with_pr_refs(
-                  "${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}",
-                )
-              }} // stage
+          // Set the job result default
+          currentBuild.result="SUCCESS"
 
-              stage('Execute Pre Script') {{
-                // Retry the 'pre' stage 3 times. The 'pre' stage is considered
-                // to be preparation for the test, so let's try and make sure
-                // it has the best chance of success possible.
-                retry(3) {{
-                  sh """#!/bin/bash -xeu
-                  cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
-                  if [[ -e gating/pre_merge_test/pre ]]; then
-                    gating/pre_merge_test/pre
-                  fi
-                  """
-                }}
-              }} // stage
-
-              try{{
-                stage('Execute Run Script') {{
-                  sh """#!/bin/bash -xeu
-                  cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
-                  gating/pre_merge_test/run
-                  """
-                }} // stage
-              }} finally {{
-
-                // We implement the post script execution in a finally
-                // block to ensure that it always executes as it is
-                // typically used to collect logs and this needs to
-                // happen whether the run script succeeds or fails.
-
-                stage('Execute Post Script') {{
-                  // We do not want the 'post' execution to fail the test,
-                  // but we do want to know if it fails so we make it only
-                  // return status.
-                  post_result = sh(
-                    returnStatus: true,
-                    script: """#!/bin/bash -xeu
-                               cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
-                               if [[ -e gating/pre_merge_test/post ]]; then
-                                 gating/pre_merge_test/post
-                               fi"""
+          try {{
+            ansiColor('xterm') {{
+              common.withRequestedCredentials(credentials) {{
+                stage('Checkout') {{
+                  print("Triggered by PR: ${{env.ghprbPullLink}}")
+                  common.clone_with_pr_refs(
+                    "${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}",
                   )
-                  if (post_result != 0) {{
-                    print("Pre-Merge Test (post) failed with return code ${{post_result}}")
-                  }} // if
                 }} // stage
 
-              }} // inner try
-            }} // withCredentials
-          }} // ansiColor
-        }} catch (e) {{
-          print(e)
-          currentBuild.result="FAILURE"
-          throw e
-        }} finally {{
-          common.safe_jira_comment("${{currentBuild.result}}: [${{env.BUILD_TAG}}|${{env.BUILD_URL}}]")
-          common.archive_artifacts()
-        }} // try
+                stage('Execute Pre Script') {{
+                  // Retry the 'pre' stage 3 times. The 'pre' stage is considered
+                  // to be preparation for the test, so let's try and make sure
+                  // it has the best chance of success possible.
+                  retry(3) {{
+                    sh """#!/bin/bash -xeu
+                    cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
+                    if [[ -e gating/pre_merge_test/pre ]]; then
+                      gating/pre_merge_test/pre
+                    fi
+                    """
+                  }}
+                }} // stage
+
+                try{{
+                  stage('Execute Run Script') {{
+                    sh """#!/bin/bash -xeu
+                    cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
+                    gating/pre_merge_test/run
+                    """
+                  }} // stage
+                }} finally {{
+
+                  // We implement the post script execution in a finally
+                  // block to ensure that it always executes as it is
+                  // typically used to collect logs and this needs to
+                  // happen whether the run script succeeds or fails.
+
+                  stage('Execute Post Script') {{
+                    // We do not want the 'post' execution to fail the test,
+                    // but we do want to know if it fails so we make it only
+                    // return status.
+                    post_result = sh(
+                      returnStatus: true,
+                      script: """#!/bin/bash -xeu
+                                 cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
+                                 if [[ -e gating/pre_merge_test/post ]]; then
+                                   gating/pre_merge_test/post
+                                 fi"""
+                    )
+                    if (post_result != 0) {{
+                      print("Pre-Merge Test (post) failed with return code ${{post_result}}")
+                    }} // if
+                  }} // stage
+
+                }} // inner try
+              }} // withCredentials
+            }} // ansiColor
+          }} catch (e) {{
+            print(e)
+            currentBuild.result="FAILURE"
+            throw e
+          }} finally {{
+            common.safe_jira_comment("${{currentBuild.result}}: [${{env.BUILD_TAG}}|${{env.BUILD_URL}}]")
+            common.archive_artifacts()
+          }} // try
+        }}
       }}

--- a/rpc_jobs/unit/re_unit_tests.yml
+++ b/rpc_jobs/unit/re_unit_tests.yml
@@ -60,6 +60,19 @@
             ]
           )
         }
+        "Skip Build Check": {
+          build(
+            job: "RE-unit-test-skip-build-check",
+            wait: true,
+            parameters: [
+              [
+                $class: 'StringParameterValue',
+                name: 'RPC_GATING_BRANCH',
+                value: env.RPC_GATING_BRANCH
+              ]
+            ]
+          )
+        }
       ])
 
 #TODO: Jira Issue Manipulation, Validation of Published Artefacts.

--- a/rpc_jobs/unit/skip_build_check.yml
+++ b/rpc_jobs/unit/skip_build_check.yml
@@ -1,0 +1,76 @@
+- job:
+    name: RE-unit-test-skip-build-check
+    project-type: pipeline
+    concurrent: true
+    properties:
+      - build-discarder:
+          num-to-keep: 30
+    parameters:
+      - rpc_gating_params
+    dsl: |
+      library "rpc-gating@${RPC_GATING_BRANCH}"
+      common.shared_slave{
+
+        env.RE_JOB_REPO_NAME = "test_repository"
+
+        stage("Setup repository") {
+          sh """#!/bin/bash -xeu
+            mkdir ${env.RE_JOB_REPO_NAME}
+            cd ${env.RE_JOB_REPO_NAME}
+            git init .
+            mkdir changes_can_be_skipped
+            touch changes_can_be_skipped/skip_me
+            mkdir changes_must_be_tested
+            touch changes_must_be_tested/test_me
+            git add -A
+            git commit -m Setup
+            """
+        }
+
+        skip_pattern = "^changes_can_be_skipped/"
+
+        stage("Ensure true when empty commit") {
+          sh """#!/bin/bash -xeu
+            cd ${env.RE_JOB_REPO_NAME}
+            git commit --allow-empty -m 'No changes; can be skipped'
+          """
+          Boolean skip_build = common.skip_build_check(skip_pattern)
+          assert skip_build
+        }
+
+        stage("Ensure false when some changes match pattern") {
+          sh """#!/bin/bash -xeu
+            cd ${env.RE_JOB_REPO_NAME}
+            echo '# another test edit' > changes_can_be_skipped/skip_me
+            echo '# test edit' > changes_must_be_tested/test_me
+            git add -A
+            git commit -m 'These changes must not be skipped'
+          """
+          Boolean skip_build = common.skip_build_check(skip_pattern)
+          assert ! skip_build
+        }
+
+        stage("Ensure true when all changes match pattern") {
+          sh """#!/bin/bash -xeu
+            cd ${env.RE_JOB_REPO_NAME}
+            echo '# test edit' > changes_can_be_skipped/skip_me
+            touch changes_can_be_skipped/skip_me_as_well
+            git add -A
+            git commit -m 'These changes can be skipped'
+          """
+          Boolean skip_build = common.skip_build_check(skip_pattern)
+          assert skip_build
+        }
+
+        stage("Ensure false when all changes match pattern") {
+          sh """#!/bin/bash -xeu
+            cd ${env.RE_JOB_REPO_NAME}
+            echo '# another test edit' > changes_must_be_tested/test_me
+            touch changes_must_be_tested/test_me_as_well
+            git add -A
+            git commit -m 'These changes must also not be skipped'
+          """
+          Boolean skip_build = common.skip_build_check(skip_pattern)
+          assert ! skip_build
+        }
+      }


### PR DESCRIPTION
This patch introduces the ability in a standard job to define a skip
regex. If all the paths of all the files modified by the pull request
match the regex, the build is ended and marked a success. This allows
builds to be skipped when they aren't impacted by the pull request
changes.

The regex support is provided by Python's re module with the verbose
flag enabled [1], this allow for more readable multi-line regex to be
written without the whitespace impacted the expression. When defining
`skip_pattern` in YAML use `>-` so that the string does not include new
lines.

This change also adds a regex for rpc-openstack pull requests to fix the
functionality lost when those jobs were moved from using rpc_aio.yml to
standard_job_premerge.yml.

This facility can be applied to the project, or to an individual axis.
The skip regex is also entirely optional, by default no build is
skipped.

`common.is_doc_update_pr`, the original implementation of this
functionality has been left untouched. It can be removed once all
old-style jobs using it have been removed.

[1] https://docs.python.org/2/library/re.html#re.VERBOSE

Co-Authored-By: git-harry <git-harry@live.co.uk>

Issue: [RE-787](https://rpc-openstack.atlassian.net/browse/RE-787)