### PR TITLE
RLM-316 Add PM deploy tests for artifact 'loose' mode

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -174,6 +174,10 @@
           IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
       - trusty:
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+      - xenial_loose:
+          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+      - trusty_loose:
+          IMAGE: "Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)"
     scenario:
       - "ironic"
       - "swift"


### PR DESCRIPTION
The 'loose' mode of using artifacts has been introduced
to help with initial deployments where the packages on
the hosts may be newer than those in the apt artifacts
repo. This patch adds two more tests which facilitate
verifying that this mode works on a day to day basis.

The existing tests are not changed so that the jobs
retain their history and so that the merge trigger
jobs also do not need to change.

The PR to implement the changes being tested by this
job are in https://github.com/rcbops/rpc-openstack/pull/2739

Issue: [RLM-316](https://rpc-openstack.atlassian.net/browse/RLM-316)