### PR TITLE
RE-1177 Allow library loading from PR merge refs

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -484,7 +484,7 @@ void clone_with_pr_refs(
       # use init + fetch to avoid the "dir not empty git fail"
       git init .
       # If the git repo previously existed, we remove the origin
-      git remote remove origin || true
+      git remote rm origin || true
       git remote add origin "${repo}"
       # Don't quote refspec as it should be separate args to git.
       git fetch --tags origin ${refspec}
@@ -653,14 +653,14 @@ void use_node(String label=null, body){
     try {
       print "Preparing ${env.NODE_NAME} for use"
       deleteDir()
-      dir("rpc-gating"){
-        if (! env.RPC_GATING_BRANCH){
-          env.RPC_GATING_BRANCH="master"
-        }
-        git branch: env.RPC_GATING_BRANCH, url: "https://github.com/rcbops/rpc-gating"
+      if (! env.RPC_GATING_BRANCH){
+        env.RPC_GATING_BRANCH="master"
       }
-      install_ansible()
       configure_git()
+      clone_with_pr_refs('rpc-gating',
+                         'git@github.com:rcbops/rpc-gating',
+                         env.RPC_GATING_BRANCH)
+      install_ansible()
       print "${env.NODE_NAME} preparation complete, now ready for use."
       body()
     } catch (e){

--- a/rpc_jobs/build_gating_venv.yml
+++ b/rpc_jobs/build_gating_venv.yml
@@ -17,8 +17,10 @@
         node('pubcloud_multiuse'){
           try{
             deleteDir()
+            common.clone_with_pr_refs('rpc-gating',
+                                      'git@github.com:rcbops/rpc-gating',
+                                      env.RPC_GATING_BRANCH)
             dir('rpc-gating'){
-              git branch: env.RPC_GATING_BRANCH, url: "https://github.com/rcbops/rpc-gating"
               // run in docker to ensure all the required apt packages are available
               container = docker.build env.BUILD_TAG.toLowerCase()
             }

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -67,6 +67,9 @@
           cancel-builds-on-update: true
 
     dsl: |
+      if ("{repo_name}" == "rpc-gating"){{
+        env.RPC_GATING_BRANCH = "origin/pr/${{env.ghprbPullId}}/merge"
+      }}
       library "rpc-gating@${{RPC_GATING_BRANCH}}"
 
       // Pass details about the job parameters through


### PR DESCRIPTION
This will lift the requirement that all rpc-gating PRs are from
rpc-gating, it will also ensure that we test merged heads, not the
head of the PR.

Issue: [RE-1177](https://rpc-openstack.atlassian.net/browse/RE-1177)