### PR TITLE
RE-1276 Supply cloud_creds to rpc-maas jobs

### DIFF
--- a/rpc_jobs/rpc_maas.yml
+++ b/rpc_jobs/rpc_maas.yml
@@ -23,6 +23,7 @@
           FLAVOR: "general1-8"
     action:
       - "deploy"
+    credentials: "cloud_creds"
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
@@ -45,5 +46,6 @@
     action:
       - deploy:
           FLAVOR: "general1-8"
+    credentials: "cloud_creds"
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'


### PR DESCRIPTION
rpc-maas jobs require cloud_creds to test the MaaS API, without this set
the tests pass because rpc-maas does not require those tests to be run.

Issue: [RE-1276](https://rpc-openstack.atlassian.net/browse/RE-1276)