### PR TITLE
RE-1287 Set default Phobos deploy branch to newton-rc and add time trigger

### DIFF
--- a/rpc_jobs/phobos.yml
+++ b/rpc_jobs/phobos.yml
@@ -9,7 +9,7 @@
       # See params.yml
       - rpc_gating_params
       - rpc_repo_params:
-          RPC_BRANCH: newton
+          RPC_BRANCH: newton-rc
       - rpc_eng_ops_params:
           RPC_ENG_OPS_BRANCH: master
       - string:

--- a/rpc_jobs/phobos.yml
+++ b/rpc_jobs/phobos.yml
@@ -5,6 +5,9 @@
     properties:
       - build-discarder:
           num-to-keep: 60
+    triggers:
+      # Starting between 04:00-05:00 UTC every Monday and Thursday
+      - timed: "H 4 * * 1,4"
     parameters:
       # See params.yml
       - rpc_gating_params


### PR DESCRIPTION
We are currently deploying newton-rc to phobos regularly, to prevent
mistkes, make this the default branch.

Issue: [RE-1287](https://rpc-openstack.atlassian.net/browse/RE-1287)