### PR TITLE
RE-1288 Add phobos vpn connection

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -773,6 +773,40 @@ void standard_job_slave(String slave_type, Closure body){
   }
 }
 
+
+void connect_phobos_vpn(String gateway){
+  withCredentials([
+    usernamePassword(
+      credentialsId: "phobos_vpn_ipsec",
+      usernameVariable: "ipsec_id",
+      passwordVariable: "ipsec_secret"
+    ),
+    usernamePassword(
+      credentialsId: "phobos_vpn_xauth",
+      usernameVariable: "xauth_user",
+      passwordVariable: "xauth_pass"
+    )
+  ]){
+    dir('rpc-gating/playbooks'){
+      venvPlaybook(
+        playbooks: [
+          "phobos_vpn.yml"
+        ],
+        args: [
+          "-u root"
+        ],
+        vars: [
+          ipsec_id: env.ipsec_id,
+          ipsec_secret: env.ipsec_secret,
+          xauth_user: env.xauth_user,
+          xauth_pass: env.xauth_pass,
+          gateway: gateway
+        ]
+      ) //venvPlaybook
+    } // dir
+  } // withCredentials
+}
+
 // Build an array suitable for passing to withCredentials
 // from a space or comma separated list of credential IDs.
 @NonCPS

--- a/playbooks/phobos_vpn.yml
+++ b/playbooks/phobos_vpn.yml
@@ -1,0 +1,35 @@
+- name: Configure Phobos VPN Tunnel (should only be run on single use slaves)
+  hosts: localhost
+  tasks:
+    # Use shell because python-apt isn't available so the apt module fails.
+    # I don't want to add python-apt to one of the more general slave setup
+    # scripts as it depends on python. We want to reduce the number of deps
+    # installed on general slaves to the bare minimum.
+    - name: Install apt packages
+      shell: |
+        apt-get update
+        apt-get install -y vpnc
+      register: install_packages
+      until: install_packages | success
+      retries: 5
+      delay: 2
+      tags:
+        - skip_ansible_lint
+
+
+    - name: Template vpnc config
+      template:
+        src: vpnc.conf.j2
+        dest: /etc/vpnc/phobos.conf
+
+    - name: Template vpnc systemd service
+      template:
+        src: vpnc.service.j2
+        dest: /lib/systemd/system/vpnc.service
+
+    - name: Start vpnc service
+      systemd:
+        enabled: yes
+        service: vpnc.service
+        daemon_reload: yes
+        state: restarted

--- a/playbooks/templates/vpnc.conf.j2
+++ b/playbooks/templates/vpnc.conf.j2
@@ -1,0 +1,9 @@
+IPSec gateway {{gateway}}
+
+IKE Authmode psk
+
+IPSec ID {{ ipsec_id }}
+IPSec secret {{ ipsec_secret }}
+
+Xauth username {{ xauth_user }}
+Xauth password {{ xauth_pass }}

--- a/playbooks/templates/vpnc.service.j2
+++ b/playbooks/templates/vpnc.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Cisco VPN connection to phobos
+Documentation=man:vpnc(8) http://www.unix-ag.uni-kl.de/~massar/vpnc/
+Requires=network.target
+After=network.target
+ConditionPathExists=/dev/net/tun
+
+[Service]
+Type=forking
+PIDFile=/run/vpnc/phobos.pid
+
+ExecStart=/usr/sbin/vpnc --pid-file /run/vpnc/phobos.pid /etc/vpnc/phobos.conf
+
+[Install]
+WantedBy=multi-user.target

--- a/rpc_jobs/unit/phobos_vpn.yml
+++ b/rpc_jobs/unit/phobos_vpn.yml
@@ -1,0 +1,73 @@
+- job:
+    name: RE-unit-test-phobos-vpn
+    project-type: workflow
+    concurrent: true
+    properties:
+      - build-discarder:
+          num-to-keep: 30
+    parameters:
+      # Default params are provided by macro, add any extra params, or
+      # params you want to override the defaults for.
+      - instance_params:
+          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+          FLAVOR: "performance1-1"
+          REGIONS: "DFW ORD"
+          FALLBACK_REGIONS: "IAD"
+      - rpc_gating_params
+      - string:
+          name: STAGES
+          default: "Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
+          description: |
+            Pipeline stages to run CSV. Note that this list does not influence execution order.
+            Options:
+              Allocate Resources
+              Connect Slave
+              Pause (use to hold instance for investigation before cleanup)
+              Cleanup
+              Destroy Slave
+      - string:
+          name: GATEWAY
+          default: from_creds
+          help: |
+            IP of Phobos VPN Gateway, if set to "from_creds", the gateway
+            IP will be pulled from the Jenkins Creds Store
+      - string:
+          name: PING_HOST
+          default: 172.20.4.10
+          help: |
+            Host that is only accessible via Phobos vpn, used to verify
+            connectivity
+
+    dsl: |
+      library "rpc-gating@${RPC_GATING_BRANCH}"
+      if (env.GATEWAY == "from_creds"){
+        withCredentials([
+          string(
+            credentialsId: 'phobos_vpn_gateway',
+            variable: 'gw_from_creds'
+          ),
+        ]){
+          env.GATEWAY = gw_from_creds
+        }
+      }
+      common.shared_slave(){
+        pubcloud.runonpubcloud {
+
+          stage("Ensure phobos not reachable before connecting"){
+            assert sh (returnStatus: true, script: """#!/bin/bash -x
+              ping -w 5 ${env.PING_HOST}
+            """) == 1
+          }
+
+          stage("Connect phobos VPN"){
+            common.connect_phobos_vpn(env.GATEWAY)
+          }
+
+          stage("Ensure phobos reachable after connecting"){
+            // will throw exception on failure
+            sh """#!/bin/bash -x
+              ping -w 5 ${env.PING_HOST}
+            """
+          }
+        }
+      }

--- a/rpc_jobs/unit/re_unit_tests.yml
+++ b/rpc_jobs/unit/re_unit_tests.yml
@@ -73,6 +73,19 @@
             ]
           )
         },
+        "Phobos VPN Check": {
+          build(
+            job: "RE-unit-test-phobos-vpn",
+            wait: true,
+            parameters: [
+              [
+                $class: 'StringParameterValue',
+                name: 'RPC_GATING_BRANCH',
+                value: env.RPC_GATING_BRANCH
+              ]
+            ]
+          )
+        },
       ])
 
 #TODO: Jira Issue Manipulation, Validation of Published Artefacts.


### PR DESCRIPTION
The current method of connecting to phobos requires a webhook proxy
node and a deploy node. This multi hop approach can make it hard to
access some networks within phobos.

This commit adds a vpn connection direclty from a single use test node
to phobos.

Issue: [RE-1288](https://rpc-openstack.atlassian.net/browse/RE-1288)