### PR TITLE
RE-35 Snapshot Support

### DIFF
--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -177,10 +177,10 @@ be supplied uppercase in the env dictionary, or lower case as
 direct arguments. */
 def runonpubcloud(Map args=[:], Closure body){
   add_instance_env_params_to_args(args)
-  // randomised inventory_path to avoid parallel conflicts
   if (env.WORKSPACE == null){
     throw new Exception("runonpubcloud must be run from within a node")
   }
+  // randomised inventory_path to avoid parallel conflicts
   args.inventory="inventory.${common.rand_int_str()}"
   args.inventory_path="${WORKSPACE}/rpc-gating/playbooks/${args.inventory}"
   String instance_name = common.gen_instance_name()
@@ -189,6 +189,24 @@ def runonpubcloud(Map args=[:], Closure body){
     getPubCloudSlave(args)
     common.use_node(instance_name){
       body()
+      // Read the image_name file from the single use slave.
+        try {
+          sh """#!/bin/bash -xeu
+            cp /gating/thaw/image_name $WORKSPACE/image_name
+          """
+          args.image = readFile("${WORKSPACE}/image_name").trim()
+          print ("Read image name from /gating/thaw/image_name: ${args.image}.")
+          print ("Snapshot Enabled")
+        } catch (e){
+          args.image = null
+          print ("/gating/thaw/image_name not found, not taking snapshot")
+        }
+    } // single use slave
+    // When the above use_node block ends, the workspace on the slave is wiped.
+    // This means that any repos in the workspace will not be in the snapshot.
+    // Execute the save from outside the instance.
+    if(args.image != null){
+      savePubCloudSlave(args)
     }
   }catch (e){
     print(e)

--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -40,38 +40,33 @@ def cleanup(Map args){
  *
  */
 def savePubCloudSlave(Map args){
-  common.conditionalStep(
-    step_name: 'Save Slave',
-    step: {
-      add_instance_env_params_to_args(args)
-      if (!("inventory" in args)){
-        args.inventory = "inventory"
-      }
-      withCredentials(common.get_cloud_creds()){
+  add_instance_env_params_to_args(args)
+  if (!("inventory" in args)){
+    args.inventory = "inventory"
+  }
+  withCredentials(common.get_cloud_creds()){
 
-        dir("rpc-gating/playbooks"){
-          clouds_cfg = common.writeCloudsCfg(
-            username: env.PUBCLOUD_USERNAME,
-            api_key: env.PUBCLOUD_API_KEY
-          )
-          env.OS_CLIENT_CONFIG_FILE = clouds_cfg
-          env.SAVE_IMAGE_NAME = args.image
-          common.venvPlaybook(
-            playbooks: ['save_pubcloud.yml'],
-            args: [
-              "-i ${args.inventory}",
-              "--private-key=\"${env.JENKINS_SSH_PRIVKEY}\"",
-            ],
-            vars: args
-          )
-          stash (
-            name: args.inventory,
-            includes: "${args.inventory}/hosts"
-          )
-        } // dir
-      } //withCredentials
-    } //step
-  ) //conditionalStep
+    dir("rpc-gating/playbooks"){
+      clouds_cfg = common.writeCloudsCfg(
+        username: env.PUBCLOUD_USERNAME,
+        api_key: env.PUBCLOUD_API_KEY
+      )
+      env.OS_CLIENT_CONFIG_FILE = clouds_cfg
+      env.SAVE_IMAGE_NAME = args.image
+      common.venvPlaybook(
+        playbooks: ['save_pubcloud.yml'],
+        args: [
+          "-i ${args.inventory}",
+          "--private-key=\"${env.JENKINS_SSH_PRIVKEY}\"",
+        ],
+        vars: args
+      )
+      stash (
+        name: args.inventory,
+        includes: "${args.inventory}/hosts"
+      )
+    } // dir
+  } //withCredentials
 } //save
 
 

--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -63,6 +63,11 @@
       set_fact:
         instance: "{{ (result |json_query('results[?changed]'))[0] }}"
 
+    - name: Add Host
+      add_host:
+        hostname: "singleuseslave"
+        ansible_ssh_host: "{{instance.server.accessIPv4}}"
+
     - name: Create inventory directory
       file:
         path: "{{ inventory_path }}"
@@ -90,3 +95,18 @@
     - name: Wait for startup tasks to finish
       pause:
         minutes: 5
+
+- hosts: singleuseslave
+  tasks:
+    - name: Check for thaw hook
+      stat:
+        path: /gating/thaw/run
+      register: thaw
+
+    - name: Execute thaw hook
+      shell: |
+        set -xeu
+        /gating/thaw/run
+      args:
+        executable: /bin/bash
+      when: thaw.stat.exists|bool

--- a/playbooks/save_pubcloud.yml
+++ b/playbooks/save_pubcloud.yml
@@ -1,9 +1,7 @@
 ---
-- hosts: localhost
-  connection: local
+- hosts: job_nodes
   gather_facts: no
   vars:
-    region: "{{ rax_region }}"
     script_path: "{{ lookup('env', 'WORKSPACE') }}/rpc-gating/scripts"
     os_client_config_file: "{{ lookup('env', 'OS_CLIENT_CONFIG_FILE') }}"
     image_name: "{{ lookup('env', 'SAVE_IMAGE_NAME') }}"
@@ -15,23 +13,28 @@
        msg: "The SAVE_IMAGE_NAME environment variable must be set."
       when: image_name == ""
 
+    - debug:
+        msg: "Creating image:{{ image_name }} in region:{{ rax_region }} from instance: {{ instance_name }}"
+
     - name: Get instance info
       os_server_facts:
         server: "{{ instance_name }}"
-        region_name: "{{ region }}"
+        region_name: "{{ rax_region }}"
         cloud: "{{ cloud_name }}"
+      delegate_to: localhost
 
     - name: Confirm one instance matching name
       fail:
         msg: "The number of servers matching the instance name is not 1."
       when: openstack_servers | length != 1
+      delegate_to: localhost
 
     - set_fact:
         instance: "{{ openstack_servers[0] }}"
+      delegate_to: localhost
 
     - name: Execute public cloud instance cleanup script
       script: "{{ lookup('env', 'WORKSPACE') }}/rpc-gating/scripts/rax_instance_clean.sh"
-      delegate_to: "{{ instance.accessIPv4 }}"
 
     # This task is executed asynchronously so that
     # Ansible does not wait for completion before
@@ -42,14 +45,14 @@
       async: 1
       poll: 0
       ignore_errors: true
-      delegate_to: "{{ instance.accessIPv4 }}"
 
     # In order to ensure the integrity of the instance image
-    # we wait 30 seconds to give it a chance to complete shut
+    # we wait 60 seconds to give it a chance to complete shut
     # down before executing the save.
     - name: Pause for a minute to allow the instance to shut down
       pause:
         minutes: 1
+      delegate_to: localhost
 
     - name: Save public cloud instance
       command: >-
@@ -59,3 +62,4 @@
                                                 --cloudname {{ cloud_name }}
       environment:
         OS_CLIENT_CONFIG_FILE: "{{ os_client_config_file }}"
+      delegate_to: localhost

--- a/rpc_jobs/cloud_image_build.yml
+++ b/rpc_jobs/cloud_image_build.yml
@@ -15,7 +15,7 @@
       // to ensure that the job is always executed the same
       // way.
       env.FLAVOR = "performance1-1"
-      env.STAGES = "Allocate Resources, Save Slave, Cleanup"
+      env.STAGES = "Allocate Resources, Cleanup"
       image_list = [
         [ src: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)",
           dest: "Ubuntu 16.04 LTS prepared for RPC deployment" ],

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -109,9 +109,12 @@
       - "swift"
     action:
       - deploy:
-          FLAVOR: "performance2-15"
+          FLAVOR: "7"
+    # This is the build that will be triggered by the push trigger job
+    trigger_build: 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+      - 'PM-push-trigger_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
 - project:
     name: "rpc-openstack-newton-postmerge"
@@ -128,9 +131,12 @@
       - "swift"
     action:
       - deploy:
-          FLAVOR: "performance2-15"
+          FLAVOR: "7"
+    # This is the build that will be triggered by the push trigger job
+    trigger_build: 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+      - 'PM-push-trigger_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
 - project:
     name: "rpc-openstack-mitaka-postmerge"
@@ -146,9 +152,12 @@
       - "swift"
     action:
       - deploy:
-          FLAVOR: "performance2-15"
+          FLAVOR: "7"
+    # This is the build that will be triggered by the push trigger job
+    trigger_build: 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+      - 'PM-push-trigger_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
 - project:
     name: "rpc-openstack-liberty-postmerge"
@@ -164,9 +173,12 @@
       - "swift"
     action:
       - deploy:
-          FLAVOR: "performance2-15"
+          FLAVOR: "7"
+    # This is the build that will be triggered by the push trigger job
+    trigger_build: 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+      - 'PM-push-trigger_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
 - project:
     name: "rpc-openstack-kilo-postmerge"
@@ -182,6 +194,9 @@
       - "swift"
     action:
       - deploy:
-          FLAVOR: "performance2-15"
+          FLAVOR: "7"
+    # This is the build that will be triggered by the push trigger job
+    trigger_build: 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+      - 'PM-push-trigger_{repo_name}-{branch}-{image}-{scenario}-{action}'

--- a/rpc_jobs/snapshot.yml
+++ b/rpc_jobs/snapshot.yml
@@ -1,0 +1,103 @@
+- job:
+    name: RE35-Snapshot-Test
+    project-type: workflow
+    concurrent: true
+    properties:
+      - build-discarder:
+          num-to-keep: 30
+    parameters:
+      # Default params are provided by macro, add any extra params, or
+      # params you want to override the defaults for.
+      - bool:
+          name: CREATE_RPCO_SNAPSHOT
+          default: true
+          description: |
+            Run RPCO Build and save as snapshot. Note that the name of
+            the image that is created depends on the version of RPCO being
+            built. The build used is
+            PM_rpc-openstack-newton-xenial-swift-deploy
+            The image will be rpc_${rpc_release}_xenial.
+            rpc_release can be found in:
+            rpc-openstack/rpc-openstack/etc/openstack_deploy/group_vars/all/release.yml
+
+      - bool:
+          name: BUILD_FROM_SNAPSHOT
+          description: |
+            Build instance from RPCO snapshot and run tempest.
+            Note that the IMAGE parameter should contain the
+            name of the snapshot to build from. The IMAGE
+            paramter is not passed through to the RPC AIO job,
+            which will use its own default image.
+          default: true
+      - instance_params:
+          IMAGE: "CHANGEME:rpc_rx.y.x_distro"
+          FLAVOR: "general1-8"
+          REGIONS: "DFW"
+          FALLBACK_REGIONS: ""
+      - string:
+          name: RPC_GATING_BRANCH
+          default: "RE-35"
+          description: Version of rpc-gating to use.
+    dsl: |
+      library "rpc-gating@${RPC_GATING_BRANCH}"
+      env.STAGES="Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
+      stage('Build Image'){
+        if(env.CREATE_RPCO_SNAPSHOT == 'true'){
+          // kick off rpco job
+          retry(5){
+            build(
+              job: "PM_rpc-openstack-newton-xenial-swift-deploy",
+              wait: true,
+              parameters: [
+                [
+                  $class: 'StringParameterValue',
+                  name: 'FLAVOR',
+                  value: "general1-8"
+                ],
+                [
+                  $class: 'StringParameterValue',
+                  name: 'REGIONS',
+                  value: "DFW"
+                ],
+                [
+                  $class: 'StringParameterValue',
+                  name: 'FALLBACK_REGIONS',
+                  value: ""
+                ],
+                [
+                  $class: 'StringParameterValue',
+                  name: 'RPC_GATING_BRANCH',
+                  value: "RE-35"
+                ],
+                [
+                  $class: 'StringParameterValue',
+                  name: 'BRANCH',
+                  value: "RE-35"
+                ],
+                [
+                  $class: 'BooleanParameterValue',
+                  name: 'SNAPSHOT',
+                  value: true
+                ]
+              ]
+            )
+          } // retry
+        } // if
+      } // stage
+      if (env.BUILD_FROM_SNAPSHOT == 'true'){
+        common.shared_slave(){
+          pubcloud.runonpubcloud(){
+            stage('Run Tempest on Instance created from Image'){
+              sh """#!/bin/bash -xeu
+                # Not using the rpco tempest run playbook as we don't
+                # need to run the whole defcore test set as a post thaw
+                # verify
+                ansible 'utility_all[0]' \
+                  -i /opt/openstack-ansible/playbooks/inventory/ \
+                  -m shell \
+                  -a 'cd /openstack/venvs/*/workspace; . /openstack/venvs/*/bin/activate; tempest run --regex tempest.scenario.test_minimum_basic'
+              """
+            } // stage
+          } // Run on pub cloud
+        } // shared slave
+      } // if

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -78,9 +78,12 @@
       env.RE_JOB_SCENARIO = "{scenario}"
       env.RE_JOB_ACTION = "{action}"
       env.RE_JOB_FLAVOR = "{FLAVOR}"
-      env.RE_JOB_TRIGGER = "PM"
       env.RE_JOB_REPO_NAME = "{repo_name}"
       env.RE_JOB_BRANCH = "{branch}"
+
+      // set env.RE_JOB_TRIGGER & env.RE_JOB_TRIGGER_DETAIL
+      common.setTriggerVars()
+
 
       String credentials = "{credentials}"
 

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -77,8 +77,10 @@
       env.RE_JOB_SCENARIO = "{scenario}"
       env.RE_JOB_ACTION = "{action}"
       env.RE_JOB_FLAVOR = "{FLAVOR}"
-      env.RE_JOB_TRIGGER = "PR"
       env.RE_JOB_REPO_NAME = "{repo_name}"
+
+      // set env.RE_JOB_TRIGGER & env.RE_JOB_TRIGGER_DETAIL
+      common.setTriggerVars()
 
       String credentials = "{credentials}"
 

--- a/scripts/jenkins_node.py
+++ b/scripts/jenkins_node.py
@@ -45,6 +45,7 @@ def create_node(jenkins, host_ip, name, credential_description, executors,
 
 
 def delete_node(jenkins, name):
+    print("Removing Slave from Jenkins: {}".format(name))
     jenkins.delete_node(nodename=name)
 
 

--- a/scripts/lint_support_groovy/cause.groovy
+++ b/scripts/lint_support_groovy/cause.groovy
@@ -1,0 +1,5 @@
+//Dummy cause class for lint jobs
+
+public class Cause {
+  
+}

--- a/scripts/lint_support_groovy/causes.groovy
+++ b/scripts/lint_support_groovy/causes.groovy
@@ -1,0 +1,9 @@
+//Dummy cause class for lint jobs
+package Cause
+
+public class UpstreamCause {
+
+}
+public class UserIdCause {
+
+}

--- a/scripts/lint_support_groovy/ghrpbcause.groovy
+++ b/scripts/lint_support_groovy/ghrpbcause.groovy
@@ -1,0 +1,6 @@
+//Dummy cause class for lint jobs
+package org.jenkinsci.plugins.ghprb
+
+public class GhprbCause {
+
+}

--- a/scripts/lint_support_groovy/pushcause.groovy
+++ b/scripts/lint_support_groovy/pushcause.groovy
@@ -1,0 +1,6 @@
+//Dummy cause class for lint jobs
+package com.cloudbees.jenkins
+
+public class GitHubPushCause {
+
+}

--- a/scripts/lint_support_groovy/timercause.groovy
+++ b/scripts/lint_support_groovy/timercause.groovy
@@ -1,0 +1,6 @@
+//Dummy cause class for lint jobs
+package hudson.triggers.TimerTrigger
+
+public class TimerTriggerCause {
+
+}


### PR DESCRIPTION
Please see individual commit messages, but the aims of this PR are to provide the RE infrastructure for teams to have snapshots created of their builds.

Hooks (see [RE For Projects](https://rpc-openstack.atlassian.net/wiki/spaces/RE/pages/19005457/RE+for+Projects) for more details):
* /gating/thaw/image_name: If this exists on the instance at the end of a job, (and the job uses pubcloud.runonpubcloud) then a snapshot will be created
* /gathing/thaw/run: If this exists when an instance is allocated, it will be executed. This can be used for things that need fixing when hostname/ip/etc have changed.

This PR also changes the RE_JOB_TRIGGER variable to have more granularity, the one usage of this in rpc-octavia is addressed in a PR to that repo. 

Issue: [RE-35](https://rpc-openstack.atlassian.net/browse/RE-35)

Related PRs:
* RPC-Octavia: https://github.com/rcbops/rpc-octavia/pull/21
* RPC-Openstack: https://github.com/rcbops/rpc-openstack/pull/2668