### PR TITLE
RE-1191 Control Log Storage v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
    - ansible-playbook (pip/ansible)
 
 
-## Naming Conventions
+# Conventions
+## Naming
 ### Files
 - Use `_` as the word delimiter
 - All lowercase
@@ -33,3 +34,23 @@
   - `RPC-AIO_{series}-{image}-{action}-{scenario}-{ztrigger}`
   - `RPC-AIO_master-xenial-deploy-swift-periodic`
   - `Merge-Trigger-JJB`
+
+
+## Required Properties
+### Retention Policy
+Every Job must have a retention policy either based on days or number of builds.
+
+Example job with number of builds retention policy:
+```
+  - job:
+      properties:
+        - build-discarder:
+            num-to-keep: 30
+```
+Example job with number of days retention policy:
+```
+  - job:
+      properties:
+        - build-discarder:
+            days-to-keep: 30
+```

--- a/job_dsl/dep_update.groovy
+++ b/job_dsl/dep_update.groovy
@@ -2,7 +2,7 @@
 // as this file won't be templated by JJB.
 // Alternative is to use parameters with JJB vars as the defaults.
 library "rpc-gating@${RPC_GATING_BRANCH}"
-common.shared_slave(){
+common.globalWraps(){
   try {
     stage("Configure Git"){
       common.configure_git()
@@ -66,4 +66,4 @@ common.shared_slave(){
     } // if
     throw e
   } // try
-} // shared_slave
+} // globalWraps

--- a/job_dsl/release.groovy
+++ b/job_dsl/release.groovy
@@ -1,6 +1,5 @@
 library "rpc-gating@${RPC_GATING_BRANCH}"
-common.shared_slave(){
-
+common.globalWraps(){
   stage("Configure Git"){
     common.configure_git()
   }
@@ -37,4 +36,4 @@ common.shared_slave(){
       } // sshagent
     } // withCredentials
   } // stage
-}
+} // globalWraps

--- a/lint.sh
+++ b/lint.sh
@@ -25,6 +25,7 @@ create_jjb_ini(){
   echo -e "[jenkins]\nurl=http://127.0.0.1:8080" > lint_jjb.ini
 }
 
+# Check JJB for syntax
 check_jjb(){
   which jenkins-jobs >/dev/null \
     || { echo "jenkins-jobs unavailble, please install jenkins-job-builder from pip"
@@ -87,18 +88,21 @@ check_bash(){
   done < <(find ${fargs[@]} -iname \*.sh)
 }
 
-check_naming_standards() {
+check_jjb_lint() {
+  # Check JJB for internal standards:
+  #   * naming conventions
+  #   * retention policy
   # Limits lint to only gating unique files
   # Excludes webhooktranslator as it has additional packaging
-  # and it's own tox
+  # and its own tox.
   # Excludes NonCPS.groovy as this filename is required, but
   # not matching rpc-gating conventions
   dirs_to_lint="pipeline_steps,rpc_jobs,scripts"
   exclude_files="NonCPS.groovy"
-  python scripts/lint_naming_conventions.py \
+  python scripts/lint_jjb.py \
     --dirs ${dirs_to_lint} --exclude ${exclude_files} \
-    && echo "Naming conventions: OK" \
-    || { echo "Naming conventions: FAIL"; rc=1; }
+    && echo "JJB Lint: OK" \
+    || { echo "JJB Lint: FAIL"; rc=1; }
 }
 
 check_python(){
@@ -166,7 +170,7 @@ check_groovy
 check_ansible
 check_bash
 check_python
-check_naming_standards
+check_jjb_lint
 check_webhooktranslator
 
 if [[ $rc == 0 ]]

--- a/rpc_jobs/build_gating_venv.yml
+++ b/rpc_jobs/build_gating_venv.yml
@@ -4,6 +4,8 @@
     concurrent: false
     properties:
       - rpc-gating-github
+      - build-discarder:
+          days-to-keep: 7
     triggers:
       - github # triggered post merge, not on PR
     parameters:

--- a/rpc_jobs/build_gating_venv.yml
+++ b/rpc_jobs/build_gating_venv.yml
@@ -10,109 +10,112 @@
       - rpc_gating_params
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
-      //common.shared_slave(){
-      //can't use common.shared_slave as it calls install_ansible,
-      //which calls this job.
-      lock('build_gating_venv'){
-        node('pubcloud_multiuse'){
-          try{
-            deleteDir()
-            common.clone_with_pr_refs('rpc-gating',
-                                      'git@github.com:rcbops/rpc-gating',
-                                      env.RPC_GATING_BRANCH)
-            dir('rpc-gating'){
-              // run in docker to ensure all the required apt packages are available
-              container = docker.build env.BUILD_TAG.toLowerCase()
-            }
-            // Venv is build within docker as it requires extra packages
-            container.inside{
-              sh """#!/bin/bash -xeu
-
-              # Install virtualenv if required
-              if [[ ! -d ".venv" ]]; then
-                requirements="virtualenv==15.1.0"
-                pip install -U "\${requirements}" \
-                  || pip install --isolated -U "\${requirements}"
-
-                if which scl
-                then
-                  # redhat/centos
-                  source /opt/rh/python27/enable
-                  virtualenv --no-pip --no-setuptools --no-wheel --python=/opt/rh/python27/root/usr/bin/python .venv
-                  # hack the selinux module into the venv
-                  cp -r /usr/lib64/python2.6/site-packages/selinux .venv/lib64/python2.7/site-packages/ ||:
-                else
-                  virtualenv --no-pip --no-setuptools --no-wheel .venv
-                fi
-              fi
-
-              # Install Pip
-              set +xeu
-              source .venv/bin/activate
-              set -xeu
-
-              # UG-613 change TMPDIR to directory with more space
-              export TMPDIR="/var/lib/jenkins/tmp"
-
-              # If the pip version we're using is not the same as the constraint then replace it
-              PIP_TARGET="\$(awk -F= '/^pip==/ {print \$3}' rpc-gating/constraints.txt)"
-              VENV_PYTHON=".venv/bin/python"
-              VENV_PIP=".venv/bin/pip"
-              if [[ "\$(\${VENV_PIP} --version)" != "pip \${PIP_TARGET}"* ]]; then
-                # Install a known version of pip, setuptools, and wheel in the venv
-                CURL_CMD="curl --silent --show-error --retry 5"
-                OUTPUT_FILE="get-pip.py"
-                \${CURL_CMD} https://bootstrap.pypa.io/get-pip.py > \${OUTPUT_FILE} \
-                  || \${CURL_CMD} https://raw.githubusercontent.com/pypa/get-pip/master/get-pip.py > \${OUTPUT_FILE}
-                GETPIP_OPTIONS="pip setuptools wheel --constraint rpc-gating/constraints.txt"
-                \${VENV_PYTHON} \${OUTPUT_FILE} \${GETPIP_OPTIONS} \
-                  || \${VENV_PYTHON} \${OUTPUT_FILE} --isolated \${GETPIP_OPTIONS}
-              fi
-
-              # Install rpc-gating requirements
-              PIP_OPTIONS="-c rpc-gating/constraints.txt -r rpc-gating/requirements.txt"
-              \${VENV_PIP} install \${PIP_OPTIONS} \
-                || \${VENV_PIP} install --isolated \${PIP_OPTIONS}
-
-              # Install ansible roles
-              mkdir -p rpc-gating/playbooks/roles
-              ansible-galaxy install -r rpc-gating/role_requirements.yml -p rpc-gating/playbooks/roles
-              """
-            } // container
-
-            // venv is pushed to rpc repo from outside docker container, as binding
-            // credentials files does not work within docker (used for ssh key)
-            withCredentials(artifact_build.get_rpc_repo_creds()) {
-              sh """#!/bin/bash -xeu
-                # Tar venv and roles
-                pushd rpc-gating
-                  SHA=\$(git rev-parse HEAD)
-                popd
-                archive="rpcgatingvenv_\${SHA}.tbz"
-                find .venv -name \\*.pyc -delete
-                echo "\${PWD}/.venv" > .venv/original_venv_path
-                echo \$SHA > .venv/venv_sha
-                tar cjfp \$archive .venv rpc-gating/playbooks/roles
-
-                # Add ssh host key
-                grep "\${REPO_HOST}" ~/.ssh/known_hosts \
-                  || echo "\${REPO_HOST} \$(cat \$REPO_HOST_PUBKEY)" \
-                  >> ~/.ssh/known_hosts
-
-                REPO_PATH="/var/www/repo/rpcgating/venvs"
-
-                # Upload generated version
-                scp -i \$REPO_USER_KEY \$archive \$REPO_USER@\$REPO_HOST:\$REPO_PATH
-
-                # Generate index
-                ssh -i \$REPO_USER_KEY \$REPO_USER@\$REPO_HOST "cd \$REPO_PATH; ls -1 *tbz > index"
-
-                # Keep 10 newest archives, remove the rest.
-                ssh -i \$REPO_USER_KEY \$REPO_USER@\$REPO_HOST "cd \$REPO_PATH && ls -t1 *tbz |tail -n +11 |while read f; do echo "'removing \$f'"; rm "'\$f'"; done"
-              """
-            }
-          } finally {
+      timestamps {
+        // common.shared_slave(){
+        // can't use common.shared_slave as it calls install_ansible,
+        // which calls this job.
+        // can't use globalWraps because it calls common.shared_slave
+        lock('build_gating_venv'){
+          node('pubcloud_multiuse'){
+            try{
               deleteDir()
-          } // try
-        } // node pubcloud_multiuse
-      } // lock
+              common.clone_with_pr_refs('rpc-gating',
+                                        'git@github.com:rcbops/rpc-gating',
+                                        env.RPC_GATING_BRANCH)
+              dir('rpc-gating'){
+                // run in docker to ensure all the required apt packages are available
+                container = docker.build env.BUILD_TAG.toLowerCase()
+              }
+              // Venv is build within docker as it requires extra packages
+              container.inside{
+                sh """#!/bin/bash -xeu
+
+                # Install virtualenv if required
+                if [[ ! -d ".venv" ]]; then
+                  requirements="virtualenv==15.1.0"
+                  pip install -U "\${requirements}" \
+                    || pip install --isolated -U "\${requirements}"
+
+                  if which scl
+                  then
+                    # redhat/centos
+                    source /opt/rh/python27/enable
+                    virtualenv --no-pip --no-setuptools --no-wheel --python=/opt/rh/python27/root/usr/bin/python .venv
+                    # hack the selinux module into the venv
+                    cp -r /usr/lib64/python2.6/site-packages/selinux .venv/lib64/python2.7/site-packages/ ||:
+                  else
+                    virtualenv --no-pip --no-setuptools --no-wheel .venv
+                  fi
+                fi
+
+                # Install Pip
+                set +xeu
+                source .venv/bin/activate
+                set -xeu
+
+                # UG-613 change TMPDIR to directory with more space
+                export TMPDIR="/var/lib/jenkins/tmp"
+
+                # If the pip version we're using is not the same as the constraint then replace it
+                PIP_TARGET="\$(awk -F= '/^pip==/ {print \$3}' rpc-gating/constraints.txt)"
+                VENV_PYTHON=".venv/bin/python"
+                VENV_PIP=".venv/bin/pip"
+                if [[ "\$(\${VENV_PIP} --version)" != "pip \${PIP_TARGET}"* ]]; then
+                  # Install a known version of pip, setuptools, and wheel in the venv
+                  CURL_CMD="curl --silent --show-error --retry 5"
+                  OUTPUT_FILE="get-pip.py"
+                  \${CURL_CMD} https://bootstrap.pypa.io/get-pip.py > \${OUTPUT_FILE} \
+                    || \${CURL_CMD} https://raw.githubusercontent.com/pypa/get-pip/master/get-pip.py > \${OUTPUT_FILE}
+                  GETPIP_OPTIONS="pip setuptools wheel --constraint rpc-gating/constraints.txt"
+                  \${VENV_PYTHON} \${OUTPUT_FILE} \${GETPIP_OPTIONS} \
+                    || \${VENV_PYTHON} \${OUTPUT_FILE} --isolated \${GETPIP_OPTIONS}
+                fi
+
+                # Install rpc-gating requirements
+                PIP_OPTIONS="-c rpc-gating/constraints.txt -r rpc-gating/requirements.txt"
+                \${VENV_PIP} install \${PIP_OPTIONS} \
+                  || \${VENV_PIP} install --isolated \${PIP_OPTIONS}
+
+                # Install ansible roles
+                mkdir -p rpc-gating/playbooks/roles
+                ansible-galaxy install -r rpc-gating/role_requirements.yml -p rpc-gating/playbooks/roles
+                """
+              } // container
+
+              // venv is pushed to rpc repo from outside docker container, as binding
+              // credentials files does not work within docker (used for ssh key)
+              withCredentials(artifact_build.get_rpc_repo_creds()) {
+                sh """#!/bin/bash -xeu
+                  # Tar venv and roles
+                  pushd rpc-gating
+                    SHA=\$(git rev-parse HEAD)
+                  popd
+                  archive="rpcgatingvenv_\${SHA}.tbz"
+                  find .venv -name \\*.pyc -delete
+                  echo "\${PWD}/.venv" > .venv/original_venv_path
+                  echo \$SHA > .venv/venv_sha
+                  tar cjfp \$archive .venv rpc-gating/playbooks/roles
+
+                  # Add ssh host key
+                  grep "\${REPO_HOST}" ~/.ssh/known_hosts \
+                    || echo "\${REPO_HOST} \$(cat \$REPO_HOST_PUBKEY)" \
+                    >> ~/.ssh/known_hosts
+
+                  REPO_PATH="/var/www/repo/rpcgating/venvs"
+
+                  # Upload generated version
+                  scp -i \$REPO_USER_KEY \$archive \$REPO_USER@\$REPO_HOST:\$REPO_PATH
+
+                  # Generate index
+                  ssh -i \$REPO_USER_KEY \$REPO_USER@\$REPO_HOST "cd \$REPO_PATH; ls -1 *tbz > index"
+
+                  # Keep 10 newest archives, remove the rest.
+                  ssh -i \$REPO_USER_KEY \$REPO_USER@\$REPO_HOST "cd \$REPO_PATH && ls -t1 *tbz |tail -n +11 |while read f; do echo "'removing \$f'"; rm "'\$f'"; done"
+                """
+              }
+            } finally {
+                deleteDir()
+            } // try
+          } // node pubcloud_multiuse
+        } // lock
+      } // timestamps

--- a/rpc_jobs/cloud_image_build.yml
+++ b/rpc_jobs/cloud_image_build.yml
@@ -10,22 +10,22 @@
       - rpc_gating_params
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
+      common.globalWraps(){
 
-      // These are defined statically instead of parameters
-      // to ensure that the job is always executed the same
-      // way.
-      env.FLAVOR = "performance1-1"
-      env.STAGES = "Allocate Resources, Cleanup"
-      image_list = [
-        [ src: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)",
-          dest: "Ubuntu 16.04 LTS prepared for RPC deployment" ],
-        [ src: "Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)",
-          dest: "Ubuntu 14.04 LTS prepared for RPC deployment" ]
-      ]
-      region_list = [
-        "DFW", "HKG", "IAD", "ORD", "SYD"
-      ]
-      common.shared_slave(){
+        // These are defined statically instead of parameters
+        // to ensure that the job is always executed the same
+        // way.
+        env.FLAVOR = "performance1-1"
+        env.STAGES = "Allocate Resources, Cleanup"
+        image_list = [
+          [ src: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)",
+            dest: "Ubuntu 16.04 LTS prepared for RPC deployment" ],
+          [ src: "Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)",
+            dest: "Ubuntu 14.04 LTS prepared for RPC deployment" ]
+        ]
+        region_list = [
+          "DFW", "HKG", "IAD", "ORD", "SYD"
+        ]
         try {
           currentBuild.result = "SUCCESS"
           // Define the parallel build map
@@ -53,5 +53,5 @@
           print e
           currentBuild.result = "FAILURE"
           throw e
-        }
-      }
+        } // try
+      } // globalWraps

--- a/rpc_jobs/influx.yml
+++ b/rpc_jobs/influx.yml
@@ -53,6 +53,8 @@
 
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
-      common.internal_slave(){
-        influx.setup()
-      } // cit node
+      common.globalWraps(){
+        common.internal_slave(){
+          influx.setup()
+        } // cit node
+      } // globalWraps

--- a/rpc_jobs/install_jenkins_plugins.yml
+++ b/rpc_jobs/install_jenkins_plugins.yml
@@ -2,6 +2,9 @@
     name: 'Install-Jenkins-Plugins'
     project-type: workflow
     concurrent: false
+    properties:
+      - build-discarder:
+          days-to-keep: 7
     parameters:
       # See params.yml
       - rpc_gating_params

--- a/rpc_jobs/install_jenkins_plugins.yml
+++ b/rpc_jobs/install_jenkins_plugins.yml
@@ -7,7 +7,7 @@
       - rpc_gating_params
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
-      common.shared_slave(){ // CIT slave node
+      common.globalWraps(){
         withCredentials([
           usernamePassword(
             credentialsId: "service_account_jenkins_api_creds",
@@ -22,4 +22,4 @@
             )
           } //dir
         } // withCredentials
-      } // CIT slave node
+      } // globalWraps

--- a/rpc_jobs/irr_role_test.yml
+++ b/rpc_jobs/irr_role_test.yml
@@ -107,8 +107,8 @@
 
     dsl: |
       library "rpc-gating@${{RPC_GATING_BRANCH}}"
-      timeout(time: 5, unit: 'HOURS'){{
-        common.shared_slave() {{
-            irr_role_tests.run_irr_tests()
-        }} // cit node
-      }} // timeout
+      common.globalWraps(){{
+        timeout(time: 5, unit: 'HOURS'){{
+          irr_role_tests.run_irr_tests()
+        }} // timeout
+      }} // globalWraps

--- a/rpc_jobs/jjb_setup.yml
+++ b/rpc_jobs/jjb_setup.yml
@@ -29,8 +29,9 @@
     name: 'Jenkins-Job-Builder'
     project-type: workflow
     description: Creates and updates jobs with Jenkins Job Builder.
-    build-discarder:
-        days-to-keep: 20
+    properties:
+      - build-discarder:
+          days-to-keep: 20
     parameters:
         - string:
             name: JOBS

--- a/rpc_jobs/jjb_setup.yml
+++ b/rpc_jobs/jjb_setup.yml
@@ -39,21 +39,22 @@
         - rpc_gating_params
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
-      common.internal_slave(){
-        try {
-          dir("rpc-gating"){
-            stage('Run JJB'){
-              withCredentials([
-                usernamePassword(
-                  credentialsId: "service_account_jenkins_api_creds",
-                  usernameVariable: "JENKINS_USER",
-                  passwordVariable: "JENKINS_API_PASSWORD"
-                )
-              ]){
-                sh """#!/bin/bash -xe
-                  source ../.venv/bin/activate
+      common.globalWraps(){
+        common.internal_slave(){
+          try {
+            dir("rpc-gating"){
+              stage('Run JJB'){
+                withCredentials([
+                  usernamePassword(
+                    credentialsId: "service_account_jenkins_api_creds",
+                    usernameVariable: "JENKINS_USER",
+                    passwordVariable: "JENKINS_API_PASSWORD"
+                  )
+                ]){
+                  sh """#!/bin/bash -xe
+                    source ../.venv/bin/activate
 
-                  cat > jenkins_jobs.ini << EOF
+                    cat > jenkins_jobs.ini << EOF
       [job-builder]
       ignore_cache=False
       keep_descriptions=False
@@ -66,30 +67,31 @@
       url=${JENKINS_URL}
       EOF
 
-                  if [[ "$RPC_GATING_BRANCH" == "master" ]] && [[ "$JOBS" == "-r rpc_jobs" ]]; then
-                      echo "Setting --delete-old as RPC_GATING_BRANCH=master and JOBS='-r rpc_jobs'"
-                      UPDATE_ARGS="--delete-old"
-                  fi
+                    if [[ "$RPC_GATING_BRANCH" == "master" ]] && [[ "$JOBS" == "-r rpc_jobs" ]]; then
+                        echo "Setting --delete-old as RPC_GATING_BRANCH=master and JOBS='-r rpc_jobs'"
+                        UPDATE_ARGS="--delete-old"
+                    fi
 
-                  jenkins-jobs --conf jenkins_jobs.ini \
-                               --user $JENKINS_USER \
-                               --password $JENKINS_API_PASSWORD \
-                               --ignore-cache \
-                               \$JJB_ARGS update \$UPDATE_ARGS $JOBS
-                """
+                    jenkins-jobs --conf jenkins_jobs.ini \
+                                 --user $JENKINS_USER \
+                                 --password $JENKINS_API_PASSWORD \
+                                 --ignore-cache \
+                                 \$JJB_ARGS update \$UPDATE_ARGS $JOBS
+                  """
+                }
               }
             }
-          }
-        } catch(e) {
-          print(e)
-          // Here we only create a JIRA issue when we are not running the job
-          // against a testing branch or against a specific job
-          if (env.RPC_GATING_BRANCH == "master" && env.JOBS == "-r rpc_jobs") {
-            common.create_jira_issue("RE",
-                                     env.BUILD_TAG,
-                                     env.BUILD_URL,
-                                     "Task")
-          }
-          throw e
-        }
-      }
+          } catch(e) {
+            print(e)
+            // Here we only create a JIRA issue when we are not running the job
+            // against a testing branch or against a specific job
+            if (env.RPC_GATING_BRANCH == "master" && env.JOBS == "-r rpc_jobs") {
+              common.create_jira_issue("RE",
+                                       env.BUILD_TAG,
+                                       env.BUILD_URL,
+                                       "Task")
+            }
+            throw e
+          } // catch
+        } // internal_slave
+      } // globalWraps

--- a/rpc_jobs/long_running_slave.yml
+++ b/rpc_jobs/long_running_slave.yml
@@ -33,7 +33,7 @@
 
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
-      common.shared_slave(){
+      common.globalWraps(){
           dir("rpc-maas"){
             git branch: env.RPC_MAAS_BRANCH, url: env.RPC_MAAS_REPO
           }
@@ -95,4 +95,4 @@
             // this doesn't run by default as cleanup isn't included in stages
             pubcloud.delPubCloudSlave(instance_name: instance_name)
           }
-      } // cit node
+      } // globalWraps

--- a/rpc_jobs/ops_fabric_analytics.yml
+++ b/rpc_jobs/ops_fabric_analytics.yml
@@ -23,7 +23,7 @@
           status-context: 'ops-fabric-analytics-gate'
     dsl: |
       library "rpc-gating@${env.RPC_GATING_BRANCH}"
-      common.shared_slave(){
+      common.globalWraps(){
         common.clone_with_pr_refs()
         stage("Build Docker Image"){
             analytics_container = docker.build env.BUILD_TAG.toLowerCase()
@@ -37,4 +37,4 @@
             }
           } // timeout
         } // docker container
-      } // shared_slave
+      } // globalWraps

--- a/rpc_jobs/ops_fabric_chatbot.yml
+++ b/rpc_jobs/ops_fabric_chatbot.yml
@@ -23,7 +23,7 @@
           status-context: 'ops-fabric-chatbot-gate'
     dsl: |
       library "rpc-gating@${env.RPC_GATING_BRANCH}"
-      common.shared_slave(){
+      common.globalWraps(){
         common.clone_with_pr_refs()
         stage("Build Docker Image"){
             chatbot_container = docker.build env.BUILD_TAG.toLowerCase()
@@ -48,4 +48,4 @@
             }
           } // timeout
         } // docker container
-      } // shared_slave
+      } // global wraps

--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -25,6 +25,7 @@
           days-to-keep: 3
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
+
       // Get list of jenkins slaves
       @NonCPS
       def getLongRunningNodes() {
@@ -40,82 +41,84 @@
         }
       }
 
-      // run node cleanups on all nodes
-      def nodes = getLongRunningNodes()
-      def parallel_steps = [:]
-      for (int i=0; i<nodes.size(); i++){
-        nodeName = nodes[i]
-        parallel_steps['node_'+nodeName] = {
-          common.use_node(nodeName){
-            try {
-              stage("Cleanup "+nodeName){
-                dir("rpc-gating") {
-                  sh "scripts/workspace_cleanup.sh"
-                  sh "scripts/tmp_cleanup.sh"
-                  sh "scripts/docker_cleanup.sh"
+      common.globalWraps(){
+        // run node cleanups on all nodes
+        def nodes = getLongRunningNodes()
+        def parallel_steps = [:]
+        for (int i=0; i<nodes.size(); i++){
+          nodeName = nodes[i]
+          parallel_steps['node_'+nodeName] = {
+            common.use_node(nodeName){
+              try {
+                stage("Cleanup "+nodeName){
+                  dir("rpc-gating") {
+                    sh "scripts/workspace_cleanup.sh"
+                    sh "scripts/tmp_cleanup.sh"
+                    sh "scripts/docker_cleanup.sh"
+                  }
                 }
+              } catch(e) {
+                print(e)
+                common.create_jira_issue("RE",
+                                         env.BUILD_TAG,
+                                         env.BUILD_URL,
+                                         "Task")
+                throw e
               }
-            } catch(e) {
-              print(e)
-              common.create_jira_issue("RE",
-                                       env.BUILD_TAG,
-                                       env.BUILD_URL,
-                                       "Task")
-              throw e
             }
           }
         }
-      }
-      parallel parallel_steps
+        parallel parallel_steps
 
-      // run the pubcloud and jenkins node cleanup only on an internal slave
-      common.internal_slave(){
-        try {
-          dir("rpc-gating") {
-            stage("Docker Build"){
-                common.docker_cache_workaround()
-                container = docker.build env.BUILD_TAG.toLowerCase()
-            }
-            // container.inside is a docker function that does
-            // not run the same initialisaiton steps as
-            // common.use_node/shared_slave/internal_slave.
-            container.inside {
-              stage("Docker Checkout"){
-                git branch: env.RPC_GATING_BRANCH, url: "https://github.com/rcbops/rpc-gating"
+        // run the pubcloud and jenkins node cleanup only on an internal slave
+        common.internal_slave(){
+          try {
+            dir("rpc-gating") {
+              stage("Docker Build"){
+                  common.docker_cache_workaround()
+                  container = docker.build env.BUILD_TAG.toLowerCase()
               }
-              stage("Public Cloud Cleanup"){
-                withCredentials([
-                  string(
-                    credentialsId: "dev_pubcloud_username",
-                    variable: "PUBCLOUD_USERNAME"
-                  ),
-                  string(
-                    credentialsId: "dev_pubcloud_api_key",
-                    variable: "PUBCLOUD_API_KEY"
-                  ),
-                  usernamePassword(
-                    credentialsId: "service_account_jenkins_api_creds",
-                    usernameVariable: "JENKINS_USERNAME",
-                    passwordVariable: "JENKINS_API_KEY"
-                  ),
-                ]){
-                  clouds_cfg = common.writeCloudsCfg(
-                    username: env.PUBCLOUD_USERNAME,
-                    api_key: env.PUBCLOUD_API_KEY,
-                  )
-                  withEnv(["OS_CLIENT_CONFIG_FILE=${clouds_cfg}"]){
-                    sh "python scripts/periodic_cleanup.py"
+              // container.inside is a docker function that does
+              // not run the same initialisaiton steps as
+              // common.use_node/shared_slave/internal_slave.
+              container.inside {
+                stage("Docker Checkout"){
+                  git branch: env.RPC_GATING_BRANCH, url: "https://github.com/rcbops/rpc-gating"
+                }
+                stage("Public Cloud Cleanup"){
+                  withCredentials([
+                    string(
+                      credentialsId: "dev_pubcloud_username",
+                      variable: "PUBCLOUD_USERNAME"
+                    ),
+                    string(
+                      credentialsId: "dev_pubcloud_api_key",
+                      variable: "PUBCLOUD_API_KEY"
+                    ),
+                    usernamePassword(
+                      credentialsId: "service_account_jenkins_api_creds",
+                      usernameVariable: "JENKINS_USERNAME",
+                      passwordVariable: "JENKINS_API_KEY"
+                    ),
+                  ]){
+                    clouds_cfg = common.writeCloudsCfg(
+                      username: env.PUBCLOUD_USERNAME,
+                      api_key: env.PUBCLOUD_API_KEY,
+                    )
+                    withEnv(["OS_CLIENT_CONFIG_FILE=${clouds_cfg}"]){
+                      sh "python scripts/periodic_cleanup.py"
+                    }
                   }
                 }
               }
             }
+          } catch(e) {
+            print(e)
+            common.create_jira_issue("RE",
+                                     env.BUILD_TAG,
+                                     env.BUILD_URL,
+                                     "Task")
+            throw e
           }
-        } catch(e) {
-          print(e)
-          common.create_jira_issue("RE",
-                                   env.BUILD_TAG,
-                                   env.BUILD_URL,
-                                   "Task")
-          throw e
-        }
-      }
+        } // internal_slave
+      } // globalWraps

--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -41,6 +41,8 @@
         }
       }
 
+      // end of functions
+
       common.globalWraps(){
         // run node cleanups on all nodes
         def nodes = getLongRunningNodes()

--- a/rpc_jobs/phobos.yml
+++ b/rpc_jobs/phobos.yml
@@ -89,7 +89,7 @@
         } // sshagent
       }
       library "rpc-gating@${RPC_GATING_BRANCH}"
-      timestamps(){
+      common.globalWraps(){
         common.use_node("deploy-phobos"){
           try {
             withCredentials([
@@ -125,7 +125,6 @@
                   # log current HEAD
                   git show
                   git status
-  
                   pushd openstack-ansible
                     sudo git stash
                     sudo git reset --hard
@@ -198,4 +197,4 @@
             """
           }
         } // phobos node
-      } // timestamps
+      } // globalWraps

--- a/rpc_jobs/phobos.yml
+++ b/rpc_jobs/phobos.yml
@@ -45,6 +45,8 @@
             Tokens can be obtained from pitchfork.
 
     dsl: |
+      library "rpc-gating@${RPC_GATING_BRANCH}"
+
       void slack_notify(message, color){
         if(env.SLACK_NOTIFICATIONS == "true"){
           msg_plus_link="${message} (${env.BUILD_URL})"
@@ -88,7 +90,9 @@
           } // retry
         } // sshagent
       }
-      library "rpc-gating@${RPC_GATING_BRANCH}"
+
+      // end of functions
+
       common.globalWraps(){
         common.use_node("deploy-phobos"){
           try {

--- a/rpc_jobs/pull_request_issue_link.yml
+++ b/rpc_jobs/pull_request_issue_link.yml
@@ -28,6 +28,8 @@
     properties:
       - github:
           url: "{repo_url}"
+      - build-discarder:
+          days-to-keep: 7
     parameters:
       - rpc_gating_params
       - string:

--- a/rpc_jobs/pull_request_issue_link.yml
+++ b/rpc_jobs/pull_request_issue_link.yml
@@ -35,6 +35,6 @@
           default: "{repo}"
     dsl: |
       library "rpc-gating@${{RPC_GATING_BRANCH}}"
-      common.shared_slave() {{
+      common.globalWraps(){{
         github.add_issue_url_to_pr()
-      }}
+      }} // globalWraps

--- a/rpc_jobs/repo_server.yml
+++ b/rpc_jobs/repo_server.yml
@@ -11,7 +11,7 @@
       - timed: "@daily"
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
-      common.shared_slave(){
+      common.globalWraps(){
         try{
           common.withRequestedCredentials("cloud_creds, id_rsa_cloud10_jenkins_file"){
             stage("Prepare Ansible Roles"){
@@ -101,4 +101,4 @@
         } finally {
           common.archive_artifacts()
         }
-      } // cit node
+      } // globalWraps

--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -89,18 +89,18 @@
           cancel-builds-on-update: true
     dsl: |
       library "rpc-gating@${{RPC_GATING_BRANCH}}"
-      image_list = [
-        master: [
-            "Ubuntu 16.04.2 LTS prepared for RPC deployment"
-        ],
-        newton: [
-            "Ubuntu 16.04.2 LTS prepared for RPC deployment",
-            "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+      common.globalWraps(){{
+        image_list = [
+          master: [
+              "Ubuntu 16.04.2 LTS prepared for RPC deployment"
+          ],
+          newton: [
+              "Ubuntu 16.04.2 LTS prepared for RPC deployment",
+              "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+          ]
         ]
-      ]
-      env.trigger="{ztrigger}"
-      env.series="{series}"
-      common.shared_slave() {{
+        env.trigger="{ztrigger}"
+        env.series="{series}"
         try {{
           currentBuild.result = "SUCCESS"
           // We need to checkout the rpc-openstack repo on the CIT Slave
@@ -215,4 +215,4 @@
         }} finally {{
           common.safe_jira_comment("${{currentBuild.result}}: [${{env.BUILD_TAG}}|${{env.BUILD_URL}}]")
         }}
-      }} // node
+      }} // globalWraps

--- a/rpc_jobs/setup_nodepool.yml
+++ b/rpc_jobs/setup_nodepool.yml
@@ -11,7 +11,7 @@
       - timed: "@daily"
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
-      common.shared_slave(){
+      common.globalWraps(){
         try{
           common.withRequestedCredentials("cloud_creds, id_rsa_cloud10_jenkins_file"){
             stage("Prepare Ansible Roles"){
@@ -106,4 +106,4 @@
         } finally {
           common.archive_artifacts()
         }
-      } // cit node
+      } // globalWraps

--- a/rpc_jobs/snapshot.yml
+++ b/rpc_jobs/snapshot.yml
@@ -40,52 +40,52 @@
           description: Version of rpc-gating to use.
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
-      env.STAGES="Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
-      stage('Build Image'){
-        if(env.CREATE_RPCO_SNAPSHOT == 'true'){
-          // kick off rpco job
-          retry(5){
-            build(
-              job: "PM_rpc-openstack-newton-xenial-swift-deploy",
-              wait: true,
-              parameters: [
-                [
-                  $class: 'StringParameterValue',
-                  name: 'FLAVOR',
-                  value: "general1-8"
-                ],
-                [
-                  $class: 'StringParameterValue',
-                  name: 'REGIONS',
-                  value: "DFW"
-                ],
-                [
-                  $class: 'StringParameterValue',
-                  name: 'FALLBACK_REGIONS',
-                  value: ""
-                ],
-                [
-                  $class: 'StringParameterValue',
-                  name: 'RPC_GATING_BRANCH',
-                  value: "RE-35"
-                ],
-                [
-                  $class: 'StringParameterValue',
-                  name: 'BRANCH',
-                  value: "RE-35"
-                ],
-                [
-                  $class: 'BooleanParameterValue',
-                  name: 'SNAPSHOT',
-                  value: true
+      common.globalWraps(){
+        env.STAGES="Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
+        stage('Build Image'){
+          if(env.CREATE_RPCO_SNAPSHOT == 'true'){
+            // kick off rpco job
+            retry(5){
+              build(
+                job: "PM_rpc-openstack-newton-xenial-swift-deploy",
+                wait: true,
+                parameters: [
+                  [
+                    $class: 'StringParameterValue',
+                    name: 'FLAVOR',
+                    value: "general1-8"
+                  ],
+                  [
+                    $class: 'StringParameterValue',
+                    name: 'REGIONS',
+                    value: "DFW"
+                  ],
+                  [
+                    $class: 'StringParameterValue',
+                    name: 'FALLBACK_REGIONS',
+                    value: ""
+                  ],
+                  [
+                    $class: 'StringParameterValue',
+                    name: 'RPC_GATING_BRANCH',
+                    value: "RE-35"
+                  ],
+                  [
+                    $class: 'StringParameterValue',
+                    name: 'BRANCH',
+                    value: "RE-35"
+                  ],
+                  [
+                    $class: 'BooleanParameterValue',
+                    name: 'SNAPSHOT',
+                    value: true
+                  ]
                 ]
-              ]
-            )
-          } // retry
-        } // if
-      } // stage
-      if (env.BUILD_FROM_SNAPSHOT == 'true'){
-        common.shared_slave(){
+              )
+            } // retry
+          } // if
+        } // stage
+        if (env.BUILD_FROM_SNAPSHOT == 'true'){
           pubcloud.runonpubcloud(){
             stage('Run Tempest on Instance created from Image'){
               sh """#!/bin/bash -xeu
@@ -99,5 +99,5 @@
               """
             } // stage
           } // Run on pub cloud
-        } // shared slave
-      } // if
+        } // if
+      } // globalWraps

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -68,112 +68,114 @@
 
     dsl: |
       library "rpc-gating@${{RPC_GATING_BRANCH}}"
+      common.globalWraps(){{
 
-      env.STAGES="Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
+        env.STAGES="Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
 
-      // Pass details about the job parameters through
-      // to the target environment so that scripts can
-      // use them to adapt behaviour.
-      env.RE_JOB_NAME = "{name}"
-      env.RE_JOB_IMAGE = "{image}"
-      env.RE_JOB_SCENARIO = "{scenario}"
-      env.RE_JOB_ACTION = "{action}"
-      env.RE_JOB_FLAVOR = "{FLAVOR}"
-      env.RE_JOB_REPO_NAME = "{repo_name}"
-      env.RE_JOB_BRANCH = "{branch}"
+        // Pass details about the job parameters through
+        // to the target environment so that scripts can
+        // use them to adapt behaviour.
+        env.RE_JOB_NAME = "{name}"
+        env.RE_JOB_IMAGE = "{image}"
+        env.RE_JOB_SCENARIO = "{scenario}"
+        env.RE_JOB_ACTION = "{action}"
+        env.RE_JOB_FLAVOR = "{FLAVOR}"
+        env.RE_JOB_REPO_NAME = "{repo_name}"
+        env.RE_JOB_BRANCH = "{branch}"
 
-      // set env.RE_JOB_TRIGGER & env.RE_JOB_TRIGGER_DETAIL
-      common.setTriggerVars()
+        // set env.RE_JOB_TRIGGER & env.RE_JOB_TRIGGER_DETAIL
+        common.setTriggerVars()
 
 
-      String credentials = "{credentials}"
+        String credentials = "{credentials}"
 
-      // Not part of the published interface, used by this job later on
-      // to create failure tickets in the correct project.
-      JIRA_PROJECT_KEY = "{jira_project_key}"
+        // Not part of the published interface, used by this job later on
+        // to create failure tickets in the correct project.
+        JIRA_PROJECT_KEY = "{jira_project_key}"
 
-      common.standard_job_slave(env.SLAVE_TYPE) {{
-        // Set the default environment variables used
-        // by the artifact and test result collection.
-        env.RE_HOOK_ARTIFACT_DIR="${{env.WORKSPACE}}/artifacts"
-        env.RE_HOOK_RESULT_DIR="${{env.WORKSPACE}}/results"
+        common.standard_job_slave(env.SLAVE_TYPE) {{
+          // Set the default environment variables used
+          // by the artifact and test result collection.
+          env.RE_HOOK_ARTIFACT_DIR="${{env.WORKSPACE}}/artifacts"
+          env.RE_HOOK_RESULT_DIR="${{env.WORKSPACE}}/results"
 
-        // Set the job result default
-        currentBuild.result="SUCCESS"
+          // Set the job result default
+          currentBuild.result="SUCCESS"
 
-        try {{
-          common.withRequestedCredentials(credentials) {{
-
-            stage('Checkout') {{
-              common.clone_with_pr_refs(
-                "${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}",
-                env.REPO_URL,
-                env.BRANCH,
-              )
-            }} // stage
-
-            stage('Execute Pre Script') {{
-              // Retry the 'pre' stage 3 times. The 'pre' stage is considered
-              // to be preparation for the test, so let's try and make sure
-              // it has the best chance of success possible.
-              retry(3) {{
-                sh """#!/bin/bash -xeu
-                  cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
-                  if [[ -e gating/post_merge_test/pre ]]; then
-                    gating/post_merge_test/pre
-                  fi
-                """
-              }}
-            }} // stage
-
-            try{{
-              stage('Execute Run Script') {{
-                sh """#!/bin/bash -xeu
-                  cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
-                  gating/post_merge_test/run
-                """
-              }} // stage
-            }} finally {{
-              stage('Execute Post Script') {{
-                // We do not want the 'post' execution to fail the test,
-                // but we do want to know if it fails so we make it only
-                // return status.
-                post_result = sh(
-                  returnStatus: true,
-                  script: """#!/bin/bash -xeu
-                             cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
-                             if [[ -e gating/post_merge_test/post ]]; then
-                               gating/post_merge_test/post
-                             fi"""
-                )
-                if (post_result != 0) {{
-                  print("Post-Merge Test (post) failed with return code ${{post_result}}")
-                }} // if
-              }} // inner try
-            }} // stage
-          }} // withCredentials
-        }} catch (e) {{
-          print(e)
-          currentBuild.result="FAILURE"
-          // Try and ascertain the cause of the exception.
-          // If it was caused by a user, its a manual abort and
-          // an issue shouldn't be created. If it was created by
-          // SYSTEM or the exception doesn't contain enough information
-          // then an issue should be created.
-          String user
           try {{
-            user = e.getCauses()[0].getUser().toString()
-          }} catch (f){{
-            user = 'SYSTEM'
-          }}
-          if(user == 'SYSTEM' && JIRA_PROJECT_KEY != ''){{
-            common.create_jira_issue(JIRA_PROJECT_KEY,
-                                     env.BUILD_TAG,
-                                     env.BUILD_URL,
-                                     "Task")
-          }}
-          throw e
-        }} finally {{
-          common.archive_artifacts()
-        }} // try
-      }}
+            common.withRequestedCredentials(credentials) {{
+
+              stage('Checkout') {{
+                common.clone_with_pr_refs(
+                  "${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}",
+                  env.REPO_URL,
+                  env.BRANCH,
+                )
+              }} // stage
+
+              stage('Execute Pre Script') {{
+                // Retry the 'pre' stage 3 times. The 'pre' stage is considered
+                // to be preparation for the test, so let's try and make sure
+                // it has the best chance of success possible.
+                retry(3) {{
+                  sh """#!/bin/bash -xeu
+                    cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
+                    if [[ -e gating/post_merge_test/pre ]]; then
+                      gating/post_merge_test/pre
+                    fi
+                  """
+                }}
+              }} // stage
+
+              try{{
+                stage('Execute Run Script') {{
+                  sh """#!/bin/bash -xeu
+                    cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
+                    gating/post_merge_test/run
+                  """
+                }} // stage
+              }} finally {{
+                stage('Execute Post Script') {{
+                  // We do not want the 'post' execution to fail the test,
+                  // but we do want to know if it fails so we make it only
+                  // return status.
+                  post_result = sh(
+                    returnStatus: true,
+                    script: """#!/bin/bash -xeu
+                               cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
+                               if [[ -e gating/post_merge_test/post ]]; then
+                                 gating/post_merge_test/post
+                               fi"""
+                  )
+                  if (post_result != 0) {{
+                    print("Post-Merge Test (post) failed with return code ${{post_result}}")
+                  }} // if
+                }} // inner try
+              }} // stage
+            }} // withCredentials
+          }} catch (e) {{
+            print(e)
+            currentBuild.result="FAILURE"
+            // Try and ascertain the cause of the exception.
+            // If it was caused by a user, its a manual abort and
+            // an issue shouldn't be created. If it was created by
+            // SYSTEM or the exception doesn't contain enough information
+            // then an issue should be created.
+            String user
+            try {{
+              user = e.getCauses()[0].getUser().toString()
+            }} catch (f){{
+              user = 'SYSTEM'
+            }}
+            if(user == 'SYSTEM' && JIRA_PROJECT_KEY != ''){{
+              common.create_jira_issue(JIRA_PROJECT_KEY,
+                                       env.BUILD_TAG,
+                                       env.BUILD_URL,
+                                       "Task")
+            }}
+            throw e
+          }} finally {{
+            common.archive_artifacts()
+          }} // try
+        }} // standard_job_slave
+      }} // globalWraps

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -80,28 +80,28 @@
         env.RPC_GATING_BRANCH = "origin/pr/${{env.ghprbPullId}}/merge"
       }}
       library "rpc-gating@${{RPC_GATING_BRANCH}}"
+      common.globalWraps(){{
 
-      // Pass details about the job parameters through
-      // to the target environment so that scripts can
-      // use them to adapt behaviour.
-      env.RE_JOB_NAME = "{name}"
-      env.RE_JOB_IMAGE = "{image}"
-      env.RE_JOB_SCENARIO = "{scenario}"
-      env.RE_JOB_ACTION = "{action}"
-      env.RE_JOB_FLAVOR = "{FLAVOR}"
-      env.RE_JOB_REPO_NAME = "{repo_name}"
+        // Pass details about the job parameters through
+        // to the target environment so that scripts can
+        // use them to adapt behaviour.
+        env.RE_JOB_NAME = "{name}"
+        env.RE_JOB_IMAGE = "{image}"
+        env.RE_JOB_SCENARIO = "{scenario}"
+        env.RE_JOB_ACTION = "{action}"
+        env.RE_JOB_FLAVOR = "{FLAVOR}"
+        env.RE_JOB_REPO_NAME = "{repo_name}"
 
-      // set env.RE_JOB_TRIGGER & env.RE_JOB_TRIGGER_DETAIL
-      common.setTriggerVars()
+        // set env.RE_JOB_TRIGGER & env.RE_JOB_TRIGGER_DETAIL
+        common.setTriggerVars()
 
-      String credentials = "{credentials}"
+        String credentials = "{credentials}"
 
-      Boolean run_test = true
-      // We need to checkout the repo on the CIT Slave so that
-      // we can check whether the patch only includes changes
-      // in files matching the skip pattern. If that is the case,
-      // we can skip the rest of the job execution and return success.
-      common.shared_slave() {{
+        Boolean run_test = true
+        // We need to checkout the repo on the CIT Slave so that
+        // we can check whether the patch only includes changes
+        // in files matching the skip pattern. If that is the case,
+        // we can skip the rest of the job execution and return success.
         common.withRequestedCredentials(credentials) {{
           stage('Check PR against skip-list') {{
             print("Triggered by PR: ${{env.ghprbPullLink}}")
@@ -111,82 +111,82 @@
             run_test = ! common.skip_build_check(skip_pattern)
           }} // stage
         }} // withRequestedCredentials
-      }}
 
-      if (run_test) {{
-        common.standard_job_slave(env.SLAVE_TYPE) {{
-          // Set the default environment variables used
-          // by the artifact and test result collection.
-          env.RE_HOOK_ARTIFACT_DIR="${{env.WORKSPACE}}/artifacts"
-          env.RE_HOOK_RESULT_DIR="${{env.WORKSPACE}}/results"
+        if (run_test) {{
+          common.standard_job_slave(env.SLAVE_TYPE) {{
+            // Set the default environment variables used
+            // by the artifact and test result collection.
+            env.RE_HOOK_ARTIFACT_DIR="${{env.WORKSPACE}}/artifacts"
+            env.RE_HOOK_RESULT_DIR="${{env.WORKSPACE}}/results"
 
-          // Set the job result default
-          currentBuild.result="SUCCESS"
+            // Set the job result default
+            currentBuild.result="SUCCESS"
 
-          try {{
-            common.withRequestedCredentials(credentials) {{
-              stage('Checkout') {{
-                print("Triggered by PR: ${{env.ghprbPullLink}}")
-                common.clone_with_pr_refs(
-                  "${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}",
-                )
-              }} // stage
-
-              stage('Execute Pre Script') {{
-                // Retry the 'pre' stage 3 times. The 'pre' stage is considered
-                // to be preparation for the test, so let's try and make sure
-                // it has the best chance of success possible.
-                retry(3) {{
-                  sh """#!/bin/bash -xeu
-                  cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
-                  if [[ -e gating/pre_merge_test/pre ]]; then
-                    gating/pre_merge_test/pre
-                  fi
-                  """
-                }}
-              }} // stage
-
-              try{{
-                stage('Execute Run Script') {{
-                  sh """#!/bin/bash -xeu
-                  cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
-                  gating/pre_merge_test/run
-                  """
-                }} // stage
-              }} finally {{
-
-                // We implement the post script execution in a finally
-                // block to ensure that it always executes as it is
-                // typically used to collect logs and this needs to
-                // happen whether the run script succeeds or fails.
-
-                stage('Execute Post Script') {{
-                  // We do not want the 'post' execution to fail the test,
-                  // but we do want to know if it fails so we make it only
-                  // return status.
-                  post_result = sh(
-                    returnStatus: true,
-                    script: """#!/bin/bash -xeu
-                               cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
-                               if [[ -e gating/pre_merge_test/post ]]; then
-                                 gating/pre_merge_test/post
-                               fi"""
+            try {{
+              common.withRequestedCredentials(credentials) {{
+                stage('Checkout') {{
+                  print("Triggered by PR: ${{env.ghprbPullLink}}")
+                  common.clone_with_pr_refs(
+                    "${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}",
                   )
-                  if (post_result != 0) {{
-                    print("Pre-Merge Test (post) failed with return code ${{post_result}}")
-                  }} // if
                 }} // stage
 
-              }} // inner try
-            }} // withCredentials
-          }} catch (e) {{
-            print(e)
-            currentBuild.result="FAILURE"
-            throw e
-          }} finally {{
-            common.safe_jira_comment("${{currentBuild.result}}: [${{env.BUILD_TAG}}|${{env.BUILD_URL}}]",
-                                     env.RE_JOB_REPO_NAME)
-            common.archive_artifacts()
-          }} // try
-        }}
-      }}
+                stage('Execute Pre Script') {{
+                  // Retry the 'pre' stage 3 times. The 'pre' stage is considered
+                  // to be preparation for the test, so let's try and make sure
+                  // it has the best chance of success possible.
+                  retry(3) {{
+                    sh """#!/bin/bash -xeu
+                    cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
+                    if [[ -e gating/pre_merge_test/pre ]]; then
+                      gating/pre_merge_test/pre
+                    fi
+                    """
+                  }}
+                }} // stage
+
+                try{{
+                  stage('Execute Run Script') {{
+                    sh """#!/bin/bash -xeu
+                    cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
+                    gating/pre_merge_test/run
+                    """
+                  }} // stage
+                }} finally {{
+
+                  // We implement the post script execution in a finally
+                  // block to ensure that it always executes as it is
+                  // typically used to collect logs and this needs to
+                  // happen whether the run script succeeds or fails.
+
+                  stage('Execute Post Script') {{
+                    // We do not want the 'post' execution to fail the test,
+                    // but we do want to know if it fails so we make it only
+                    // return status.
+                    post_result = sh(
+                      returnStatus: true,
+                      script: """#!/bin/bash -xeu
+                                 cd ${{env.WORKSPACE}}/${{env.RE_JOB_REPO_NAME}}
+                                 if [[ -e gating/pre_merge_test/post ]]; then
+                                   gating/pre_merge_test/post
+                                 fi"""
+                    )
+                    if (post_result != 0) {{
+                      print("Pre-Merge Test (post) failed with return code ${{post_result}}")
+                    }} // if
+                  }} // stage
+
+                }} // inner try
+              }} // withCredentials
+            }} catch (e) {{
+              print(e)
+              currentBuild.result="FAILURE"
+              throw e
+            }} finally {{
+              common.safe_jira_comment("${{currentBuild.result}}: [${{env.BUILD_TAG}}|${{env.BUILD_URL}}]",
+                                       env.RE_JOB_REPO_NAME)
+              common.archive_artifacts()
+            }} // try
+          }} // standard job slave
+        }} // if run test
+      }} // globalWraps

--- a/rpc_jobs/sync_credential_store.yml
+++ b/rpc_jobs/sync_credential_store.yml
@@ -2,6 +2,9 @@
     name: 'Sync-Credential-Store'
     project-type: workflow
     concurrent: false
+    properties:
+      - build-discarder:
+          days-to-keep: 360
     parameters:
       - rpc_gating_params
       - string:

--- a/rpc_jobs/sync_credential_store.yml
+++ b/rpc_jobs/sync_credential_store.yml
@@ -24,43 +24,45 @@
 
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
-      common.internal_slave(){
-        withCredentials([
-          file(
-            credentialsId: 'service_account_jenkins_ssh_key',
-            variable: 'JENKINS_SSH_KEY'
-          )
-        ]){
-          dir("rpc-gating/scripts"){
-            TMP_DIR = pwd(tmp:true)
-            withEnv([
-              "TMP_DIR=${TMP_DIR}",
-              "PWSAFE_PROJECT_ID=${PWSAFE_PROJECT_ID}",
-              "JENKINS_URL=${JENKINS_URL}",
-              "JENKINS_SSH_KEY=${JENKINS_SSH_KEY}",
-              "SSO_USERNAME=${SSO_USERNAME}",
-              "SSO_PASSWORD=${SSO_PASSWORD}"])
-            {
-              sshagent (credentials: ['rpc-jenkins-svc-github-key']) {
-                sh """#!/bin/bash
-                  scl enable python27 bash
+      common.globalWraps(){
+        common.internal_slave(){
+          withCredentials([
+            file(
+              credentialsId: 'service_account_jenkins_ssh_key',
+              variable: 'JENKINS_SSH_KEY'
+            )
+          ]){
+            dir("rpc-gating/scripts"){
+              TMP_DIR = pwd(tmp:true)
+              withEnv([
+                "TMP_DIR=${TMP_DIR}",
+                "PWSAFE_PROJECT_ID=${PWSAFE_PROJECT_ID}",
+                "JENKINS_URL=${JENKINS_URL}",
+                "JENKINS_SSH_KEY=${JENKINS_SSH_KEY}",
+                "SSO_USERNAME=${SSO_USERNAME}",
+                "SSO_PASSWORD=${SSO_PASSWORD}"])
+              {
+                sshagent (credentials: ['rpc-jenkins-svc-github-key']) {
+                  sh """#!/bin/bash
+                    scl enable python27 bash
 
-                  if [[ ! -d ".venv" ]]; then
-                      virtualenv -p /opt/rh/python27/root/usr/bin/python .venv
-                  fi
-                  set +x; source .venv/bin/activate; set -x
+                    if [[ ! -d ".venv" ]]; then
+                        virtualenv -p /opt/rh/python27/root/usr/bin/python .venv
+                    fi
+                    set +x; source .venv/bin/activate; set -x
 
-                  pip install ${PIP_PWSAFE_LOCATION}
-                  pip install functools32
+                    pip install ${PIP_PWSAFE_LOCATION}
+                    pip install functools32
 
-                  if [[ ! -f "jenkins-cli.jar" ]]; then
-                      wget ${JENKINS_URL}/jnlpJars/jenkins-cli.jar
-                  fi
+                    if [[ ! -f "jenkins-cli.jar" ]]; then
+                        wget ${JENKINS_URL}/jnlpJars/jenkins-cli.jar
+                    fi
 
-                  python pull_passwords.py
-                """
-              } // sshagent
-            } // withEnv
-          } // dir
-        } // withCred
-      } // CIT slave node
+                    python pull_passwords.py
+                  """
+                } // sshagent
+              } // withEnv
+            } // dir
+          } // withCred
+        } // CIT slave node
+      } // globalWraps

--- a/rpc_jobs/unit/artefact_publish.yml
+++ b/rpc_jobs/unit/artefact_publish.yml
@@ -9,7 +9,7 @@
       - rpc_gating_params
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
-      common.shared_slave(){
+      common.globalWraps(){
         // Do something that creates an artifact
         stage("Build"){
           sh """

--- a/rpc_jobs/unit/globalwraps.yml
+++ b/rpc_jobs/unit/globalwraps.yml
@@ -1,0 +1,14 @@
+- job:
+    name: RE-unit-test-globalwraps
+    project-type: pipeline
+    concurrent: true
+    properties:
+      - build-discarder:
+          num-to-keep: 30
+    parameters:
+      - rpc_gating_params
+    dsl: |
+      library "rpc-gating@${RPC_GATING_BRANCH}"
+      common.globalWraps(){
+        print ("This print will be wrapped by the global wrappers.")
+      }

--- a/rpc_jobs/unit/re_unit_tests.yml
+++ b/rpc_jobs/unit/re_unit_tests.yml
@@ -14,6 +14,8 @@
           cancel-builds-on-update: true
     properties:
       - rpc-gating-github
+      - build-discarder:
+          days-to-keep: 30
     parameters:
       - rpc_gating_params
     dsl: |

--- a/rpc_jobs/unit/re_unit_tests.yml
+++ b/rpc_jobs/unit/re_unit_tests.yml
@@ -86,6 +86,19 @@
             ]
           )
         },
+        "Global Wraps Check": {
+          build(
+            job: "RE-unit-test-globalwraps",
+            wait: true,
+            parameters: [
+              [
+                $class: 'StringParameterValue',
+                name: 'RPC_GATING_BRANCH',
+                value: env.RPC_GATING_BRANCH
+              ]
+            ]
+          )
+        },
       ])
 
 #TODO: Jira Issue Manipulation, Validation of Published Artefacts.

--- a/rpc_jobs/unit/single_use_slave.yml
+++ b/rpc_jobs/unit/single_use_slave.yml
@@ -27,7 +27,7 @@
               Destroy Slave
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
-      common.shared_slave(){
+      common.globalWraps(){
         pubcloud.runonpubcloud {
           sh """
             echo "I'm running on a single use slave!"

--- a/rpc_jobs/unit/skip_build_check.yml
+++ b/rpc_jobs/unit/skip_build_check.yml
@@ -14,7 +14,7 @@
             | ^changes_can_be_skipped/
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
-      common.shared_slave{
+      common.globalWraps{
 
         env.RE_JOB_REPO_NAME = "test_repository"
 

--- a/rpc_jobs/unit/with_requested_credentials.yml
+++ b/rpc_jobs/unit/with_requested_credentials.yml
@@ -9,7 +9,7 @@
       - rpc_gating_params
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
-      common.shared_slave{
+      common.globalWraps{
 
         stage("Test valid credentials and bundles"){
           common.withRequestedCredentials("cloud_creds id_rsa_cloud10_jenkins_file"){

--- a/rpc_jobs/webhook.yml
+++ b/rpc_jobs/webhook.yml
@@ -47,6 +47,8 @@
 
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
-      common.internal_slave(){
-          webhooks.webhooks()
-      } // cit node
+      common.globalWraps(){
+        common.internal_slave(){
+            webhooks.webhooks()
+        } // cit node
+      } // globalWraps


### PR DESCRIPTION
This PR adds two controls for log storage:

- Ensure that no console log may exceed 200MB - the job will be killed if that limit is exceeded. This is added via globalWraps, a new function that wraps every job, and will make it easier to add or remove global wrappers in future. This function allocates a shared slave, so shared_slave allocations have been removed from jobs where they are no longer necessary. Added a unit test for this functionality. 
- Ensure that all jobs have a retention policy so logs are not stored indefinitely. A lint rule is added to enforce this.


Issue: [RE-1191](https://rpc-openstack.atlassian.net/browse/RE-1191)