### PR TITLE
[RLM-917] Add job to deploy without artifacts

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -15,6 +15,9 @@
     action:
       - deploy:
           FLAVOR: "performance2-15"
+      - deploy_no_artifacts:
+          FLAVOR: "performance2-15"
+          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
@@ -37,6 +40,9 @@
     action:
       - deploy:
           FLAVOR: "performance2-15"
+      - deploy_no_artifacts:
+          FLAVOR: "performance2-15"
+          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 


### PR DESCRIPTION
The RPC artifacting solution is not always going to be useful in all
customer environments. This change adds a job action which will instruct
the RPC-O gate to test without artifacts for the newton.* and master
branches.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [RLM-917](https://rpc-openstack.atlassian.net/browse/RLM-917)