### PR TITLE
RLM-727 Enables MNAIO leap jobs to Newton

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -93,11 +93,11 @@
       - "swift"
     action:
       - "liberty_to_newton_leap"
-#      - "r12.2.8_to_newton_leap"
-#      - "r12.2.5_to_newton_leap"
-#      - "r12.2.2_to_newton_leap"
-#      - "r12.1.2_to_newton_leap"
-#      - "kilo_to_newton_leap"
+      - "r12.2.8_to_newton_leap"
+      - "r12.2.5_to_newton_leap"
+      - "r12.2.2_to_newton_leap"
+      - "r12.1.2_to_newton_leap"
+      - "kilo_to_newton_leap"
     jira_project_key: "RLM"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'


### PR DESCRIPTION
Enables MNAIO leap jobs to Newton, holding off on release until these are more stable.