### PR TITLE
RE-1151 Add playbook / jobs to deploy repo servers

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -102,7 +102,7 @@ check_naming_standards() {
 }
 
 check_python(){
-  flake8 --exclude=.lintvenv,webhooktranslator . \
+  flake8 --exclude=.lintvenv,webhooktranslator,playbooks/roles . \
     && echo "Python syntax ok" \
     || { echo "Python syntax fail"; rc=1; }
 }

--- a/playbooks/repo_server.yml
+++ b/playbooks/repo_server.yml
@@ -1,0 +1,54 @@
+---
+- hosts: repo_all
+  user: root
+  gather_facts: no
+  tasks:
+    - name: Gather facts
+      setup:
+        gather_subset: "!facter,!ohai"
+
+    - set_fact:
+        repo_server_volumes: "{{ item['volumes'] }}"
+      when: "{{ item['name'] == inventory_hostname }}"
+      with_items: "{{ instance_list | default([]) }}"
+
+    - name: Create vg0 volume group
+      lvg:
+        vg: vg0
+        pvs: "{{ repo_server_volumes | map(attribute='device') | join(',') }}"
+        state: present
+
+    - name: Create repo logical volume
+      lvol:
+        lv: repo
+        vg: vg0
+        size: 100%PVS
+        shrink: no
+        state: present
+
+    - name: Create filesystem on /dev/vg0/repo
+      filesystem:
+        fstype: ext4
+        force: no
+        dev: /dev/vg0/repo
+        resizefs: yes # suicide?
+
+    - name: Mount /dev/vg0/repo
+      mount:
+        path: /var/www/repo
+        src: /dev/vg0/repo
+        fstype: ext4
+        state: mounted
+
+- hosts: repo_all
+  user: root
+  gather_facts: no
+  vars:
+    is_metal: true
+    openstack_release: testing
+  pre_tasks:
+    - name: Gather facts
+      setup:
+        gather_subset: "!facter,!ohai"
+  roles:
+    - role: "repo_server"

--- a/playbooks/repo_server.yml
+++ b/playbooks/repo_server.yml
@@ -7,9 +7,10 @@
       setup:
         gather_subset: "!facter,!ohai"
 
-    - set_fact:
+    - name: "Create fact for instance's volumes"
+      set_fact:
         repo_server_volumes: "{{ item['volumes'] }}"
-      when: "{{ item['name'] == inventory_hostname }}"
+      when: "item['name'] == inventory_hostname"
       with_items: "{{ instance_list | default([]) }}"
 
     - name: Create vg0 volume group

--- a/playbooks/setup_openstack_instances.yml
+++ b/playbooks/setup_openstack_instances.yml
@@ -8,6 +8,22 @@
 #     region: DFW
 #     metadata:
 #       group: mygroup
+#
+# Additionally, you can optionally specify volumes
+# to be created and attached:
+#
+# instance_list:
+#   - name: instance1
+#     flavor: general1-1
+#     region: DFW
+#     volumes:
+#       - name: vol1
+#         device: /dev/xvde
+#         type: SATA
+#         size: 1024
+#     metadata:
+#       group: mygroup
+#
 
 - name: Create/delete OpenStack Instances
   hosts: localhost
@@ -23,7 +39,7 @@
       # deployment tooling.
       build_config: core
   tasks:
-    - name: Unlock instances scheduled to be changed
+    - name: Unlock instances scheduled to be deleted or where volumes may need to be added
       os_server_actions:
         action: unlock
         server: "{{ instance['name'] | lower }}"
@@ -31,8 +47,7 @@
         region_name: "{{ instance['region'] | default('IAD') }}"
         wait: yes
         timeout: 900
-      when:
-        - "instance['name'] in groups['all']"
+      when: "{{ instance['name'] in groups['all'] and (instance['state'] | default('present') == 'absent' or (instance['state'] | default('present') == 'present' and 'volumes' in instance)) }}"
       with_items: "{{ instance_list | default([]) }}"
       loop_control:
         loop_var: instance
@@ -58,7 +73,46 @@
       loop_control:
         loop_var: instance
 
-    - name: Lock instances to prevent changes
+    # NOTE(mattt): Currently we do not support detaching/deleting volumes, this
+    #              functionality will need to come at a later time.
+    - name: Create data volumes
+      os_volume:
+        display_name: "{{ item[1]['name'] }}"
+        volume_type: "{{ item[1]['type'] }}"
+        size: "{{ item[1]['size'] }}"
+        state: present
+        cloud: "{{ cloud_name | default('public_cloud') }}"
+        region_name: "{{ item[0]['region'] }}"
+        wait: yes
+        timeout: 900
+      when:
+        - "'state' not in item[0] or item[0]['state'] != 'absent'"
+      with_subelements:
+        - "{{ instance_list | default([]) }}"
+        - volumes
+        - skip_missing: True
+
+    - name: Attach the data volumes
+      os_server_volume:
+        server: "{{ item[0]['name'] }}"
+        volume: "{{ item[1]['name'] }}"
+        device: "{{ item[1]['device'] }}"
+        state: present
+        cloud: "{{ cloud_name | default('public_cloud') }}"
+        region_name: "{{ item[0]['region'] }}"
+        wait: yes
+        timeout: 900
+      when:
+        - "'state' not in item[0] or item[0]['state'] != 'absent'"
+      with_subelements:
+        - "{{ instance_list | default([]) }}"
+        - volumes
+        - skip_missing: True
+
+    - name: Refresh dynamic inventory for any changes made
+      meta: refresh_inventory
+
+    - name: Lock instances to prevent accidental deletion
       os_server_actions:
         action: lock
         server: "{{ instance['name'] | lower }}"
@@ -66,8 +120,7 @@
         region_name: "{{ instance['region'] | default('IAD') }}"
         wait: yes
         timeout: 900
-      when:
-        - "instance['state'] | default('present') != 'absent'"
+      when: "{{ instance['name'] in groups['all'] }}"
       with_items: "{{ instance_list | default([]) }}"
       loop_control:
         loop_var: instance

--- a/playbooks/setup_openstack_instances.yml
+++ b/playbooks/setup_openstack_instances.yml
@@ -6,6 +6,7 @@
 #   - name: instance1
 #     flavor: general1-1
 #     region: DFW
+#     state: present
 #     metadata:
 #       group: mygroup
 #
@@ -16,11 +17,13 @@
 #   - name: instance1
 #     flavor: general1-1
 #     region: DFW
+#     state: present
 #     volumes:
 #       - name: vol1
 #         device: /dev/xvde
 #         type: SATA
 #         size: 1024
+#         state: present
 #     metadata:
 #       group: mygroup
 #

--- a/playbooks/setup_openstack_instances.yml
+++ b/playbooks/setup_openstack_instances.yml
@@ -50,7 +50,9 @@
         region_name: "{{ instance['region'] | default('IAD') }}"
         wait: yes
         timeout: 900
-      when: "{{ instance['name'] in groups['all'] and (instance['state'] | default('present') == 'absent' or (instance['state'] | default('present') == 'present' and 'volumes' in instance)) }}"
+      when:
+        - "instance['name'] in groups['all']"
+        - "{{ (instance['state'] | default('present') == 'absent' or (instance['state'] | default('present') == 'present' and 'volumes' in instance)) }}"
       with_items: "{{ instance_list | default([]) }}"
       loop_control:
         loop_var: instance
@@ -104,7 +106,8 @@
         wait: yes
         timeout: 900
       when:
-        - "{{ item[0]['state'] | default('present') == 'absent' and item[1]['state'] | default('present') == 'absent' }}"
+        - "{{ item[0]['state'] | default('present') == 'absent' }}"
+        - "{{ item[1]['state'] | default('present') == 'absent' }}"
       with_subelements:
         - "{{ instance_list | default([]) }}"
         - volumes

--- a/playbooks/setup_openstack_instances.yml
+++ b/playbooks/setup_openstack_instances.yml
@@ -73,8 +73,6 @@
       loop_control:
         loop_var: instance
 
-    # NOTE(mattt): Currently we do not support detaching/deleting volumes, this
-    #              functionality will need to come at a later time.
     - name: Create data volumes
       os_volume:
         display_name: "{{ item[1]['name'] }}"
@@ -86,12 +84,34 @@
         wait: yes
         timeout: 900
       when:
-        - "'state' not in item[0] or item[0]['state'] != 'absent'"
+        - "{{ item[0]['state'] | default('present') != 'absent' }}"
       with_subelements:
         - "{{ instance_list | default([]) }}"
         - volumes
         - skip_missing: True
 
+    - name: Delete data volumes on deleted instances
+      os_volume:
+        display_name: "{{ item[1]['name'] }}"
+        volume_type: "{{ item[1]['type'] }}"
+        size: "{{ item[1]['size'] }}"
+        state: absent
+        cloud: "{{ cloud_name | default('public_cloud') }}"
+        region_name: "{{ item[0]['region'] }}"
+        wait: yes
+        timeout: 900
+      when:
+        - "{{ item[0]['state'] | default('present') == 'absent' and item[1]['state'] | default('present') == 'absent' }}"
+      with_subelements:
+        - "{{ instance_list | default([]) }}"
+        - volumes
+        - skip_missing: True
+
+    # NOTE(mattt):
+    # At present we do not support detaching / deleting volumes attached to a
+    # running instance. We'd need to do some poking around inside the instance
+    # to check if the disk is in use before we know it's safe to detach /
+    # delete, and this will require a bunch more testing.
     - name: Attach the data volumes
       os_server_volume:
         server: "{{ item[0]['name'] }}"
@@ -103,7 +123,7 @@
         wait: yes
         timeout: 900
       when:
-        - "'state' not in item[0] or item[0]['state'] != 'absent'"
+        - "{{ item[0]['state'] | default('present') != 'absent' and item[1]['state'] | default('present') != 'absent' }}"
       with_subelements:
         - "{{ instance_list | default([]) }}"
         - volumes

--- a/repo_server/instances.yml
+++ b/repo_server/instances.yml
@@ -1,0 +1,32 @@
+---
+instance_list:
+  - name: repo-server-dfw-1
+    flavor: general1-8
+    region: DFW
+    volumes:
+      - name: repo-server-dfw-1-xvde
+        device: /dev/xvde
+        type: SATA
+        size: 1024
+    metadata:
+      group: "repo_all"
+  - name: repo-server-iad-1
+    flavor: general1-8
+    region: IAD
+    volumes:
+      - name: repo-server-iad-1-xvde
+        device: /dev/xvde
+        type: SATA
+        size: 1024
+    metadata:
+      group: "repo_all"
+  - name: repo-server-ord-1
+    flavor: general1-8
+    region: ORD
+    volumes:
+      - name: repo-server-ord-1-xvde
+        device: /dev/xvde
+        type: SATA
+        size: 1024
+    metadata:
+      group: "repo_all"

--- a/repo_server/instances.yml
+++ b/repo_server/instances.yml
@@ -3,30 +3,36 @@ instance_list:
   - name: repo-server-dfw-1
     flavor: general1-8
     region: DFW
+    state: present
     volumes:
       - name: repo-server-dfw-1-xvde
         device: /dev/xvde
         type: SATA
         size: 1024
+        state: present
     metadata:
       group: "repo_all"
   - name: repo-server-iad-1
     flavor: general1-8
     region: IAD
+    state: present
     volumes:
       - name: repo-server-iad-1-xvde
         device: /dev/xvde
         type: SATA
         size: 1024
+        state: present
     metadata:
       group: "repo_all"
   - name: repo-server-ord-1
     flavor: general1-8
     region: ORD
+    state: present
     volumes:
       - name: repo-server-ord-1-xvde
         device: /dev/xvde
         type: SATA
         size: 1024
+        state: present
     metadata:
       group: "repo_all"

--- a/repo_server/role_requirements.yml
+++ b/repo_server/role_requirements.yml
@@ -1,0 +1,8 @@
+- name: apt_package_pinning
+  scm: git
+  src: https://git.openstack.org/openstack/openstack-ansible-apt_package_pinning
+  version: e5034411a1e4502e633a000cd1bfe02566bf8712
+- name: repo_server
+  scm: git
+  src: https://git.openstack.org/openstack/openstack-ansible-repo_server
+  version: f4731abfb090b7e730bd728a3f7751c791ae9f86

--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -9,7 +9,7 @@
             Hours. Instances older than this will be removed.
       - string:
           name: "PROTECTED_PREFIX"
-          default: "long-running-slave|influx-|WEBHOOK-PROXY|nodepool"
+          default: "long-running-slave|influx-|WEBHOOK-PROXY|nodepool|repo-server-"
           description: |
             Instances that match this prefix regex will not be cleaned up.
       - string:

--- a/rpc_jobs/repo_server.yml
+++ b/rpc_jobs/repo_server.yml
@@ -1,0 +1,104 @@
+- job:
+    name: Setup-Repo-Servers
+    project-type: pipeline
+    concurrent: false
+    properties:
+      - build-discarder:
+          num-to-keep: 30
+    parameters:
+      - rpc_gating_params
+    triggers:
+      - timed: "@daily"
+    dsl: |
+      library "rpc-gating@${RPC_GATING_BRANCH}"
+      common.shared_slave(){
+        try{
+          common.withRequestedCredentials("cloud_creds, id_rsa_cloud10_jenkins_file"){
+            stage("Prepare Ansible Roles"){
+              // Getting the roles is a bit flaky sometimes, so we
+              // implement a retry to improve the chances of success.
+              retry(3){
+                common.venvGalaxy(
+                  "install",
+                  "-r ${env.WORKSPACE}/rpc-gating/repo_server/role_requirements.yml",
+                  "-p ${env.WORKSPACE}/roles"
+                )
+              }
+            } // stage
+
+            stage("Prepare Environment"){
+              // write the clouds.yaml file
+              env.OS_CLIENT_CONFIG_FILE = common.writeCloudsCfg(
+                username: env.PUBCLOUD_USERNAME,
+                api_key: env.PUBCLOUD_API_KEY
+              )
+
+              // Tell ansible where to find roles
+              env.ANSIBLE_ROLES_PATH = "${env.WORKSPACE}/roles"
+
+              // Tell ansible where the dynamic inventory is
+              env.ANSIBLE_INVENTORY = "${env.WORKSPACE}/rpc-gating/scripts/ansible_v2_3_2_0_1_contrib_inventory_openstack.py"
+
+              // Tell ansible where the ssh private key is
+              env.ANSIBLE_PRIVATE_KEY_FILE = "${env.JENKINS_SSH_PRIVKEY}"
+
+            } // stage
+
+            stage("Prepare Instances"){
+              dir('rpc-gating/playbooks'){
+
+                // Run the setup playbook
+                common.venvPlaybook(
+                  playbooks: [
+                    "setup_openstack_instances.yml"
+                  ],
+                  args: [
+                    "-v",
+                    "-e '@${env.WORKSPACE}/rpc-gating/repo_server/instances.yml'"
+                  ]
+                ) //venvPlaybook
+
+                // We need an inventory refresh, so we execute
+                // this using a fresh shell instead of including
+                // the playbooks in the previous ansible-playbook
+                // play list.
+
+                // Run the instance prep plays
+                common.venvPlaybook(
+                  playbooks: [
+                    "drop_ssh_auth_keys.yml",
+                    "slave_security.yml"
+                  ],
+                  args: [
+                    "-v",
+                    "-e target_hosts=repo_all"
+                  ]
+                ) //venvPlaybook
+
+              } //dir
+            } // stage
+
+            stage("Setup Repo Servers"){
+              dir('rpc-gating/playbooks'){
+
+                // Run the setup playbook
+                common.venvPlaybook(
+                  playbooks: [
+                    "repo_server.yml"
+                  ],
+                  args: [
+                    "-v",
+                    "-e '@${env.WORKSPACE}/rpc-gating/repo_server/instances.yml'"
+                  ]
+                ) //venvPlaybook
+
+              } //dir
+            } // stage
+          } //withCredentials
+        } catch (e) {
+          print(e)
+          throw(e)
+        } finally {
+          common.archive_artifacts()
+        }
+      } // cit node


### PR DESCRIPTION
This commit leverages the work done in [1] to continuously deploy
repo servers for artifact storage.

In order to do this, setup_openstack_instances.yml had to be
modified to provision block storage, which is required for storage of
artifacts.  This primarily involves:

- adjusting the initial unlock to only happen when the instance is
  marked for deletion (state=absent), or when there are volumes defined
  in instance_list
- adding the necessary tasks to deploy and attach the specified volumes
- adding an inventory refresh to provide an updated inventory for when
  we need to query inventory to determine if an instance needs to be
  locked
- finally, we check if the instance is in the inventory to determine if
  it needs to be locked

To keep things simple for the first iteration, this PR does
not handle detaching / deleting volumes on a running instance as a fair
bit of work would need to take place to ensure the disks are not in
use.  That said, volumes with a state of `absent` on an instance with
state `absent` will result in those volumes being deleted after the
instance is removed.

NOTE: To address a failing lint job, we've had to skip playbooks/roles
      in check_python() in lint.sh.  We have external ansible roles
      being pulled in here and shouldn't run a python lint against this
      dir.

TODO:
  - lock down any necessary ports w/ ufw
  - look at combining setup_openstack_instances.yml,
    drop_ssh_auth_keys.yml, and slave_security.yml into the same
    venvPlaybook execution in both rpc_jobs/setup_nodepool.yml and
    rpc_jobs/repo_server.yml (this will avoid an extra inventory
    lookup since the inventory is refreshed at the end of
    playbooks/setup_openstack_instances.yml)

[1] https://github.com/rcbops/rpc-gating/pull/542/

Issue: [RE-1151](https://rpc-openstack.atlassian.net/browse/RE-1151)