### PR TITLE
remove the  release-script job

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -89,7 +89,6 @@
       - "ansible-lint"
       - "bashate"
       - "flake8"
-      - "release-script"
       - "releasenotes"
     action:
       - "tox-test"


### PR DESCRIPTION
It is not used anymore.  Stop testing it so the code itself can be
removed.