### PR TITLE
RE-1162 Add lint jobs for rpc-upgrades

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -2,7 +2,7 @@
 - project:
     name: "rpc-upgrades-aio-newton-head-pr"
     repo_name: "rpc-upgrades"
-    repo_url: "http://github.com/rcbops/rpc-upgrades"
+    repo_url: "https://github.com/rcbops/rpc-upgrades"
     branches:
      - "master"
     image:
@@ -21,7 +21,7 @@
 - project:
     name: "rpc-upgrades-aio-tox-pr"
     repo_name: "rpc-upgrades"
-    repo_url: "http://github.com/rcbops/rpc-upgrades"
+    repo_url: "https://github.com/rcbops/rpc-upgrades"
     branches:
      - "master"
     image:
@@ -43,7 +43,7 @@
 - project:
     name: "rpc-upgrades-aio-newton-head-pm"
     repo_name: "rpc-upgrades"
-    repo_url: "http://github.com/rcbops/rpc-upgrades"
+    repo_url: "https://github.com/rcbops/rpc-upgrades"
     image:
       - trusty_aio:
           FLAVOR: "performance2-15"
@@ -81,7 +81,7 @@
 - project:
     name: "rpc-upgrades-aio-newton-release-pm"
     repo_name: "rpc-upgrades"
-    repo_url: "http://github.com/rcbops/rpc-upgrades"
+    repo_url: "https://github.com/rcbops/rpc-upgrades"
     image:
       - trusty_aio:
           FLAVOR: "performance2-15"
@@ -103,7 +103,7 @@
 - project:
     name: "rpc-upgrades-mnaio-newton-head-pm"
     repo_name: "rpc-upgrades"
-    repo_url: "http://github.com/rcbops/rpc-upgrades"
+    repo_url: "https://github.com/rcbops/rpc-upgrades"
     image:
       # in mnaio builds, the OS equals the VMs OS
       - trusty_mnaio:
@@ -127,7 +127,7 @@
 - project:
     name: "rpc-upgrades-mnaio-newton-release-pm"
     repo_name: "rpc-upgrades"
-    repo_url: "http://github.com/rcbops/rpc-upgrades"
+    repo_url: "https://github.com/rcbops/rpc-upgrades"
     image:
       # in mnaio builds, the OS equals the VMs OS
       - trusty_mnaio:

--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -19,6 +19,28 @@
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
 - project:
+    name: "rpc-upgrades-aio-tox-pr"
+    repo_name: "rpc-upgrades"
+    repo_url: "http://github.com/rcbops/rpc-upgrades"
+    branches:
+     - "master"
+    image:
+      - container:
+          SLAVE_TYPE: "container"
+    scenario:
+      - "ansible-lint"
+      - "ansible-syntax"
+      - "bashate"
+      - "pep8"
+      - "releasenotes"
+      - "docs"
+    action:
+      - "tox-test"
+    jira_project_key: "RLM"
+    jobs:
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
+
+- project:
     name: "rpc-upgrades-aio-newton-head-pm"
     repo_name: "rpc-upgrades"
     repo_url: "http://github.com/rcbops/rpc-upgrades"


### PR DESCRIPTION
This PR adds jobs which will replace rpc-upgrades' Travis CI usage.

Issue: [RE-1162](https://rpc-openstack.atlassian.net/browse/RE-1162)