### PR TITLE
RO-3158 Add ironic scenario for RPC-O master/pike

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -148,6 +148,7 @@
       - xenial:
           IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
     scenario:
+      - "ironic"
       - "swift"
     action:
       - deploy:
@@ -167,6 +168,7 @@
       - trusty:
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
     scenario:
+      - "ironic"
       - "swift"
     action:
       - deploy:


### PR DESCRIPTION
The ironic test appears to be missing - it's tested
in the PR but not in the PM. This adds the missing
scenario.

Issue: [RO-3158](https://rpc-openstack.atlassian.net/browse/RO-3158)