### PR TITLE
RO-3147 Fix ansible warnings

### DIFF
--- a/playbooks/setup_jenkins_slave.yml
+++ b/playbooks/setup_jenkins_slave.yml
@@ -76,7 +76,7 @@
         state: present
         regexp: 'jenkins'
         line: 'jenkins ALL=(ALL) NOPASSWD: ALL'
-      when: "{{ allow_jenkins_sudo }}"
+      when: allow_jenkins_sudo | bool
 
     - name: Copy constraints file over to cloud server
       copy:

--- a/playbooks/upload_to_swift.yml
+++ b/playbooks/upload_to_swift.yml
@@ -7,6 +7,7 @@
       command: "tar -cjf {{ archive_name }} {{ artifacts_dir }}"
       args:
         chdir: "{{ artifacts_parent_dir }}"
+        warn: no
       tags:
         - skip_ansible_lint
 


### PR DESCRIPTION
This patches fixes a warning from the command module when
using `tar`.

    [WARNING]: Consider using unarchive module rather than running tar

Issue: [RO-3147](https://rpc-openstack.atlassian.net/browse/RO-3147)