### PR TITLE
RE-1205 safe_jira_comment cleanup

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -621,20 +621,19 @@ def is_doc_update_pr(String git_dir) {
  */
 def get_jira_issue_key(String repo_path="rpc-openstack"){
   def key_regex = "[a-zA-Z][a-zA-Z0-9_]+-[1-9][0-9]*"
-  dir(repo_path){
-    commits = sh(
-      returnStdout: true,
-      script: """
-        git log --pretty=%B upstream/${ghprbTargetBranch}..${ghprbSourceBranch}""")
-    print("looking for Jira issue keys in the following commits: ${commits}")
-    try{
-      String key = (commits =~ key_regex)[0]
-      print ("First Found Jira Issue Key: ${key}")
-      return key
-    } catch (e){
-      throw new Exception("""
-  No JIRA Issue key were found in commits ${repo_path}:${ghprbSourceBranch}""")
-    }
+  commits = sh(
+    returnStdout: true,
+    script: """#!/bin/bash -e
+      cd ${repo_path}
+      git log --pretty=%B origin/${ghprbTargetBranch}..origin/${ghprbSourceBranch}""")
+  print("Looking for Jira issue keys in the following commits: ${commits}")
+  try{
+    String key = (commits =~ key_regex)[0]
+    print ("First Found Jira Issue Key: ${key}")
+    return key
+  } catch (e){
+    throw new Exception("""
+No JIRA Issue key were found in commits ${repo_path}:${ghprbSourceBranch}""")
   }
 }
 

--- a/pipeline_steps/irr_role_tests.groovy
+++ b/pipeline_steps/irr_role_tests.groovy
@@ -26,7 +26,8 @@ def run_irr_tests() {
       currentBuild.result="FAILURE"
       throw e
     } finally {
-      common.safe_jira_comment("${currentBuild.result}: [${env.BUILD_TAG}|${env.BUILD_URL}]")
+      common.safe_jira_comment("${currentBuild.result}: [${env.BUILD_TAG}|${env.BUILD_URL}]",
+                               env.ghprbGhRepository)
       common.archive_artifacts()
     }
   } // pubcloud slave

--- a/rpc_jobs/cloud_image_build.yml
+++ b/rpc_jobs/cloud_image_build.yml
@@ -53,7 +53,5 @@
           print e
           currentBuild.result = "FAILURE"
           throw e
-        } finally {
-          common.safe_jira_comment("${currentBuild.result}: [${env.BUILD_TAG}|${env.BUILD_URL}]")
         }
       }

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -184,7 +184,8 @@
             currentBuild.result="FAILURE"
             throw e
           }} finally {{
-            common.safe_jira_comment("${{currentBuild.result}}: [${{env.BUILD_TAG}}|${{env.BUILD_URL}}]")
+            common.safe_jira_comment("${{currentBuild.result}}: [${{env.BUILD_TAG}}|${{env.BUILD_URL}}]",
+                                     env.RE_JOB_REPO_NAME)
             common.archive_artifacts()
           }} // try
         }}


### PR DESCRIPTION
A number of jobs are throwing an error on this function call, and it
appears the cause is three-fold:

1. A number of jobs are not passing in repo_path, meaning the default
   of rpc-openstack is being used, and this is incorrect for a number
   of non rpc-openstack-related jobs.
2. Jobs run inside a docker container are not cd'ing into the correct
   directory (see JENKINS-33510).
3. safe_jira_comment calls get_jira_issue_key which is trying to do a
   git log against an upstream branch, but upstream is not configured
   as a remote.

This commit does the following to address:

1. Updates the git-log in get_jira_issue_key (called by
   safe_jira_comment) to use origin instead of upstream, and also
   prefixes ${ghprbSourceBranch} with origin.
2. Removes the dir() in get_jira_issue_key and cd's into the correct
   dir in the sh() helper.
3. Updates the safe_jira_comment call in irr_role_tests.groovy to pass
   in env.ghprbGhRepository.  This seems incorrect as
   env.ghprbGhRepository contains team/repo (ie. rcbops/rpc-ceph), but
   that's where clone_with_pr_refs() is called from.
4. Removes the safe_jira_comment call from cloud_iamge_build.yml since
   that job doesn't seem to be associated with a git repo or triggered
   by PR.
5. Updates standard_job_premerge.yml to pass env.RE_JOB_REPO_NAME into
   safe_jira_comment.

Issue: [RE-1205](https://rpc-openstack.atlassian.net/browse/RE-1205)