### PR TITLE
RLM-820 Increase timeout to 8 hours

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -750,7 +750,7 @@ void internal_slave(body){
 }
 
 void standard_job_slave(String slave_type, Closure body){
-  timeout(time: 6, unit: 'HOURS'){
+  timeout(time: 8, unit: 'HOURS'){
     shared_slave(){
       if (slave_type == "instance"){
         pubcloud.runonpubcloud(){


### PR DESCRIPTION
Running against the 6 hour mark for a full MNAIO deploy, leapfrog,
and QC.  Bumping it to 8 should provide breathing room for additional
items.

Issue: [RLM-820](https://rpc-openstack.atlassian.net/browse/RLM-820)