### PR TITLE
[RO-3870] Change the PR job to non-artifacted

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -13,8 +13,8 @@
       | ^gating/post_merge_test/
       | ^gating/update_dependencies/
     image:
-      - xenial:
-          IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
+      - xenial_no_artifacts:
+          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
     scenario:
       - ironic:
           TRIGGER_PR_PHRASE_ONLY: true
@@ -149,7 +149,7 @@
     branch: "master"
     jira_project_key: "RO"
     image:
-      - xenial:
+      - xenial_strict_artifacts:
           IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
       - xenial_loose_artifacts:
           IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
@@ -174,7 +174,6 @@
     branch: "master"
     jira_project_key: "RO"
     image:
-      - xenial_mnaio
       - xenial_mnaio_loose_artifacts
       - xenial_mnaio_no_artifacts
     scenario:


### PR DESCRIPTION
The default PR test needs to be non-artifacted. This change updates the
PR image properties so that non-artifacted jobs can run as the default.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [RO-3870](https://rpc-openstack.atlassian.net/browse/RO-3870)