### PR TITLE
RE-1275 Remove rpc-ceph IRR job

### DIFF
--- a/rpc_jobs/irr_role_test.yml
+++ b/rpc_jobs/irr_role_test.yml
@@ -55,21 +55,6 @@
     jobs:
       - 'RPC-IRR_{repo}-{series}-{image}-{context}'
 
-- project:
-    name: "RPC-Ceph-Jobs"
-    repo:
-      - rpc-ceph:
-          irr_repo_url: https://github.com/rcbops/rpc-ceph
-    series:
-      - master
-    image:
-      - xenial:
-          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
-    context:
-      - master
-    jobs:
-      - 'RPC-IRR_{repo}-{series}-{image}-{context}'
-
 
 - job-template:
     # DEFAULTS


### PR DESCRIPTION
This commit removes the legacy rpc-ceph IRR job.

Please do not merge until after [1] merges.

[1] https://github.com/rcbops/rpc-gating/pull/598

Issue: [RE-1275](https://rpc-openstack.atlassian.net/browse/RE-1275)