### PR TITLE
RE-35 Merge instance_prep into allocate_pubcloud

### DIFF
--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -101,7 +101,6 @@ String getPubCloudSlave(Map args){
           env.OS_CLIENT_CONFIG_FILE = clouds_cfg
           common.venvPlaybook(
             playbooks: ["allocate_pubcloud.yml",
-                        "instance_prep.yml",
                         "drop_ssh_auth_keys.yml"],
             args: [
               "-i ${args.inventory}",

--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -97,6 +97,13 @@
         minutes: 5
 
 - hosts: singleuseslave
+  remote_user: root
+  gather_facts: False
+  tasks:
+    - name: RLM-275 Adds python packages if python is not present
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal python-yaml)
+
+- hosts: singleuseslave
   tasks:
     - name: Check for thaw hook
       stat:

--- a/playbooks/instance_prep.yml
+++ b/playbooks/instance_prep.yml
@@ -1,6 +1,0 @@
-- hosts: job_nodes
-  remote_user: root
-  gather_facts: False
-  tasks:
-    - name: RLM-275 Adds python packages if python is not present
-      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal python-yaml)


### PR DESCRIPTION
Previously, instance_prep ran before we did any ansible tasks on a
server.  However, additional tasks were added to allocate_pubcloud that
run before instance_prep is executed, which results in jobs failing
when python does not exist in the base image.

This commit merges instance_prep with allocate_pubcloud.

Issue: [RE-35](https://rpc-openstack.atlassian.net/browse/RE-35)