### PR TITLE
RE-1301 Send phobos msgs to #rpc-ceph

### DIFF
--- a/rpc_jobs/phobos.yml
+++ b/rpc_jobs/phobos.yml
@@ -52,7 +52,7 @@
           msg_plus_link="${message} (${env.BUILD_URL})"
           slackSend(channel: "#rpc-releng", message: msg_plus_link, color: color)
           slackSend(channel: "#rpc-eng-ops", message: msg_plus_link, color: color)
-          slackSend(channel: "#ceph", message: msg_plus_link, color: color)
+          slackSend(channel: "#rpc-ceph", message: msg_plus_link, color: color)
           slackSend(channel: "#rpc-engineering", message: msg_plus_link, color: color)
         }
       }


### PR DESCRIPTION
A new room was recently spun up and we have been asked to send these
phobos deploy notifications to #rpc-ceph instead.

Issue: [RE-1301](https://rpc-openstack.atlassian.net/browse/RE-1301)