### PR TITLE
RE-1270 Remove PIP from setup_jenkins_slave.yml

### DIFF
--- a/playbooks/setup_jenkins_slave.yml
+++ b/playbooks/setup_jenkins_slave.yml
@@ -78,58 +78,6 @@
         line: 'jenkins ALL=(ALL) NOPASSWD: ALL'
       when: "{{ allow_jenkins_sudo }}"
 
-    - name: Copy constraints file over to cloud server
-      copy:
-        src: "{{ lookup('env', 'WORKSPACE') ~ '/rpc-gating/constraints.txt' }}"
-        dest: "/opt/rpc_gating_constraints.txt"
-
-    - block:
-        - name: Get Modern PIP
-          get_url:
-            url: "https://bootstrap.pypa.io/get-pip.py"
-            dest: "/opt/get-pip.py"
-            force: "yes"
-          register: get_pip
-          until: get_pip | success
-          retries: 5
-          delay: 2
-          tags:
-            - pip-install-script
-
-      rescue:
-        - name: Get Modern PIP using fallback URL
-          get_url:
-            url: "https://raw.githubusercontent.com/pypa/get-pip/master/get-pip.py"
-            dest: "/opt/get-pip.py"
-            force: "yes"
-          when: get_pip | failed
-          register: get_pip_fallback
-          until: get_pip_fallback | success
-          retries: 5
-          delay: 2
-          tags:
-            - pip-install-script
-
-    - block:
-        - name: Install PIP
-          shell: |
-            python /opt/get-pip.py -c /opt/rpc_gating_constraints.txt
-          register: pip_install
-          until: pip_install | success
-          retries: 3
-          delay: 2
-
-      rescue:
-        - name: Install PIP (fall back mode)
-          shell: |
-            python /opt/get-pip.py --isolated -c /opt/rpc_gating_constraints.txt
-          register: pip_install_fall_back
-          until: pip_install_fall_back | success
-          retries: 3
-          delay: 2
-
-
-      # pip module didn't work here as it couldn't locate the virtualenv binary
     - name: Start slave
       delegate_to: localhost
       shell: |


### PR DESCRIPTION
As far as I can tell, there's no reason for this to happen any more.

This came to light testing the new rpc-openstack MNAIO jobs -- when run
through jenkins (where we install pip w/ rpc-gating's constraints file)
ansible failed to run with the following error:

```
ContextualVersionConflict: (cryptography 1.2.3 (/usr/lib/python2.7/dist-packages), Requirement.parse('cryptography>=1.5'), set(['paramiko']))
```

When testing manually (without installing pip w/ constraints), a newer
version of setuptools is installed and doesn't cause ansible to throw
that error.  The version of cryptography is still problematic but
ansible seems to be able to handle it internally and works as expected.

Issue: [RE-1270](https://rpc-openstack.atlassian.net/browse/RE-1270)