### PR TITLE
RLM-1290 Add Kilo version specific jobs to newton release

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -38,7 +38,7 @@
       - "r12.2.2_to_newton_leap"
       - "r12.1.2_to_newton_leap"
       - "kilo_to_newton_leap" 
-      - "r14.4.1_to_newton_minor"
+      - "r14.6.0_to_newton_minor"
     jira_project_key: "RLM"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
@@ -74,6 +74,17 @@
       - "r12.1.2_to_r14.6.0_leap"
       - "kilo_to_r14.6.0_leap"
       - "kilo_to_r14.2.0_leap"
+      - "r11.0.0_to_r14.6.0_leap"
+      - "r11.0.1_to_r14.6.0_leap"
+      - "r11.0.4_to_r14.6.0_leap"
+      - "r11.1.3_to_r14.6.0_leap"
+      - "r11.1.4_to_r14.6.0_leap"
+      - "r11.1.5_to_r14.6.0_leap"
+      - "r11.1.6_to_r14.6.0_leap"
+      - "r11.1.9_to_r14.6.0_leap"
+      - "r11.1.10_to_r14.6.0_leap"
+      - "r11.1.15_to_r14.6.0_leap"
+      - "r11.1.18_to_r14.6.0_leap"
     jira_project_key: "RLM"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'


### PR DESCRIPTION
Adds all deployed Kilo versions to validate that they work
with rpc-upgrades.  This will enable us to fully use
rpc-upgrades for leaps and move away from the 14.2.0 newton
dependency.

Also bumps the minor job to the latest release.

Issue: [RLM-1290](https://rpc-openstack.atlassian.net/browse/RLM-1290)