### PR TITLE
RE-1164 Add rpc-maas jobs to replace Travis CI

### DIFF
--- a/rpc_jobs/rpc_maas.yml
+++ b/rpc_jobs/rpc_maas.yml
@@ -49,3 +49,25 @@
     credentials: "cloud_creds"
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
+
+- project:
+    name: "rpc-maas-master-tox-premerge"
+    repo_name: "rpc-maas"
+    repo_url: "https://github.com/rcbops/rpc-maas"
+    series: "master"
+    branches:
+      - "master.*"
+    image:
+      - container:
+          SLAVE_TYPE: "container"
+    scenario:
+      - "ansible-lint"
+      - "ansible-syntax"
+      - "bashate"
+      - "docs"
+      - "pep8"
+      - "releasenotes"
+    action:
+      - "tox-test"
+    jobs:
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'


### PR DESCRIPTION
This change adds the jobs necessary to stop using Travis CI with
rpc-maas and is part of the work to move all projects to using the
standard jobs.

Issue: [RE-1164](https://rpc-openstack.atlassian.net/browse/RE-1164)