### PR TITLE
RE-1211 Reduce num-to-keep for PM jobs

### DIFF
--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -42,7 +42,7 @@
     IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
     properties:
       - build-discarder:
-          num-to-keep: "30"
+          num-to-keep: 14
       - github:
           url: "{repo_url}"
     parameters:


### PR DESCRIPTION
Since these jobs run once a day, it should be fine to retain two weeks
worth of logs for troubleshooting, investigating, etc.

Issue: [RE-1211](https://rpc-openstack.atlassian.net/browse/RE-1211)