### PR TITLE
RE-1269 Remove trusty/ironic PM tests

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -214,6 +214,14 @@
     action:
       - deploy:
           FLAVOR: "7"
+    exclude:
+      - scenario: ironic
+        image: trusty
+      - scenario: ironic
+        image: trusty_loose_artifacts
+      - scenario: ironic
+        image: trusty_no_artifacts
+
     # This is the build that will be triggered by the push trigger job
     trigger_build: 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
     jobs:


### PR DESCRIPTION
The ironic tests are currently failing across the board
and until the issues are resolved they are just wasting
resources. Trusty is not intended to be a supported
platform for ironic deployments in RPC-O.

This patch removes all the trusty/ironic PM jobs.

Issue: [RE-1269](https://rpc-openstack.atlassian.net/browse/RE-1269)