### PR TITLE
RLM-1159 Add MNAIO PM jobs for {master,newton}-rc branches

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -190,6 +190,27 @@
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
 - project:
+    name: "rpc-openstack-master-rc-mnaio-postmerge"
+    repo_name: "rpc-openstack"
+    repo_url: "https://github.com/rcbops/rpc-openstack"
+    branch: "master-rc"
+    jira_project_key: "RO"
+    image:
+      - xenial_mnaio
+      - xenial_mnaio_loose_artifacts
+      - xenial_mnaio_no_artifacts
+    scenario:
+      - "swift"
+    action:
+      - deploy:
+          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+          FLAVOR: "onmetal-io1"
+          REGIONS: "IAD"
+          FALLBACK_REGIONS: ""
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+- project:
     name: "rpc-openstack-newton-aio-postmerge"
     repo_name: "rpc-openstack"
     repo_url: "https://github.com/rcbops/rpc-openstack"
@@ -215,9 +236,6 @@
         image: trusty
       - scenario: ironic
         image: trusty_loose_artifacts
-      - scenario: ironic
-        image: trusty_no_artifacts
-
     # This is the build that will be triggered by the push trigger job
     trigger_build: 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
     jobs:
@@ -235,6 +253,26 @@
       - xenial_mnaio_loose_artifacts
     scenario:
       - "ironic"
+      - "swift"
+    action:
+      - deploy:
+          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+          FLAVOR: "onmetal-io1"
+          REGIONS: "IAD"
+          FALLBACK_REGIONS: ""
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+- project:
+    name: "rpc-openstack-newton-rc-mnaio-postmerge"
+    repo_name: "rpc-openstack"
+    repo_url: "https://github.com/rcbops/rpc-openstack"
+    branch: "newton-rc"
+    jira_project_key: "RO"
+    image:
+      - xenial_mnaio
+      - xenial_mnaio_loose_artifacts
+    scenario:
       - "swift"
     action:
       - deploy:


### PR DESCRIPTION
In order to facilitate ongoing testing during the soak period
this patch adds periodic MNAIO jobs for the {master,newton}-rc
branches.

The trusty_no_artifacts axis exclusion is removed from the
newton AIO PM job as that axis no longer exists.

Issue: [RLM-1159](https://rpc-openstack.atlassian.net/browse/RLM-1159)