### PR TITLE
RE-1300 Remove strict mode RPC-O MNAIO jobs for the RC branches

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -196,7 +196,6 @@
     branch: "master-rc"
     jira_project_key: "RO"
     image:
-      - xenial_mnaio
       - xenial_mnaio_loose_artifacts
       - xenial_mnaio_no_artifacts
     scenario:
@@ -270,7 +269,6 @@
     branch: "newton-rc"
     jira_project_key: "RO"
     image:
-      - xenial_mnaio
       - xenial_mnaio_loose_artifacts
     scenario:
       - "swift"


### PR DESCRIPTION
Given that the MNAIO tooling currently deploys the latest packages
for the base OS, the strict mode test will fail on the RC branches
as soon as a newer apt package than the artifacted packages releases.
Therefore, until a mechanism is worked out to deploy the base OS
using artifacts, the strict mode tests are just going to deliver
failures for a well known reason. As such, they should be removed
for now.

Issue: [RE-1300](https://rpc-openstack.atlassian.net/browse/RE-1300)