### PR TITLE
RE-1200 override MaaS Verify retries

### DIFF
--- a/rpc_jobs/phobos.yml
+++ b/rpc_jobs/phobos.yml
@@ -56,7 +56,8 @@
       }
       void verify(){
         sshagent (credentials:['rpc-jenkins-svc-github-ssh-key']){
-          sh """#!/bin/bash
+          retry(3){
+            sh """#!/bin/bash
       # Deliberate outdent to match bash's heredoc requirements.
       sudo -E bash <<EOF
               cd rpc-eng-ops/phobos-re-automation
@@ -69,6 +70,7 @@
               pip install ansible==2.4.0.0 netaddr==0.7.19 shade==1.24.0 >/dev/null
               export OS_CLIENT_CONFIG_FILE="/tmp/phobos_verification_clouds.yml"
               vars_files="\$(for i in \$(ls /etc/openstack_deploy/user_*.yml); do echo -ne "-e @\$i "; done)"
+              # Note long retry period is to allow rabbit queues to settle, see RE-1200
               ansible-playbook \
                 -i /opt/rpc-openstack/openstack-ansible/playbooks/inventory/ \
                 -e rpc_eng_ops_version="${RPC_ENG_OPS_BRANCH}" \
@@ -76,11 +78,14 @@
                 -e maas_use_api="true" \
                 -e maas_verify_status="true" \
                 -e maas_verify_wait="false" \
+                -e maas_verify_delay="60" \
+                -e maas_verify_retries="15" \
                 -e WORKSPACE="${WORKSPACE}" \
                 \\\$vars_files \
                 verify.yml
       EOF
-          """
+            """
+          } // retry
         } // sshagent
       }
       library "rpc-gating@${RPC_GATING_BRANCH}"

--- a/rpc_jobs/phobos.yml
+++ b/rpc_jobs/phobos.yml
@@ -89,111 +89,113 @@
         } // sshagent
       }
       library "rpc-gating@${RPC_GATING_BRANCH}"
-      common.use_node("deploy-phobos"){
-        try {
-          withCredentials([
-              string(
-                credentialsId: "PHOBOS_DEDICATED_ACCOUNT_NUMBER",
-                variable: "RAX_DEDICATED_ACCOUNT_NUMBER"
-              ),
-              usernamePassword(
-                credentialsId: "rpc_jenkins_svc",
-                usernameVariable: "RAX_SSO_USER",
-                passwordVariable: "RAX_SSO_PASSWORD"
-              ),
-              usernamePassword(
-                credentialsId: "phobos_verification_admin",
-                usernameVariable: "PHOBOS_VERIFICATION_ADMIN_USER",
-                passwordVariable: "PHOBOS_VERIFICATION_ADMIN_PASSWORD"
-              )
-              // MAAS_TOKEN is added to env in "Check MaaS Credentials"
-          ]){
-            // do checkout before warning users to ensure branch is valid.
-            stage("Checkout"){
-              // groovy git function used for new clones
-              dir("rpc-eng-ops"){
-                git branch: env.RPC_ENG_OPS_BRANCH, url: env.RPC_ENG_OPS_REPO, credentialsId: 'rpc-jenkins-svc-github-ssh-key'
-              }
-              dir("rpc-maas-verify"){
-                git branch: env.RPC_MAAS_BRANCH, url: "https://github.com/rcbops/rpc-maas"
-              }
-              // Shell used instead of git function as I want to make all
-              // modifications to the exisiting clone expicit
-              sh """#!/bin/bash -xeu
-                cd /opt/rpc-openstack
-                # log current HEAD
-                git show
-                git status
-
-                pushd openstack-ansible
-                  sudo git stash
-                  sudo git reset --hard
-                popd
-                sudo git fetch --all
-                sudo git stash
-                sudo git reset --hard
-                sudo git checkout "${env.RPC_BRANCH}"
-                sudo git reset --hard origin/${env.RPC_BRANCH} || sudo git reset --hard ${env.RPC_BRANCH}
-                sudo git submodule update --init
-              """
-            }
-            stage("Check MaaS Credentials"){
-              // MaaS credentials check must be performed on an internal
-              // slave as it may use the internal identity api which
-              // isn't available from phobos.
-              common.internal_slave(){
+      timestamps(){
+        common.use_node("deploy-phobos"){
+          try {
+            withCredentials([
+                string(
+                  credentialsId: "PHOBOS_DEDICATED_ACCOUNT_NUMBER",
+                  variable: "RAX_DEDICATED_ACCOUNT_NUMBER"
+                ),
+                usernamePassword(
+                  credentialsId: "rpc_jenkins_svc",
+                  usernameVariable: "RAX_SSO_USER",
+                  passwordVariable: "RAX_SSO_PASSWORD"
+                ),
+                usernamePassword(
+                  credentialsId: "phobos_verification_admin",
+                  usernameVariable: "PHOBOS_VERIFICATION_ADMIN_USER",
+                  passwordVariable: "PHOBOS_VERIFICATION_ADMIN_PASSWORD"
+                )
+                // MAAS_TOKEN is added to env in "Check MaaS Credentials"
+            ]){
+              // do checkout before warning users to ensure branch is valid.
+              stage("Checkout"){
+                // groovy git function used for new clones
                 dir("rpc-eng-ops"){
                   git branch: env.RPC_ENG_OPS_BRANCH, url: env.RPC_ENG_OPS_REPO, credentialsId: 'rpc-jenkins-svc-github-ssh-key'
                 }
-                sh """#!/bin/bash
-                  scl enable python27 ${WORKSPACE}/rpc-eng-ops/phobos-re-automation/maas_creds_check.sh
-                """
-                // Ensure that the MAAS_TOKEN env var is correct
-                // whether the token was obtained from the service account
-                // or supplied via job param.
-                env.MAAS_TOKEN = readFile file: "MAAS_TOKEN"
-              }
-            }
-            stage("Pre Deployment Verify"){
-              verify()
-            }
-            stage("Pre Deploy Warning"){
-                if (env.PRE_DEPLOY_PAUSE == "true"){
-                  slack_notify("Phobos Deploy starting in 15 minutes.", "warning")
-                  sleep(time: 15, unit: "MINUTES")
+                dir("rpc-maas-verify"){
+                  git branch: env.RPC_MAAS_BRANCH, url: "https://github.com/rcbops/rpc-maas"
                 }
-                slack_notify("Phobos Deploy starting now.", "warning")
-            }
-            stage("Deploy"){
-              if (env.DEPLOY == "true"){
+                // Shell used instead of git function as I want to make all
+                // modifications to the exisiting clone expicit
                 sh """#!/bin/bash -xeu
-                  sudo -E rpc-eng-ops/phobos-re-automation/deploy.sh
+                  cd /opt/rpc-openstack
+                  # log current HEAD
+                  git show
+                  git status
+  
+                  pushd openstack-ansible
+                    sudo git stash
+                    sudo git reset --hard
+                  popd
+                  sudo git fetch --all
+                  sudo git stash
+                  sudo git reset --hard
+                  sudo git checkout "${env.RPC_BRANCH}"
+                  sudo git reset --hard origin/${env.RPC_BRANCH} || sudo git reset --hard ${env.RPC_BRANCH}
+                  sudo git submodule update --init
                 """
               }
-            }
-            stage("Post Deployment Verification"){
-              // no point verifying twice if we're not running a deploy
-              if (env.DEPLOY == "true"){
+              stage("Check MaaS Credentials"){
+                // MaaS credentials check must be performed on an internal
+                // slave as it may use the internal identity api which
+                // isn't available from phobos.
+                common.internal_slave(){
+                  dir("rpc-eng-ops"){
+                    git branch: env.RPC_ENG_OPS_BRANCH, url: env.RPC_ENG_OPS_REPO, credentialsId: 'rpc-jenkins-svc-github-ssh-key'
+                  }
+                  sh """#!/bin/bash
+                    scl enable python27 ${WORKSPACE}/rpc-eng-ops/phobos-re-automation/maas_creds_check.sh
+                  """
+                  // Ensure that the MAAS_TOKEN env var is correct
+                  // whether the token was obtained from the service account
+                  // or supplied via job param.
+                  env.MAAS_TOKEN = readFile file: "MAAS_TOKEN"
+                }
+              }
+              stage("Pre Deployment Verify"){
                 verify()
               }
-            }
+              stage("Pre Deploy Warning"){
+                  if (env.PRE_DEPLOY_PAUSE == "true"){
+                    slack_notify("Phobos Deploy starting in 15 minutes.", "warning")
+                    sleep(time: 15, unit: "MINUTES")
+                  }
+                  slack_notify("Phobos Deploy starting now.", "warning")
+              }
+              stage("Deploy"){
+                if (env.DEPLOY == "true"){
+                  sh """#!/bin/bash -xeu
+                    sudo -E rpc-eng-ops/phobos-re-automation/deploy.sh
+                  """
+                }
+              }
+              stage("Post Deployment Verification"){
+                // no point verifying twice if we're not running a deploy
+                if (env.DEPLOY == "true"){
+                  verify()
+                }
+              }
+              if(env.DEPLOY == "true"){
+                slack_notify("Phobos Deploy Complete", "good")
+              }
+            } // withCredentials
+          } catch (e) {
             if(env.DEPLOY == "true"){
-              slack_notify("Phobos Deploy Complete", "good")
+              slack_notify("Phobos Deploy Failed", "danger")
+              common.create_jira_issue("RE", "PHOBOS DEPLOY / ${env.BUILD_TAG}")
+            } else {
+              slack_notify("Phobos Verification Failed", "warning")
             }
-          } // withCredentials
-        } catch (e) {
-          if(env.DEPLOY == "true"){
-            slack_notify("Phobos Deploy Failed", "danger")
-            common.create_jira_issue("RE", "PHOBOS DEPLOY / ${env.BUILD_TAG}")
-          } else {
-            slack_notify("Phobos Verification Failed", "warning")
+            throw e
+          } finally {
+            sh """#!/bin/bash -xeu
+              # All files in the workspace must be owned by jenkins
+              # so they can be cleaned up by jenkins.
+              sudo chown -R jenkins:jenkins . &>/dev/null
+            """
           }
-          throw e
-        } finally {
-          sh """#!/bin/bash -xeu
-            # All files in the workspace must be owned by jenkins
-            # so they can be cleaned up by jenkins.
-            sudo chown -R jenkins:jenkins . &>/dev/null
-          """
-        }
-      } // phobos node
+        } // phobos node
+      } // timestamps


### PR DESCRIPTION
At the end of the RE-1200 deploy, a large spike in rabbitmq messages
was observed that built up over ~40 minutes before quickly clearing.
This caused the verification stage to fail. An immediate reverify
succeeded as the spike had subsided.

To avoid this situation in future, we extend maas retries to 15 minutes,
and retry the whole verification phase 3 times. This will allow for the
duration of a similar spike, and time for the alarm status to change in
MaaS.

Issue: [RE-1200](https://rpc-openstack.atlassian.net/browse/RE-1200)