### PR TITLE
RE-1285 Ensure RPC-O artifact build tests fire for master-rc

### DIFF
--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -5,7 +5,7 @@
     series:
       - master:
           branch: master
-          branches: "master"
+          branches: "master.*"
       - newton:
           branch: newton
           branches: "newton.*"


### PR DESCRIPTION
Currently the master-rc branch is ignored, but it should not be.

Issue: [RE-1285](https://rpc-openstack.atlassian.net/browse/RE-1285)