### PR TITLE
RE-1269 Correct ironic/trusty exclusion

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -211,13 +211,10 @@
       - deploy:
           FLAVOR: "7"
     exclude:
-      - scenario: ironic
-        image: trusty
-      - scenario: ironic
-        image: trusty_loose_artifacts
-      - scenario: ironic
-        image: trusty_no_artifacts
-
+      - scenario: "ironic"
+        image: "trusty"
+      - scenario: "ironic"
+        image: "trusty_loose_artifacts"
     # This is the build that will be triggered by the push trigger job
     trigger_build: 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
     jobs:


### PR DESCRIPTION
Somehow the follow job is still being generated:
PM_rpc-openstack-newton-trusty_loose_artifacts-swift-deploy

This attempts to correct that, and also removes
the newton/no_artifacts exclusion as that axis
does not exist.

Issue: [RE-1269](https://rpc-openstack.atlassian.net/browse/RE-1269)