### PR TITLE
RE-1228 Patch openstack inventory script

### DIFF
--- a/scripts/ansible_v2_3_2_0_1_contrib_inventory_openstack.py
+++ b/scripts/ansible_v2_3_2_0_1_contrib_inventory_openstack.py
@@ -119,8 +119,12 @@ def get_host_groups(inventory, refresh=False):
 
 
 def append_hostvars(hostvars, groups, key, server, namegroup=False):
+    # NOTE(mattt): Patched locally until
+    #              https://github.com/ansible/ansible/pull/34452 merges
+    #              and we're able to bump to latest 2.3 release.
     hostvars[key] = dict(
         ansible_ssh_host=server['interface_ip'],
+        ansible_host=server['interface_ip'],
         openstack=server)
     for group in get_groups_from_server(server, namegroup=namegroup):
         groups[group].append(key)


### PR DESCRIPTION
The openstack.py bundled w/ ansible 2.3.2.0 does not set a hostvar for
ansible_host, and ansible 2.0 deprecated ansible_ssh_host in favour of
ansible_host.  Using the current inventory script causes problems with
stable/pike's version of repo_server since it uses ansible_host and not
ansible_ssh_host.

Issue: [RE-1228](https://rpc-openstack.atlassian.net/browse/RE-1228)
  
  