### PR TITLE
RLM-1291 Adds Mitaka to Newton Major job

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -32,6 +32,7 @@
     scenario:
       - "swift"
     action:
+      - "mitaka_to_newton_major"
       - "liberty_to_newton_leap"
       - "r12.2.8_to_newton_leap"
       - "r12.2.5_to_newton_leap"


### PR DESCRIPTION
Adds Mitaka to Newton Major job so we can get
an idea of it's current status and get it working in
rpc-upgrades.

Issue: [RLM-1291](https://rpc-openstack.atlassian.net/browse/RLM-1291)