### PR TITLE
RE-1225 Exclude webhook-proxy from cleanup

### DIFF
--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -9,7 +9,7 @@
             Hours. Instances older than this will be removed.
       - string:
           name: "PROTECTED_PREFIX"
-          default: "long-running-slave|influx-|WEBHOOK-PROXY|nodepool|repo-server-"
+          default: "long-running-slave|influx-|WEBHOOK-PROXY|webhook-proxy|nodepool|repo-server-"
           description: |
             Instances that match this prefix regex will not be cleaned up.
       - string:


### PR DESCRIPTION
The periodic cleanup job is failing because it's attempting to delete
an instance called `webhook-proxy`, which is locked and cannot be
deleted.

We already have an instance called `WEBHOOK-PROXY` and a periodic
cleanup exclusion for this, so this commit simply adds an exclusion for
`webhook-proxy` also.

Issue: [RE-1225](https://rpc-openstack.atlassian.net/browse/RE-1225)