### PR TITLE
[RE-1097] ensure correct source repo is used for PR

### DIFF
--- a/job_dsl/release.groovy
+++ b/job_dsl/release.groovy
@@ -10,9 +10,9 @@ common.shared_slave(){
     // of the environment variables automatically as
     // they will not be provided by a human.
     if ( env.ghprbPullId != null ) {
-      List org_repo = env.ghprbGhRepository.split("/")
-      env.ORG = org_repo[0]
-      env.REPO = org_repo[1]
+      List source_repo = env.ghprbAuthorRepoGitUrl.split("/")
+      env.ORG = source_repo[-2]
+      env.REPO = source_repo[-1].tokenize(".")[0]
       env.RC_BRANCH = env.ghprbSourceBranch
     }
     withCredentials([


### PR DESCRIPTION
When a PR is made from a fork, we need to ensure we are cloning from
the correct source repo where the PR branch exists

```ghprbAuthorRepoGitUrl``` always contains the source repo (fork) url,
in the format:

```https://github.com/external_org/repo_name.git```

Job showing successful clone of external fork (although the release job failed for other reasons):

https://rpc.jenkins.cit.rackspace.net/job/RE-Release-PR_rpc-openstack-master/211/console


Issue: [RE-1097](https://rpc-openstack.atlassian.net/browse/RE-1097)