### PR TITLE
RE-1275 Add rpc-ceph premerge standard jobs

### DIFF
--- a/rpc_jobs/rpc_ceph.yml
+++ b/rpc_jobs/rpc_ceph.yml
@@ -1,17 +1,40 @@
- - project:
-    name: "rpc-ceph-post-merge"
+- project:
+    name: "rpc-ceph-pre-merge"
 
     repo_name: "rpc-ceph"
-    # URL of the rpc-octavia repository
     repo_url: "https://github.com/rcbops/rpc-ceph"
 
-    # currently we only do master. Once RPC-O switches
-    # to Pike we will retire os-octavia and use the
-    # upstream installer
     branches:
       - "master"
 
-    # Use image for RPC-O install
+    image:
+      - xenial:
+          FLAVOR: "general1-8"
+          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+
+    # rpc-ceph ignores that setting for now
+    scenario:
+      - "functional"
+
+    # rpc-ceph ignores that setting for now
+    action:
+      - "test"
+
+    jira_project_key: "CEPHSTORA"
+
+    # Required to properly test deployment of rpc-maas
+    credentials: "cloud_creds"
+
+    # Link to the standard pre-merge-template
+    jobs:
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
+
+- project:
+    name: "rpc-ceph-post-merge"
+
+    repo_name: "rpc-ceph"
+    repo_url: "https://github.com/rcbops/rpc-ceph"
+
     image:
       - xenial:
           FLAVOR: "general1-8"


### PR DESCRIPTION
This commit updates rpc_jobs/rpc_ceph.yml by adding a pre-merge test.
Additionally, it updates the postmerge project by removing some
references to rpc-octavia.

Once we are sure this premerge test works we can remove rpc-ceph from
rpc_jobs/irr_role_test.yml.

Issue: [RE-1275](https://rpc-openstack.atlassian.net/browse/RE-1275)