### PR TITLE
RLM-820 Reduce timeout during startup

### DIFF
--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -94,7 +94,7 @@
 
     - name: Wait for startup tasks to finish
       pause:
-        minutes: 5
+        minutes: 1
 
 - hosts: singleuseslave
   remote_user: root


### PR DESCRIPTION
Reduce the time on startup to 1 minute instead of 5
to see if this causes any issues.

Issue: [RLM-820](https://rpc-openstack.atlassian.net/browse/RLM-820)