### PR TITLE
[CEPHSTORA-53] Add Ceph/Keystone integration Job

### DIFF
--- a/rpc_jobs/irr_role_test.yml
+++ b/rpc_jobs/irr_role_test.yml
@@ -52,6 +52,7 @@
           IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
     context:
       - master
+      - ceph_keystone
     jobs:
       - 'RPC-IRR_{repo}-{series}-{image}-{context}'
 


### PR DESCRIPTION
This PR adds a ceph_keystone IRR_CONTEXT for the rpc-ceph repo. This
will be used to test ceph RGW/keystone integration.

Issue: [CEPHSTORA-53](https://rpc-openstack.atlassian.net/browse/CEPHSTORA-53)