### PR TITLE
RE-1138 Update existing issue on build failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ playbooks/roles/geerlingguy.nginx/
 playbooks/roles/jnv.unattended-upgrades/
 playbooks/roles/willshersystems.sshd/
 playbooks/roles/mongrelion.docker/
+runjenkins.yml

--- a/job_dsl/dep_update.groovy
+++ b/job_dsl/dep_update.groovy
@@ -59,10 +59,7 @@ common.globalWraps(){
     print(e)
     // Only create failure card when run as a post-merge job
     if ( env.ghprbPullId == null ) {
-      common.create_jira_issue("RE",
-                               env.BUILD_TAG,
-                               env.BUILD_URL,
-                               "Task")
+      common.build_failure_issue("RE")
     } // if
     throw e
   } // try

--- a/lint.sh
+++ b/lint.sh
@@ -39,7 +39,7 @@ check_jjb(){
 # This pulls job.dsl from jjb templates so they can be checked for groovy syntax
 extract_groovy_from_jjb(){
   mkdir -p tmp_groovy
-  for jjbfile in rpc_jobs/*.yml
+  for jjbfile in $(find rpc_jobs -iname \*.yml)
   do
     scripts/extract_dsl.py --jjbfile "${jjbfile}" --outdir tmp_groovy
   done

--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -227,7 +227,10 @@ def runonpubcloud(Map args=[:], Closure body){
       } catch (e){
         print "Error while cleaning up, swallowing this exception to prevent "\
               +"cleanup errors from failing the build: ${e}"
-        common.create_jira_issue("RE", "Cleanup Failure: ${env.BUILD_TAG}")
+        common.create_jira_issue("RE",
+                                 "Cleanup Failure: ${env.BUILD_TAG}",
+                                 "[${env.BUILD_TAG}|${env.BUILD_URL}]",
+                                 ["jenkins", "cleanup_fail"])
       } // inner try
     } // if
   } //outer try

--- a/rpc_jobs/jjb_setup.yml
+++ b/rpc_jobs/jjb_setup.yml
@@ -87,10 +87,7 @@
             // Here we only create a JIRA issue when we are not running the job
             // against a testing branch or against a specific job
             if (env.RPC_GATING_BRANCH == "master" && env.JOBS == "-r rpc_jobs") {
-              common.create_jira_issue("RE",
-                                       env.BUILD_TAG,
-                                       env.BUILD_URL,
-                                       "Task")
+              common.build_failure_issue("RE")
             }
             throw e
           } // catch

--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -61,10 +61,7 @@
                 }
               } catch(e) {
                 print(e)
-                common.create_jira_issue("RE",
-                                         env.BUILD_TAG,
-                                         env.BUILD_URL,
-                                         "Task")
+                common.build_failure_issue("RE")
                 throw e
               }
             }
@@ -116,10 +113,7 @@
             }
           } catch(e) {
             print(e)
-            common.create_jira_issue("RE",
-                                     env.BUILD_TAG,
-                                     env.BUILD_URL,
-                                     "Task")
+            common.build_failure_issue("RE")
             throw e
           }
         } // internal_slave

--- a/rpc_jobs/phobos.yml
+++ b/rpc_jobs/phobos.yml
@@ -188,7 +188,7 @@
           } catch (e) {
             if(env.DEPLOY == "true"){
               slack_notify("Phobos Deploy Failed", "danger")
-              common.create_jira_issue("RE", "PHOBOS DEPLOY / ${env.BUILD_TAG}")
+              common.build_failure_issue("RE")
             } else {
               slack_notify("Phobos Verification Failed", "warning")
             }

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -168,10 +168,7 @@
               user = 'SYSTEM'
             }}
             if(user == 'SYSTEM' && JIRA_PROJECT_KEY != ''){{
-              common.create_jira_issue(JIRA_PROJECT_KEY,
-                                       env.BUILD_TAG,
-                                       env.BUILD_URL,
-                                       "Task")
+              common.build_failure_issue(JIRA_PROJECT_KEY)
             }}
             throw e
           }} finally {{

--- a/rpc_jobs/unit/jira.yml
+++ b/rpc_jobs/unit/jira.yml
@@ -1,0 +1,187 @@
+- job:
+    name: RE-unit-test-jira
+    project-type: pipeline
+    concurrent: true
+    properties:
+      - build-discarder:
+          num-to-keep: 30
+    parameters:
+      - rpc_gating_params
+    dsl: |
+      def cleanup(String issue, String issue_query){
+        // remove build specific label to avoid adding an extra label
+        // to jira every time this job runs.
+        common.jira_set_labels(issue, base_labels)
+        common.jira_close(issue)
+        issues = common.jira_query(issue_query)
+        print issues
+        assert issues.size() == 0
+      }
+
+      library "rpc-gating@${RPC_GATING_BRANCH}"
+      common.shared_slave{
+        project = "SAN" // sandbox project
+        base_labels = ['re_unit', 'RE-unit-test-jira', 'jenkins']
+        labels = base_labels + env.BUILD_TAG
+        issue_query = "labels = \"re_unit\" AND labels = \"${env.BUILD_TAG}\" and project = ${project} and status = BACKLOG"
+
+        try {
+          stage("Test query command with issue key"){
+            String key = "SAN-1"
+            List issues = common.jira_query("key = ${key}")
+            print issues
+            assert issues.size() == 1
+            assert key == issues[0]
+          }
+
+          stage("Test create issue"){
+            List issues = common.jira_query(issue_query)
+            print issues
+            assert issues.size() == 0
+            issue = common.create_jira_issue(
+              project,
+              "Test create issue ${env.BUILD_TAG}",
+              "",
+              labels
+            )
+            issues = common.jira_query(issue_query)
+            print issues
+            print issue
+            assert issues.size() == 1
+            assert issues[0] == issue
+            cleanup(issues[0], issue_query)
+          }
+
+          stage("Test get or create issue"){
+            List issues = common.jira_query(issue_query)
+            print issues
+            assert issues.size() == 0
+
+            // Create issue
+            issue = common.get_or_create_jira_issue(
+              project,
+              "BACKLOG",
+              "Test get or create issue ${env.BUILD_TAG}",
+              "",
+              labels
+            )
+            // Assert issue exists
+            issues = common.jira_query(issue_query)
+            print issues
+            print issue
+            assert issues.size() == 1
+            assert issues[0] == issue
+
+            // Attempt to create same issue again
+            issue_2 = common.get_or_create_jira_issue(
+              project,
+              "BACKLOG",
+              "Test get or create issue ${env.BUILD_TAG}",
+              "",
+              labels
+            )
+
+            // Assert that the same issue key is retrieved both times
+            print issue
+            print issue_2
+            assert issue == issue_2
+
+            // Assert that only 1 matching issue exists
+            issues = common.jira_query(issue_query)
+            print issues
+            assert issues.size() == 1
+            assert issues[0] == issue
+            cleanup(issues[0], issue_query)
+          }
+          stage("Test close_all max issue limit"){
+            // Create 3 test issues
+            // intrange not serializable :(
+            for (i in [1,2,3]){
+              common.create_jira_issue(
+                project,
+                "Test delete max ${env.BUILD_TAG} ${i}",
+                "",
+                labels + "delete_max"
+              )
+            } //end for
+            try {
+              // Try and delete a maximum of two issues
+              test_query = issue_query + " AND labels = \"delete_max\""
+              common.jira_close_all(test_query, 2)
+              // Should not get here, as exception should be thrown
+              throw new Exception("RE Jira unit test failed: Test max issue limit")
+            } catch (hudson.AbortException e){
+              // test pass
+            } catch (Exception e){
+              // test fail
+              throw e
+            } finally {
+              // should pass with max_issues=3
+              common.jira_close_all(test_query, 3)
+            }
+          }
+          stage("Test close_all allow_all_projects=false fails with no project in query"){
+            try {
+              // should fail as project not specified in query
+              common.jira_close_all("labels = \"test_close_all_no_matches\"", 0)
+              throw new Exception("RE Jira unit test failed: Test close_all allow_all_projects")
+            } catch (hudson.AbortException e){
+              // test pass
+            } catch (Exception e){
+              // test fail
+              throw e
+            }
+
+          }
+          stage("Test close_all allow_all_projects=true succeeds with no project in query"){
+            // should match nothing and successfully delete nothing
+            common.jira_close_all("labels = \"test_close_all_no_matches\"", 0,
+                                  true)
+          }
+        // default catch allows Exception and all subclasses which doesn't
+        // include AssertionError which is a subclass of Error.
+        } catch (Error | Exception e) {
+          print ("Jira unit test try/catch block 1 error: ${e}")
+          common.jira_close_all(issue_query)
+          throw e
+        }
+
+        // This stage uses the job name as a label rather than the build tag,
+        // concurrent runs will interfere. A lock is used to serialise.
+        stage("Test build_failure_issue"){
+          lock("unit_test_jira_build_failure_issue_test"){
+            try {
+              labels = ["jenkins-build-failure", "jenkins", env.JOB_NAME ]
+              issue_query = "labels = \"${env.JOB_NAME}\" AND labels = \"jenkins-build-failure\" AND labels = \"jenkins\" AND project = ${project} AND status = BACKLOG"
+
+              List issues = common.jira_query(issue_query)
+              print issues
+              assert issues.size() == 0
+
+              // Create issue and add a comment
+              common.build_failure_issue(project)
+              issues = common.jira_query(issue_query)
+              print issues
+              assert issues.size() == 1
+              comments = common.jira_comments(issues[0])
+              print comments
+              assert comments.size() == 1
+
+              // Ensure that duplicate issue is not created, and that
+              // a comment is added to the existing issue
+              common.build_failure_issue(project)
+              issues = common.jira_query(issue_query)
+              print issues
+              assert issues.size() == 1
+              comments = common.jira_comments(issues[0])
+              print comments
+              assert comments.size() == 2
+              cleanup(issues[0], issue_query)
+            } catch (Error | Exception e) {
+              print ("Jira unit test try/catch block 2 error: ${e}")
+              common.jira_close_all("project = ${project} AND labels = \"${env.JOB_NAME}\" AND status = BACKLOG")
+              throw e
+            }
+          }
+        }
+      } // shared slave

--- a/rpc_jobs/unit/re_unit_tests.yml
+++ b/rpc_jobs/unit/re_unit_tests.yml
@@ -101,6 +101,19 @@
             ]
           )
         },
+        "Jira Issue check": {
+          build(
+            job: "RE-unit-test-jira",
+            wait: true,
+            parameters: [
+              [
+                $class: 'StringParameterValue',
+                name: 'RPC_GATING_BRANCH',
+                value: env.RPC_GATING_BRANCH
+              ]
+            ]
+          )
+        },
       ])
 
-#TODO: Jira Issue Manipulation, Validation of Published Artefacts.
+#TODO: Validation of Published Artefacts.

--- a/scripts/dep_update.sh
+++ b/scripts/dep_update.sh
@@ -48,13 +48,13 @@ else
   issue=$(python ${WORKSPACE}/rpc-gating/scripts/jirautils.py \
         --user "${JIRA_USER}" \
         --password "${JIRA_PASS}" \
-        create_issue \
+        get_or_create_issue \
           --project "${JIRA_PROJECT_KEY}" \
           --summary "${jira_summary}" \
           --description "${message}" \
-          --type "${JIRA_ISSUE_TYPE}" \
           --label RE_DEP_UPDATE \
-          --existing-issue-query "project = ${JIRA_PROJECT_KEY} AND status = BACKLOG AND summary ~ \"${jira_summary}\""
+          --label jenkins \
+          --label "${repo}_${branch}"
   )
   echo "Issue: ${issue}"
 

--- a/scripts/jirautils.py
+++ b/scripts/jirautils.py
@@ -2,9 +2,132 @@
 
 # This script contains jira related utilties for Jenkins.
 
+import logging
+import re
+from collections import defaultdict
 
 import click
+
 from jira import JIRA, JIRAError
+
+# Logging config
+logging.basicConfig()
+LOGGER = logging.getLogger("jirautils")
+
+# Cache of done transitions per project, saves looking this up for
+# every issue
+transitions = {}
+
+
+# Internal functions
+# These should return a value but not output to
+# the standard output streams.
+
+
+def issues_for_query(query):
+    ctx = click.get_current_context()
+    authed_jira = ctx.obj
+    LOGGER.debug("Looking for issues matching query: {q}".format(q=query))
+    try:
+        issues = sorted(authed_jira.search_issues(query),
+                        key=lambda i: int(i.id))
+        LOGGER.debug("Issues returned by query: {}".format(
+            [i.key for i in issues]))
+        return issues
+    except JIRAError as e:
+        LOGGER.critical("Error querying for issues, bad JQL?"
+                        " Query: {q}, Error: {e}"
+                        .format(q=query, e=e))
+        ctx.exit(1)
+
+
+def get_label_query_terms(labels):
+    terms = []
+    for label in labels:
+        terms.append("labels = \"{label}\"".format(label=label))
+    return " AND ".join(terms)
+
+
+def _get_or_create_issue(project, status, labels, description, summary):
+    issue = None
+
+    # Check for existing issues
+    query = ("{label_terms} AND project = \"{p}\" AND status = {s}"
+             .format(label_terms=get_label_query_terms(labels),
+                     p=project, s=status))
+    issues = issues_for_query(query)
+
+    if len(issues) == 1:
+        issue = issues[0]
+        LOGGER.debug("Found existing issue: {ik}".format(ik=issue.key))
+    elif len(issues) > 1:
+        issue = issues[0]
+        LOGGER.debug("Query: {q} Returned >1 issues: {il}. "
+                     "Will use the oldest issue {i}".format(
+                        q=query,
+                        il=",".join(i.key for i in issues),
+                        i=issue))
+    else:
+        issue = _create_issue(
+            summary=summary,
+            description=description,
+            project=project,
+            labels=labels)
+
+    return issue
+
+
+def _create_issue(summary, description, project, labels, issue_type="Task"):
+    ctx = click.get_current_context()
+    authed_jira = ctx.obj
+
+    LOGGER.debug("Creating new issue")
+    return authed_jira.create_issue(
+        project=project,
+        summary=summary,
+        description=description,
+        issuetype={'name': issue_type},
+        labels=labels
+    )
+
+
+def find_done_transition(authed_jira, issue):
+    """Find the final state for an issue.
+
+    Each project can have a different set of states. In order to close issues
+    we have to determine the correct final state. This function finds the
+    transition to the end state and caches that per project.
+    """
+    try:
+        return transitions[issue.fields.project.key]
+    except KeyError:
+        issue_transitions = authed_jira.transitions(issue)
+        done_transition = [t for t in issue_transitions
+                           if t['to']['statusCategory']['key'] == 'done'][0]
+        transitions[issue.fields.project.key] = done_transition
+        return done_transition
+
+
+def _close_all(query, max_issues=30):
+    ctx = click.get_current_context()
+    authed_jira = ctx.obj
+    issues = issues_for_query(query)
+    if len(issues) > max_issues:
+        raise ValueError("Attempting to close too many issues, "
+                         "query matched {issues} but limit is set to {limit}"
+                         .format(issues=len(issues), limit=max_issues))
+    for issue in issues:
+        done_transition = find_done_transition(authed_jira, issue)
+        authed_jira.transition_issue(
+            issue,
+            done_transition['id'])
+    return issues
+
+
+# CLI Functions
+# These should not be called, apart from by click. if you need to reuse one
+# move its functionality into a private function and call that from both
+# places.
 
 
 @click.group()
@@ -17,9 +140,79 @@ from jira import JIRA, JIRAError
 @click.option('--instance', 'jira_instance',
               help="Jira instance url",
               default="https://rpc-openstack.atlassian.net")
-def cli(user, password, jira_instance):
+@click.option('--debug/--no-debug', default=False)
+def cli(user, password, jira_instance, debug):
     click.get_current_context().obj = \
         JIRA(jira_instance, basic_auth=(user, password))
+    if debug:
+        LOGGER.setLevel(logging.DEBUG)
+
+
+@cli.command()
+@click.option('--query')
+def query(query):
+    """Print keys for issues that match a query."""
+    for issue in issues_for_query(query):
+        click.echo(issue.key)
+
+
+@cli.command()
+@click.option('--project')
+@click.option('--status', default="BACKLOG")
+@click.option('--label',
+              'labels',
+              help="labels an issue must match,"
+                   " or labels to add to a new issue",
+              multiple=True,
+              default=["jenkins-build-failure"])
+@click.option('--description')
+@click.option('--summary')
+def get_or_create_issue(project, status, labels, description, summary):
+    """Get existing issue or create new issue.
+
+    Note that existing issues are matched on labels, project and status,
+    not summary or description.
+    """
+    issue = _get_or_create_issue(project, status, labels, description, summary)
+    click.echo(issue.key)
+
+
+@cli.command()
+@click.option('--project')
+@click.option('--job-name', help="Name of the job")
+@click.option('--job-url', help="URL of the job")
+@click.option('--build-tag',
+              help="Build Tag (string the identifies the job and build.)")
+@click.option('--build-url', help="URL of the build")
+def build_failure_issue(project, job_name, job_url, build_tag, build_url):
+    """Create issue for build failure.
+
+    1) Identify or create an issue relating to the Job that failed.
+    2) Add a comment to the issue linking to the Build that failed.
+    """
+    ctx = click.get_current_context()
+    authed_jira = ctx.obj
+
+    issue = _get_or_create_issue(
+        project=project,
+        status="BACKLOG",
+        labels=["jenkins-build-failure", "jenkins", job_name],
+        summary="JBF: {jn}".format(jn=job_name),
+        description="The following job failed a build: [{jn}|{ju}]"
+                    .format(jn=job_name, ju=job_url))
+
+    # Whether the issue was found or created, we now have an issue relating
+    # to the job. The next step is to add a comment linking to the specific
+    # build failure.
+
+    comment = "Build Failure: [{bt}|{bu}]".format(
+        bt=build_tag,
+        bu=build_url
+    )
+    authed_jira.add_comment(issue.key, comment)
+    LOGGER.debug("Added comment to {ik}: \"{c}\"".format(
+        ik=issue.key, c=comment))
+    click.echo(issue.key)
 
 
 @cli.command()
@@ -32,47 +225,157 @@ def cli(user, password, jira_instance):
 @click.option('--project',
               help='Jira Project Key',
               required=True)
-@click.option('--type', 'issue_type',
-              help="Jira issue type",
-              default="Task")
 @click.option('--label',
               'labels',
               help="Add label to issue, can be specified multiple times",
               multiple=True,
               default=["jenkins-build-failure"])
-@click.option("--existing-issue-query",
-              help="JQL query for existing issues. If the query returns"
-              " exactly one issue, a new issue will not be created, and"
-              " the existing issue's key will be printed.")
-def create_issue(summary, description, project, issue_type, labels,
-                 existing_issue_query):
+@click.option('--type', 'issue_type',
+              help="Jira issue type",
+              default="Task")
+def create_issue(summary, description, project, labels, issue_type):
+    """Create a Jira Issue."""
+    issue = _create_issue(summary, description, project, labels, issue_type)
+    click.echo(issue.key)
+
+
+@cli.command()
+@click.option('--issue', required=True)
+def close(issue):
+    ctx = click.get_current_context()
+    try:
+        _close_all("key = {}".format(issue))
+    except JIRAError as e:
+        click.echo("Error closing issue {i}: {e}".format(i=issue, e=e.message))
+        ctx.exit(1)
+
+
+@cli.command()
+@click.option('--query', required=True)
+@click.option('--allow-all-projects/--no-allow-all-projects', default=False,
+              help="Allow queries that don't specify a project")
+@click.option('--max-issues', default=30,
+              help="Maximum number of issues to close, will abort if query "
+              "matches more issues")
+def close_all(query, allow_all_projects, max_issues):
+    ctx = click.get_current_context()
+    if "project" not in query and not allow_all_projects:
+        raise ValueError("Query specified to close_all ({q}) does not contain "
+                         "a project clause. If you wish to close issues "
+                         "from multiple projects please use "
+                         "--allow-all-projects".format(q=query))
+    try:
+        _close_all(query, max_issues)
+    except JIRAError as e:
+        click.echo("Error closing issues: {e}".format(e=e.message))
+        ctx.exit(1)
+
+
+@cli.command()
+@click.option('--issue')
+@click.option('--label', 'labels', multiple=True)
+def set_labels(issue, labels):
     ctx = click.get_current_context()
     authed_jira = ctx.obj
-    issue = None
-    if existing_issue_query is not None:
-        try:
-            issues = authed_jira.search_issues(existing_issue_query)
-        except JIRAError as e:
-            click.echo("Error querying for existing issues, bad JQL?"
-                       " Query: {q}, Error: {e}"
-                       .format(q=existing_issue_query, e=e))
-            ctx.exit(1)
-        if len(issues) == 1:
-            issue = issues[0]
-        elif len(issues) > 1:
-            click.echo("query: {q} Returned >1 issues: {il}".format(
-                q=existing_issue_query, il=issues))
-            ctx.exit(1)
+    try:
+        issue = authed_jira.issue(issue)
+        issue.update(fields={"labels": labels})
+    except JIRAError:
+        click.echo("Failed to find issue {}".format(issue))
+        ctx.exit(1)
 
-    if issue is None:
-        issue = authed_jira.create_issue(
-            project=project,
-            summary=summary,
-            description=description,
-            issuetype={'name': issue_type},
-            labels=labels
-        )
-    click.echo(issue.key)
+
+@cli.command()
+@click.option('--issue')
+def comments(issue):
+    ctx = click.get_current_context()
+    authed_jira = ctx.obj
+    try:
+        issue = authed_jira.issue(issue)
+        for comment in issue.fields.comment.comments:
+            click.echo(comment.body)
+    except JIRAError:
+        click.echo("Failed to find issue {}".format(issue))
+        ctx.exit(1)
+
+
+@cli.command()
+@click.option("--squash/--no-squash",
+              help="Squash duplicate issues")
+@click.option("--query",
+              default="labels = jenkins-build-failure and status = BACKLOG",
+              help="Limit search to issues matching this query")
+def findfailuredupes(squash, query):
+    """Find duplicate build failure issues.
+
+    Jenkins used to create a new issue for every build failure. This is no
+    longer the case as now when repeat job failures occur if an issue already
+    exists in the backlog it will be updated instead of duplicated.
+
+    This function is for finding and cleanup up duplicates left over from
+    the previous methodology.
+    """
+    ctx = click.get_current_context()
+    authed_jira = ctx.obj
+    issues = authed_jira.search_issues(query)
+    jobs = defaultdict(list)
+    for issue in issues:
+        match = re.match("^JBF:\s*(.+)-[0-9]+$", issue.fields.summary)
+        if match:
+            job = match.group(1)
+            jobs[job].append(issue)
+        else:
+            print "non matching summary: {}".format(issue.fields.summary)
+    duplicates = {job: sorted(issues, key=lambda x: int(x.id))
+                  for job, issues in jobs.items()
+                  if len(issues) > 1}
+    if duplicates:
+        print "Duplicates:"
+        for job, issues in duplicates.items():
+            print "{job} --> {issues}".format(
+                job=job, issues=", ".join(i.key for i in issues))
+        if squash:
+            print "Squashing duplicates"
+            for job, issues in duplicates.items():
+                master_issue = issues.pop(0)
+                print "{job} / {master}".format(job=job, master=master_issue)
+                for duplicate_issue in issues:
+                    # Add comment to master issue
+                    print ("  Adding Comment to master issue: {}"
+                           .format(master_issue.key))
+                    authed_jira.add_comment(
+                        master_issue.key,
+                        "Issue {d} closed as a duplicate of this issue".format(
+                            d=duplicate_issue.key))
+                    # Add comment to duplicate issue
+                    print ("  Adding Comment to duplicate issue: {}"
+                           .format(duplicate_issue.key))
+                    authed_jira.add_comment(
+                        duplicate_issue.key,
+                        "Closing as duplicate of {m}".format(
+                            m=master_issue.key))
+                    transition = find_done_transition(authed_jira,
+                                                      duplicate_issue)
+                    # Close duplicate issue
+                    print "  Transitioning: {k} --> {t}".format(
+                        k=duplicate_issue.key, t=transition['name'])
+                    authed_jira.transition_issue(
+                        duplicate_issue,
+                        transition['id'])
+                # Update master issue to match newly created build failure
+                # issues
+                master_issue.update(
+                    fields={"summary": "JBF: {jn}".format(jn=job),
+                            "labels": ["jenkins-build-failure",
+                                       "jenkins", job]
+                            }
+                )
+
+            print "Squash Complete"
+        else:
+            print "Squash disabled, leaving duplicates"
+    else:
+        print "No Duplicates Found"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR will help reduce issue spam, by updating an existing issue if one exists instead of creating duplicate issues. It also adds a tool for closing all existing issues related to a particular build except the oldest one. 

Issue: [RE-1138](https://rpc-openstack.atlassian.net/browse/RE-1138)