### PR TITLE
RE-1203 Fix use of skip_pattern in job definitions

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -5,7 +5,7 @@
     series: "master"
     branches:
       - "master"
-    skip_pattern: >-
+    skip_pattern: |
       \.md$
       | \.rst$
       | ^releasenotes/
@@ -53,7 +53,7 @@
     series: "newton"
     branches:
       - "newton.*"
-    skip_pattern: >-
+    skip_pattern: |
       \.md$
       | \.rst$
       | ^releasenotes/
@@ -103,7 +103,7 @@
     series: "mitaka"
     branches:
       - "mitaka.*"
-    skip_pattern: >-
+    skip_pattern: |
       \.md$
       | \.rst$
       | ^releasenotes/
@@ -129,7 +129,7 @@
     series: "liberty"
     branches:
       - "liberty.*"
-    skip_pattern: >-
+    skip_pattern: |
       \.md$
       | \.rst$
       | ^releasenotes/
@@ -155,7 +155,7 @@
     series: "kilo"
     branches:
       - "kilo.*"
-    skip_pattern: >-
+    skip_pattern: |
       \.md$
       | \.rst$
       | ^releasenotes/

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -26,6 +26,7 @@
     FLAVOR: "performance1-1"
     IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
     TRIGGER_PR_PHRASE_ONLY: false
+    skip_pattern: ""
     properties:
       - build-discarder:
           num-to-keep: "30"
@@ -54,6 +55,14 @@
               Destroy Slave
       - standard_job_params:
           SLAVE_TYPE: "{SLAVE_TYPE}"
+      - string:
+          name: skip_pattern
+          default: "{skip_pattern}"
+          description: |
+            Python re compatible regex, with verbose flag enabled. If all files changed by the
+            pull request match the regex the build will exit without running the test scripts.
+            This is used to skip tests that are not relevant to a change, for example testing a
+            deployment when only changing documentation. By default no builds are skipped.
     triggers:
       - github-pull-request:
           org-list:
@@ -84,7 +93,6 @@
       env.RE_JOB_REPO_NAME = "{repo_name}"
 
       String credentials = "{credentials}"
-      String skip_pattern = "{skip_pattern}"
 
       Boolean run_test = true
       // We need to checkout the repo on the CIT Slave so that

--- a/rpc_jobs/unit/skip_build_check.yml
+++ b/rpc_jobs/unit/skip_build_check.yml
@@ -7,6 +7,11 @@
           num-to-keep: 30
     parameters:
       - rpc_gating_params
+      - string:
+          name: skip_pattern
+          default: |
+            \.fileextension$
+            | ^changes_can_be_skipped/
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
       common.shared_slave{
@@ -26,8 +31,6 @@
             git commit -m Setup
             """
         }
-
-        skip_pattern = "^changes_can_be_skipped/"
 
         stage("Ensure true when empty commit") {
           sh """#!/bin/bash -xeu


### PR DESCRIPTION
This change moves `skip_pattern` to being a parameter. This means that
it is no longer defined in the pipeline script generated from the `dsl`
section of the pre-merge job template. Making this change means that the
string definition in the project no longer needs to escape special
characters.

Making `skip_pattern` a parameter fixes the rpc-openstack pull request
build failures caused by the use of unescaped `"\"` and `"$"` in the
definition of `skip_pattern` for its projects.

The regex is now supplied to the search function using an environment
variable instead of interpolating the string into the script. This
prevents any issues with interpolating a bad string.

The appearance of the regex in the console log is improved by moving it
to a new line.

Switching to use a parameter means that a trailing new line is no longer
a concern when defining `skip_pattern`. While leaving them would cause
no harm, this change removes the block chomping indicator, `-`, to
prevent any confusion from unnecessary stripping.

The block scalar used in the project definitions is switched to `|` to
improve how the pattern is displayed in the log.

Issue: [RE-1203](https://rpc-openstack.atlassian.net/browse/RE-1203)