### PR TITLE
RLM-316 Normalise job config for RPC-O artifact options

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -4,7 +4,7 @@
     repo_url: "https://github.com/rcbops/rpc-openstack"
     series: "master"
     branches:
-      - "master"
+      - "master.*"
     skip_pattern: |
       \.md$
       | \.rst$
@@ -22,9 +22,6 @@
     action:
       - deploy:
           FLAVOR: "performance2-15"
-      - deploy_no_artifacts:
-          FLAVOR: "performance2-15"
-          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
@@ -34,7 +31,7 @@
     repo_url: "https://github.com/rcbops/rpc-openstack"
     series: "master"
     branches:
-      - "master"
+      - "master.*"
     image:
       - container:
           SLAVE_TYPE: "container"
@@ -75,9 +72,6 @@
     action:
       - deploy:
           FLAVOR: "performance2-15"
-      - deploy_no_artifacts:
-          FLAVOR: "performance2-15"
-          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
@@ -157,6 +151,10 @@
     image:
       - xenial:
           IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
+      - xenial_loose_artifacts:
+          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+      - xenial_no_artifacts:
+          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
     scenario:
       - "ironic"
       - "swift"
@@ -178,11 +176,15 @@
     image:
       - xenial:
           IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
+      - xenial_loose_artifacts:
+          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+      - xenial_no_artifacts:
+          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
       - trusty:
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
-      - xenial_loose:
-          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
-      - trusty_loose:
+      - trusty_loose_artifacts:
+          IMAGE: "Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)"
+      - trusty_no_artifacts:
           IMAGE: "Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)"
     scenario:
       - "ironic"


### PR DESCRIPTION
In order to improve consistency in job naming and cater
for artifacts being disabled, enabled in 'loose' mode [1][2]
and enabled in 'strict' mode, the configuration has been
updated to use the 'image' part of the job name instead
of mixing up the use of the 'action' and 'image' sections.

The reason to make use of the 'image' section is to allow
the testing of both Xenial and Trusty deployments in these
configurations.

The PR tests for deployment without artifacts have been
removed in order to reduce the PR tests to a minimal
functional set which is least likely to fail. The
variations are all tested in the PM jobs, so it's not
neceesary for the PR coverage too.

The regex for the branch matching for master PR tests is
also updated to cater for all branches prefixed with the
word 'master', rather than only matching 'master'. This
is to ensure that tests are also executed against the
'master-rc' branch.

[1] newton: https://github.com/rcbops/rpc-openstack/pull/2739
[2] pike: https://github.com/rcbops/rpc-openstack/pull/2740

Issue: [RLM-316](https://rpc-openstack.atlassian.net/browse/RLM-316)
  
  