### PR TITLE
RE-1169 Standardise ops-fabric-chatbot jobs

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -326,7 +326,9 @@ def rpco_archive_artifacts(String build_type = "AIO"){
 def archive_artifacts(){
   stage('Compress and Publish Artifacts'){
     if (env.RE_HOOK_RESULT_DIR != null){
-      junit allowEmptyResults: true, testResults: "${env.RE_HOOK_RESULT_DIR}/*.xml"
+      dir(env.RE_HOOK_RESULT_DIR) {
+        junit allowEmptyResults: true, testResults: '*.xml'
+      }
     }
     pubcloud.uploadToSwift(
       container: "jenkins_logs",

--- a/rpc_jobs/ops_fabric_chatbot.yml
+++ b/rpc_jobs/ops_fabric_chatbot.yml
@@ -1,3 +1,19 @@
+- project:
+    name: "ops-fabric-chatbot-pre-merge"
+    repo_name: "ops-fabric-chatbot"
+    repo_url: "https://github.com/rcbops/ops-fabric-chatbot"
+    branches:
+      - "master"
+    image:
+      - container:
+          SLAVE_TYPE: "container"
+    scenario:
+      - "unit"
+    action:
+      - "test"
+    jobs:
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
+
 - job:
     name: Ops-Fabric-Chatbot-Gate
     description: "lint and unit tests for ops-fabric-chatbot"


### PR DESCRIPTION
NOTE: The junit change in common.groovy is necessary because at present
no job output is being parsed.  It looks like this pipeline helper only
accepts a relative path, so we cd into the directory and then pass in
'*.xml'.

Issue: [RE-1169](https://rpc-openstack.atlassian.net/browse/RE-1169)