### PR TITLE
RE-1163 Add rpc-openstack newton tox jobs

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -62,6 +62,27 @@
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
 - project:
+    name: "rpc-openstack-newton-tox-premerge"
+    repo_name: "rpc-openstack"
+    repo_url: "https://github.com/rcbops/rpc-openstack"
+    series: "newton"
+    branches:
+      - "newton.*"
+    image:
+      - container:
+          SLAVE_TYPE: "container"
+    scenario:
+      - "ansible-lint"
+      - "bashate"
+      - "flake8"
+      - "release-script"
+      - "releasenotes"
+    action:
+      - "tox-test"
+    jobs:
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
+
+- project:
     name: "rpc-openstack-mitaka-premerge"
     repo_name: "rpc-openstack"
     repo_url: "https://github.com/rcbops/rpc-openstack"


### PR DESCRIPTION
This project defines additional jobs to replace functionality being
provided by Travis CI in rpc-openstack.

Issue: [RE-1163](https://rpc-openstack.atlassian.net/browse/RE-1163)