### PR TITLE
RE-1169 Specify container base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:16.04
 RUN apt-get update && apt-get install -y groovy2 python-pip build-essential python-dev libssl-dev curl libffi-dev sudo git-core
 COPY requirements.txt /requirements.txt
 COPY test-requirements.txt /test-requirements.txt

--- a/Dockerfile.standard_job
+++ b/Dockerfile.standard_job
@@ -1,0 +1,10 @@
+ARG BASE_IMAGE=ubuntu
+FROM ${BASE_IMAGE}
+RUN apt-get update && apt-get install -y groovy2 python-pip build-essential python-dev libssl-dev curl libffi-dev sudo git-core
+COPY requirements.txt /requirements.txt
+COPY test-requirements.txt /test-requirements.txt
+COPY constraints.txt /constraints.txt
+RUN pip install -c /constraints.txt -r /requirements.txt
+RUN pip install -c /constraints.txt -r /test-requirements.txt
+RUN useradd jenkins --shell /bin/bash --create-home --uid 500
+RUN echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers

--- a/Dockerfile.standard_job
+++ b/Dockerfile.standard_job
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ubuntu
+ARG BASE_IMAGE=ubuntu:16.04
 FROM ${BASE_IMAGE}
 RUN apt-get update && apt-get install -y groovy2 python-pip build-essential python-dev libssl-dev curl libffi-dev sudo git-core
 COPY requirements.txt /requirements.txt

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -937,8 +937,12 @@ void standard_job_slave(String slave_type, Closure body){
         body()
       }
     } else if (slave_type == "container"){
+      String image_name = env.BUILD_TAG.toLowerCase()
+      // NOTE(mattt): This is necessary to initially gate this change as we
+      // have no parameter for SLAVE_CONTAINER_BASE_IMAGE defined yet
+      String base_image = env.SLAVE_CONTAINER_BASE_IMAGE ? env.SLAVE_CONTAINER_BASE_IMAGE : "ubuntu"
       dir("rpc-gating"){
-        container = docker.build env.BUILD_TAG.toLowerCase()
+        container = docker.build(image_name, "--build-arg BASE_IMAGE=${base_image} -f Dockerfile.standard_job .")
       }
       container.inside {
         configure_git()

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -940,7 +940,7 @@ void standard_job_slave(String slave_type, Closure body){
       String image_name = env.BUILD_TAG.toLowerCase()
       // NOTE(mattt): This is necessary to initially gate this change as we
       // have no parameter for SLAVE_CONTAINER_BASE_IMAGE defined yet
-      String base_image = env.SLAVE_CONTAINER_BASE_IMAGE ? env.SLAVE_CONTAINER_BASE_IMAGE : "ubuntu"
+      String base_image = env.SLAVE_CONTAINER_BASE_IMAGE ? env.SLAVE_CONTAINER_BASE_IMAGE : "ubuntu:16.04"
       dir("rpc-gating"){
         container = docker.build(image_name, "--build-arg BASE_IMAGE=${base_image} -f Dockerfile.standard_job .")
       }

--- a/rpc_jobs/defaults.yml
+++ b/rpc_jobs/defaults.yml
@@ -8,6 +8,7 @@
     FALLBACK_REGIONS: "IAD"
     # standard_job_params
     SLAVE_TYPE: "instance"
+    SLAVE_CONTAINER_BASE_IMAGE: "ubuntu"
     # Misc
     CRON: "H H(9-21) * * 1-5"
     credentials: ""

--- a/rpc_jobs/defaults.yml
+++ b/rpc_jobs/defaults.yml
@@ -8,7 +8,7 @@
     FALLBACK_REGIONS: "IAD"
     # standard_job_params
     SLAVE_TYPE: "instance"
-    SLAVE_CONTAINER_BASE_IMAGE: "ubuntu"
+    SLAVE_CONTAINER_BASE_IMAGE: "ubuntu:16.04"
     # Misc
     CRON: "H H(9-21) * * 1-5"
     credentials: ""

--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -110,3 +110,11 @@
             Standard jobs can be run on different types of slave. The default
             for this parameter is set to "instance" for a compute instances. To
             use a Docker container set this parameter to "container".
+      - string:
+          name: "SLAVE_CONTAINER_BASE_IMAGE"
+          default: "{SLAVE_CONTAINER_BASE_IMAGE}"
+          description: >
+            When SLAVE_TYPE is set to "container", you can optionally override
+            the base image used to build the docker image when running a docker
+            build. The default defined in the Dockerfile and on the parameter is
+            "ubuntu".

--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -117,4 +117,4 @@
             When SLAVE_TYPE is set to "container", you can optionally override
             the base image used to build the docker image when running a docker
             build. The default defined in the Dockerfile and on the parameter is
-            "ubuntu".
+            "ubuntu:16.04".

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -63,6 +63,7 @@
           description: Branch of the repo under test
       - standard_job_params:
           SLAVE_TYPE: "{SLAVE_TYPE}"
+          SLAVE_CONTAINER_BASE_IMAGE: "{SLAVE_CONTAINER_BASE_IMAGE}"
     triggers:
       - timed: "@daily"
 

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -55,6 +55,7 @@
               Destroy Slave
       - standard_job_params:
           SLAVE_TYPE: "{SLAVE_TYPE}"
+          SLAVE_CONTAINER_BASE_IMAGE: "{SLAVE_CONTAINER_BASE_IMAGE}"
       - string:
           name: skip_pattern
           default: "{skip_pattern}"

--- a/rpc_jobs/unit/re_unit_tests.yml
+++ b/rpc_jobs/unit/re_unit_tests.yml
@@ -67,7 +67,7 @@
             ]
           )
         },
-        "Standard Slave Container": {
+        "Standard Slave Container Default Image": {
           build(
             job: "RE-unit-test-slave-types",
             wait: true,
@@ -81,6 +81,29 @@
                 $class: 'StringParameterValue',
                 name: 'SLAVE_TYPE',
                 value: 'container'
+              ]
+            ]
+          )
+        },
+        "Standard Slave Container Custom Image": {
+          build(
+            job: "RE-unit-test-slave-types",
+            wait: true,
+            parameters: [
+              [
+                $class: 'StringParameterValue',
+                name: 'RPC_GATING_BRANCH',
+                value: env.RPC_GATING_BRANCH
+              ],
+              [
+                $class: 'StringParameterValue',
+                name: 'SLAVE_TYPE',
+                value: 'container'
+              ],
+              [
+                $class: 'StringParameterValue',
+                name: 'SLAVE_CONTAINER_BASE_IMAGE',
+                value: 'ubuntu:17.10'
               ]
             ]
           )

--- a/rpc_jobs/unit/single_use_slave.yml
+++ b/rpc_jobs/unit/single_use_slave.yml
@@ -16,6 +16,7 @@
       - rpc_gating_params
       - standard_job_params:
           SLAVE_TYPE: "instance"
+          SLAVE_CONTAINER_BASE_IMAGE: "ubuntu"
       - string:
           name: STAGES
           default: "Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
@@ -31,22 +32,39 @@
       library "rpc-gating@${RPC_GATING_BRANCH}"
       common.globalWraps(){
         common.standard_job_slave(env.SLAVE_TYPE){
-          String virt_type = sh(script: """#!/bin/bash
-            systemd-detect-virt
+          String inside_container = sh(script: """#!/bin/bash
+            test -f /.dockerenv && echo "yes" || echo "no"
+          """, returnStdout: true).trim()
+
+          String distro = sh(script: """#!/bin/bash
+            source /etc/lsb-release
+            echo \${DISTRIB_RELEASE}
           """, returnStdout: true).trim()
 
           sh """
-            echo "I'm a ${env.SLAVE_TYPE} slave, running ${virt_type}"
+            echo "I'm an Ubuntu ${distro} ${env.SLAVE_TYPE} slave"
           """
 
           // NOTE(mattt): If env.SLAVE_TYPE is set to an unrecognized type, an
           // exception will be raised in common.standard_job_slave()
           stage("Ensure virt type matches env.SLAVE_TYPE") {
             if (env.SLAVE_TYPE == "instance") {
-              assert virt_type == "xen"
+              assert inside_container == "no"
             } else {
-              assert virt_type == "docker"
-            }
-          }
-        }
-      }
+              assert inside_container == "yes"
+            } // if
+          } // stage
+
+          stage("Ensure container distro matches env.SLAVE_CONTAINER_BASE_IMAGE") {
+            if (env.SLAVE_TYPE == "container") {
+              if (env.SLAVE_CONTAINER_BASE_IMAGE == "ubuntu") {
+                assert distro == "16.04"
+              } else {
+                assert distro == env.SLAVE_CONTAINER_BASE_IMAGE.split(":")[1]
+              } // if
+            } else {
+              print 'Skipped as env.SLAVE_TYPE != "container"'
+            } // if
+          } // stage
+        } // standard_job_slave
+      } // globalWraps

--- a/rpc_jobs/unit/single_use_slave.yml
+++ b/rpc_jobs/unit/single_use_slave.yml
@@ -16,7 +16,7 @@
       - rpc_gating_params
       - standard_job_params:
           SLAVE_TYPE: "instance"
-          SLAVE_CONTAINER_BASE_IMAGE: "ubuntu"
+          SLAVE_CONTAINER_BASE_IMAGE: "ubuntu:16.04"
       - string:
           name: STAGES
           default: "Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
@@ -57,11 +57,7 @@
 
           stage("Ensure container distro matches env.SLAVE_CONTAINER_BASE_IMAGE") {
             if (env.SLAVE_TYPE == "container") {
-              if (env.SLAVE_CONTAINER_BASE_IMAGE == "ubuntu") {
-                assert distro == "16.04"
-              } else {
                 assert distro == env.SLAVE_CONTAINER_BASE_IMAGE.split(":")[1]
-              } // if
             } else {
               print 'Skipped as env.SLAVE_TYPE != "container"'
             } // if


### PR DESCRIPTION
In most cases, it's irrelevant which base image we use for creating a
container, however an ops-fabric test requires an ubuntu:17.10
container and subsequent tests call python3.6, which is not available
in the standard ubuntu base container image we use for all tests.

This review introduces the parameter `SLAVE_CONTAINER_BASE_IMAGE`,
allowing projects to specify which Ubuntu-flavored container base
image is used. Additionally, we duplicate the Dockerfile to
Dockerfile.standard_job because when the ARG is in the default
Dockerfile all jobs that use it which do not explicitly pass in
BASE_IMAGE will fail. This means this specific job will be impossible
to gate unless we manually update the docker call in Build-Gating-Venv.

NOTE: We remove the systemd-detect-virt call in
rpc_jobs/unit/single_use_slave.yml since systemd does not appear to be
installed on ubuntu:17.10.  Instead, we check for the existence of the
/.dockerenv file to determine if we're inside a container. This may not
be the most reliable long-term test since Docker may remove this file,
however for now it seems to work.

Issue: [RE-1169](https://rpc-openstack.atlassian.net/browse/RE-1169)