### PR TITLE
RE-1144 Set default for jira_project_key

### DIFF
--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -36,6 +36,7 @@
 - job-template:
     name: 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
     branch: "master"
+    jira_project_key: ""
     project-type: pipeline
     concurrent: true
     FLAVOR: "performance1-1"
@@ -164,7 +165,7 @@
           }} catch (f){{
             user = 'SYSTEM'
           }}
-          if(user == 'SYSTEM'){{
+          if(user == 'SYSTEM' && JIRA_PROJECT_KEY != ''){{
             common.create_jira_issue(JIRA_PROJECT_KEY,
                                      env.BUILD_TAG,
                                      env.BUILD_URL,


### PR DESCRIPTION
This change sets an empty default for jira_project_key, and updates the
conditional around create_jira_issue dependent on JIRA_PROJECT_KEY
being non-empty.  This subsequently allows users to make projects send
notifications or not depending on whether jira_project_key is set, and
should also prevent any errors from being thrown now due to missing
jira_project_key.

Issue: [RE-1144](https://rpc-openstack.atlassian.net/browse/RE-1144)