### PR TITLE
RE-1191 Remove usages of the ansicolor plugin

### DIFF
--- a/pipeline_steps/aio_prepare.groovy
+++ b/pipeline_steps/aio_prepare.groovy
@@ -8,20 +8,18 @@ def prepare(){
       } else {
         common.prepareRpcGit()
       }
-      ansiColor('xterm'){
-        dir("/opt/rpc-openstack"){
-          withEnv( common.get_deploy_script_env() + [
-            "DEPLOY_AIO=yes",
-            "DEPLOY_OA=no",
-            "DEPLOY_SWIFT=${env.DEPLOY_SWIFT}",
-            "DEPLOY_ELK=${env.DEPLOY_ELK}",
-            "DEPLOY_IRONIC=${env.DEPLOY_IRONIC}",
-            "DEPLOY_RPC=no"
-          ]){
-            sh """#!/bin/bash
-            scripts/deploy.sh
-            """
-          }
+      dir("/opt/rpc-openstack"){
+        withEnv( common.get_deploy_script_env() + [
+          "DEPLOY_AIO=yes",
+          "DEPLOY_OA=no",
+          "DEPLOY_SWIFT=${env.DEPLOY_SWIFT}",
+          "DEPLOY_ELK=${env.DEPLOY_ELK}",
+          "DEPLOY_IRONIC=${env.DEPLOY_IRONIC}",
+          "DEPLOY_RPC=no"
+        ]){
+          sh """#!/bin/bash
+          scripts/deploy.sh
+          """
         }
       }
       // If this branch can prepare its own configs, common.prepareConfigs

--- a/pipeline_steps/artifact_build.groovy
+++ b/pipeline_steps/artifact_build.groovy
@@ -31,13 +31,11 @@ def apt() {
   common.use_node('ArtifactBuilder2') {
     withCredentials(get_rpc_repo_creds()) {
       common.prepareRpcGit("auto", env.WORKSPACE)
-      ansiColor('xterm') {
-        dir("${env.WORKSPACE}/rpc-openstack") {
-          sh """#!/bin/bash
-          scripts/artifacts-building/apt/build-apt-artifacts.sh
-          """
-        } // dir
-      } // ansiColor
+      dir("${env.WORKSPACE}/rpc-openstack") {
+        sh """#!/bin/bash
+        scripts/artifacts-building/apt/build-apt-artifacts.sh
+        """
+      } // dir
     } // withCredentials
   } // use_node
 }
@@ -47,13 +45,11 @@ def git(String image) {
     try {
       withCredentials(get_rpc_repo_creds()) {
         common.prepareRpcGit()
-        ansiColor('xterm') {
-          dir("/opt/rpc-openstack/") {
-            sh """#!/bin/bash
-            scripts/artifacts-building/git/build-git-artifacts.sh
-            """
-          } // dir
-        } // ansiColor
+        dir("/opt/rpc-openstack/") {
+          sh """#!/bin/bash
+          scripts/artifacts-building/git/build-git-artifacts.sh
+          """
+        } // dir
       } // withCredentials
     } catch (e) {
       print(e)
@@ -69,13 +65,11 @@ def python(String image) {
     try {
       withCredentials(get_rpc_repo_creds()) {
         common.prepareRpcGit()
-        ansiColor('xterm') {
-          dir("/opt/rpc-openstack/") {
-            sh """#!/bin/bash
-            scripts/artifacts-building/python/build-python-artifacts.sh
-            """
-          } // dir
-        } // ansiColor
+        dir("/opt/rpc-openstack/") {
+          sh """#!/bin/bash
+          scripts/artifacts-building/python/build-python-artifacts.sh
+          """
+        } // dir
       } // withCredentials
     } catch (e) {
       print(e)
@@ -91,13 +85,11 @@ def container(String image) {
     try {
       withCredentials(get_rpc_repo_creds()) {
         common.prepareRpcGit()
-        ansiColor('xterm') {
-          dir("/opt/rpc-openstack/") {
-            sh """#!/bin/bash
-            scripts/artifacts-building/containers/build-process.sh
-            """
-          } // dir
-        } // ansiColor
+        dir("/opt/rpc-openstack/") {
+          sh """#!/bin/bash
+          scripts/artifacts-building/containers/build-process.sh
+          """
+        } // dir
       } // withCredentials
     } catch (e) {
       print(e)

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -72,13 +72,11 @@ void install_ansible(){
  *  args: list of string args to pass to ansible-galaxy
  */
 def venvGalaxy(String[] args){
-  ansiColor('xterm'){
-    sh """#!/bin/bash -x
-      which scl && source /opt/rh/python27/enable
-      set +x; . ${env.WORKSPACE}/.venv/bin/activate; set -x
-      ansible-galaxy ${args.join(' ')}
-    """
-  } //color
+  sh """#!/bin/bash -x
+    which scl && source /opt/rh/python27/enable
+    set +x; . ${env.WORKSPACE}/.venv/bin/activate; set -x
+    ansible-galaxy ${args.join(' ')}
+  """
 } //venvGalaxy
 
 /* Run ansible-playbooks within the rpc-gating venv
@@ -93,26 +91,24 @@ def venvGalaxy(String[] args){
  */
 def venvPlaybook(Map args){
   withEnv(get_deploy_script_env()){
-    ansiColor('xterm'){
-      if (!('vars' in args)){
-        args.vars=[:]
-      }
-      if (!('args' in args)){
-        args.args=[]
-      }
-      for (int i=0; i<args.playbooks.size(); i++){
-        String playbook = args.playbooks[i]
-        // randomised vars file path for parallel safety
-        String vars_file="vars.${playbook.split('/')[-1]}.${rand_int_str()}"
-        write_json(file: vars_file, obj: args.vars)
-        sh """#!/bin/bash -x
-          which scl && source /opt/rh/python27/enable
-          set +x; . ${env.WORKSPACE}/.venv/bin/activate; set -x
-          export ANSIBLE_HOST_KEY_CHECKING=False
-          ansible-playbook ${args.args.join(' ')} -e@${vars_file} ${playbook}
-        """
-      } //for
-    } //color
+    if (!('vars' in args)){
+      args.vars=[:]
+    }
+    if (!('args' in args)){
+      args.args=[]
+    }
+    for (int i=0; i<args.playbooks.size(); i++){
+      String playbook = args.playbooks[i]
+      // randomised vars file path for parallel safety
+      String vars_file="vars.${playbook.split('/')[-1]}.${rand_int_str()}"
+      write_json(file: vars_file, obj: args.vars)
+      sh """#!/bin/bash -x
+        which scl && source /opt/rh/python27/enable
+        set +x; . ${env.WORKSPACE}/.venv/bin/activate; set -x
+        export ANSIBLE_HOST_KEY_CHECKING=False
+        ansible-playbook ${args.args.join(' ')} -e@${vars_file} ${playbook}
+      """
+    } //for
   } //withenv
 } //venvplaybook
 
@@ -160,13 +156,11 @@ def openstack_ansible(Map args){
   }
   def full_env = args.environment_vars + get_deploy_script_env()
 
-  ansiColor('xterm'){
-    dir(args.path) {
-      withEnv(full_env){
-        sh """#!/bin/bash
-        openstack-ansible ${args.playbook} ${args.args}
-        """
-      }
+  dir(args.path) {
+    withEnv(full_env){
+      sh """#!/bin/bash
+      openstack-ansible ${args.playbook} ${args.args}
+      """
     }
   }
 }
@@ -834,7 +828,7 @@ List build_creds_array(String list_of_cred_ids){
     ]
 
 
-    // split string into list, reject empty items. 
+    // split string into list, reject empty items.
     List requested_creds = list_of_cred_ids.split(/[, ]+/).findAll({
       it.size() > 0
     })

--- a/pipeline_steps/deploy.groovy
+++ b/pipeline_steps/deploy.groovy
@@ -29,13 +29,11 @@ def deploy_sh(Map args) {
         )
       ]){
         withEnv(environment_vars) {
-          ansiColor('xterm') {
-            dir("/opt/rpc-openstack/") {
-              sh """#!/bin/bash
-              scripts/deploy.sh
-              """
-            } // dir
-          } // ansiColor
+          dir("/opt/rpc-openstack/") {
+            sh """#!/bin/bash
+            scripts/deploy.sh
+            """
+          } // dir
         } // withEnv
       } //withCredentials
     } // stage

--- a/pipeline_steps/irr_role_tests.groovy
+++ b/pipeline_steps/irr_role_tests.groovy
@@ -4,20 +4,18 @@ def run_irr_tests() {
     env.RE_HOOK_ARTIFACT_DIR="${WORKSPACE}/artifacts"
     env.RE_HOOK_RESULT_DIR="${WORKSPACE}/results"
     try {
-      ansiColor('xterm') {
-        dir("${env.WORKSPACE}/${env.ghprbGhRepository}") {
-          stage('Checkout'){
-            print("Triggered by PR: ${env.ghprbPullLink}")
-            common.clone_with_pr_refs()
-          }
-          stage('Execute ./run_tests.sh'){
-            withCredentials(common.get_cloud_creds()) {
-              sh """#!/bin/bash
-              mkdir -p "${RE_HOOK_RESULT_DIR}"
-              mkdir -p "${RE_HOOK_ARTIFACT_DIR}"
-              bash ./run_tests.sh
-              """
-            }
+      dir("${env.WORKSPACE}/${env.ghprbGhRepository}") {
+        stage('Checkout'){
+          print("Triggered by PR: ${env.ghprbPullLink}")
+          common.clone_with_pr_refs()
+        }
+        stage('Execute ./run_tests.sh'){
+          withCredentials(common.get_cloud_creds()) {
+            sh """#!/bin/bash
+            mkdir -p "${RE_HOOK_RESULT_DIR}"
+            mkdir -p "${RE_HOOK_ARTIFACT_DIR}"
+            bash ./run_tests.sh
+            """
           }
         }
       }

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -102,58 +102,56 @@
         currentBuild.result="SUCCESS"
 
         try {{
-          ansiColor('xterm') {{
-            common.withRequestedCredentials(credentials) {{
+          common.withRequestedCredentials(credentials) {{
 
-              stage('Checkout') {{
-                common.clone_with_pr_refs(
-                  "${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}",
-                  env.REPO_URL,
-                  env.BRANCH,
+            stage('Checkout') {{
+              common.clone_with_pr_refs(
+                "${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}",
+                env.REPO_URL,
+                env.BRANCH,
+              )
+            }} // stage
+
+            stage('Execute Pre Script') {{
+              // Retry the 'pre' stage 3 times. The 'pre' stage is considered
+              // to be preparation for the test, so let's try and make sure
+              // it has the best chance of success possible.
+              retry(3) {{
+                sh """#!/bin/bash -xeu
+                  cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
+                  if [[ -e gating/post_merge_test/pre ]]; then
+                    gating/post_merge_test/pre
+                  fi
+                """
+              }}
+            }} // stage
+
+            try{{
+              stage('Execute Run Script') {{
+                sh """#!/bin/bash -xeu
+                  cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
+                  gating/post_merge_test/run
+                """
+              }} // stage
+            }} finally {{
+              stage('Execute Post Script') {{
+                // We do not want the 'post' execution to fail the test,
+                // but we do want to know if it fails so we make it only
+                // return status.
+                post_result = sh(
+                  returnStatus: true,
+                  script: """#!/bin/bash -xeu
+                             cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
+                             if [[ -e gating/post_merge_test/post ]]; then
+                               gating/post_merge_test/post
+                             fi"""
                 )
-              }} // stage
-
-              stage('Execute Pre Script') {{
-                // Retry the 'pre' stage 3 times. The 'pre' stage is considered
-                // to be preparation for the test, so let's try and make sure
-                // it has the best chance of success possible.
-                retry(3) {{
-                  sh """#!/bin/bash -xeu
-                    cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
-                    if [[ -e gating/post_merge_test/pre ]]; then
-                      gating/post_merge_test/pre
-                    fi
-                  """
-                }}
-              }} // stage
-
-              try{{
-                stage('Execute Run Script') {{
-                  sh """#!/bin/bash -xeu
-                    cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
-                    gating/post_merge_test/run
-                  """
-                }} // stage
-              }} finally {{
-                stage('Execute Post Script') {{
-                  // We do not want the 'post' execution to fail the test,
-                  // but we do want to know if it fails so we make it only
-                  // return status.
-                  post_result = sh(
-                    returnStatus: true,
-                    script: """#!/bin/bash -xeu
-                               cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
-                               if [[ -e gating/post_merge_test/post ]]; then
-                                 gating/post_merge_test/post
-                               fi"""
-                  )
-                  if (post_result != 0) {{
-                    print("Post-Merge Test (post) failed with return code ${{post_result}}")
-                  }} // if
-                }} // inner try
-              }} // stage
-            }} // withCredentials
-          }} // ansiColor
+                if (post_result != 0) {{
+                  print("Post-Merge Test (post) failed with return code ${{post_result}}")
+                }} // if
+              }} // inner try
+            }} // stage
+          }} // withCredentials
         }} catch (e) {{
           print(e)
           currentBuild.result="FAILURE"

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -124,63 +124,61 @@
           currentBuild.result="SUCCESS"
 
           try {{
-            ansiColor('xterm') {{
-              common.withRequestedCredentials(credentials) {{
-                stage('Checkout') {{
-                  print("Triggered by PR: ${{env.ghprbPullLink}}")
-                  common.clone_with_pr_refs(
-                    "${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}",
+            common.withRequestedCredentials(credentials) {{
+              stage('Checkout') {{
+                print("Triggered by PR: ${{env.ghprbPullLink}}")
+                common.clone_with_pr_refs(
+                  "${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}",
+                )
+              }} // stage
+
+              stage('Execute Pre Script') {{
+                // Retry the 'pre' stage 3 times. The 'pre' stage is considered
+                // to be preparation for the test, so let's try and make sure
+                // it has the best chance of success possible.
+                retry(3) {{
+                  sh """#!/bin/bash -xeu
+                  cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
+                  if [[ -e gating/pre_merge_test/pre ]]; then
+                    gating/pre_merge_test/pre
+                  fi
+                  """
+                }}
+              }} // stage
+
+              try{{
+                stage('Execute Run Script') {{
+                  sh """#!/bin/bash -xeu
+                  cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
+                  gating/pre_merge_test/run
+                  """
+                }} // stage
+              }} finally {{
+
+                // We implement the post script execution in a finally
+                // block to ensure that it always executes as it is
+                // typically used to collect logs and this needs to
+                // happen whether the run script succeeds or fails.
+
+                stage('Execute Post Script') {{
+                  // We do not want the 'post' execution to fail the test,
+                  // but we do want to know if it fails so we make it only
+                  // return status.
+                  post_result = sh(
+                    returnStatus: true,
+                    script: """#!/bin/bash -xeu
+                               cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
+                               if [[ -e gating/pre_merge_test/post ]]; then
+                                 gating/pre_merge_test/post
+                               fi"""
                   )
+                  if (post_result != 0) {{
+                    print("Pre-Merge Test (post) failed with return code ${{post_result}}")
+                  }} // if
                 }} // stage
 
-                stage('Execute Pre Script') {{
-                  // Retry the 'pre' stage 3 times. The 'pre' stage is considered
-                  // to be preparation for the test, so let's try and make sure
-                  // it has the best chance of success possible.
-                  retry(3) {{
-                    sh """#!/bin/bash -xeu
-                    cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
-                    if [[ -e gating/pre_merge_test/pre ]]; then
-                      gating/pre_merge_test/pre
-                    fi
-                    """
-                  }}
-                }} // stage
-
-                try{{
-                  stage('Execute Run Script') {{
-                    sh """#!/bin/bash -xeu
-                    cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
-                    gating/pre_merge_test/run
-                    """
-                  }} // stage
-                }} finally {{
-
-                  // We implement the post script execution in a finally
-                  // block to ensure that it always executes as it is
-                  // typically used to collect logs and this needs to
-                  // happen whether the run script succeeds or fails.
-
-                  stage('Execute Post Script') {{
-                    // We do not want the 'post' execution to fail the test,
-                    // but we do want to know if it fails so we make it only
-                    // return status.
-                    post_result = sh(
-                      returnStatus: true,
-                      script: """#!/bin/bash -xeu
-                                 cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
-                                 if [[ -e gating/pre_merge_test/post ]]; then
-                                   gating/pre_merge_test/post
-                                 fi"""
-                    )
-                    if (post_result != 0) {{
-                      print("Pre-Merge Test (post) failed with return code ${{post_result}}")
-                    }} // if
-                  }} // stage
-
-                }} // inner try
-              }} // withCredentials
-            }} // ansiColor
+              }} // inner try
+            }} // withCredentials
           }} catch (e) {{
             print(e)
             currentBuild.result="FAILURE"


### PR DESCRIPTION
This plugin uses Jenkins console notes to store color information,
this is hugely inefficient as it involves storing an encoded java
object in every line.

An alternative colourisation approach is to colourise on the client side
using javascript. This has already been implemented, so we can now
remove the server side implementation.

Issue: [RE-1191](https://rpc-openstack.atlassian.net/browse/RE-1191)