### PR TITLE
RE-787 Fix missing comma in job definition

### DIFF
--- a/rpc_jobs/unit/re_unit_tests.yml
+++ b/rpc_jobs/unit/re_unit_tests.yml
@@ -59,7 +59,7 @@
               ]
             ]
           )
-        }
+        },
         "Skip Build Check": {
           build(
             job: "RE-unit-test-skip-build-check",
@@ -72,7 +72,7 @@
               ]
             ]
           )
-        }
+        },
       ])
 
 #TODO: Jira Issue Manipulation, Validation of Published Artefacts.


### PR DESCRIPTION
This change fixes an error where the unit test job fails due to a
missing comma in the definition of the tests.

Issue: [RE-787](https://rpc-openstack.atlassian.net/browse/RE-787)