### PR TITLE
RE-1276 Add rpc-maas projects using standard jobs

### DIFF
--- a/rpc_jobs/rpc_maas.yml
+++ b/rpc_jobs/rpc_maas.yml
@@ -11,10 +11,12 @@
     scenario:
       - master:
           FLAVOR: "performance2-15"
+          TRIGGER_PR_PHRASE_ONLY: true
       - pike:
           FLAVOR: "general1-8"
       - ocata:
           FLAVOR: "general1-8"
+          TRIGGER_PR_PHRASE_ONLY: true
       - newton:
           FLAVOR: "general1-8"
       - ceph:
@@ -38,7 +40,8 @@
       - newton
       - mitaka
       - liberty
-      - kilo
+      - kilo:
+          TRIGGER_PR_PHRASE_ONLY: true
     action:
       - deploy:
           FLAVOR: "general1-8"

--- a/rpc_jobs/rpc_maas.yml
+++ b/rpc_jobs/rpc_maas.yml
@@ -1,0 +1,46 @@
+- project:
+    name: "rpc-maas-master-xenial-premerge"
+    repo_name: "rpc-maas"
+    repo_url: "https://github.com/rcbops/rpc-maas"
+    series: "master"
+    branches:
+      - "master.*"
+    image:
+      - xenial:
+          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+    scenario:
+      - master:
+          FLAVOR: "performance2-15"
+      - pike:
+          FLAVOR: "general1-8"
+      - ocata:
+          FLAVOR: "general1-8"
+      - newton:
+          FLAVOR: "general1-8"
+      - ceph:
+          FLAVOR: "general1-8"
+    action:
+      - "deploy"
+    jobs:
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
+
+- project:
+    name: "rpc-maas-master-trusty-premerge"
+    repo_name: "rpc-maas"
+    repo_url: "https://github.com/rcbops/rpc-maas"
+    series: "master"
+    branches:
+      - "master.*"
+    image:
+      - trusty:
+          IMAGE: "Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)"
+    scenario:
+      - newton
+      - mitaka
+      - liberty
+      - kilo
+    action:
+      - deploy:
+          FLAVOR: "general1-8"
+    jobs:
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'


### PR DESCRIPTION
These new jobs are designed to replace the IRR jobs for rpc-maas. Once
these jobs have been added the equivalent IRR jobs will be removed in a
separate commit.

Issue: [RE-1276](https://rpc-openstack.atlassian.net/browse/RE-1276)