### PR TITLE
RO-3868 Update RPC-O test matrix

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -188,6 +188,31 @@
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
 - project:
+    name: "rpc-openstack-master-rc-aio-postmerge"
+    repo_name: "rpc-openstack"
+    repo_url: "https://github.com/rcbops/rpc-openstack"
+    branch: "master-rc"
+    jira_project_key: "RO"
+    image:
+      - xenial_strict_artifacts:
+          IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
+      - xenial_loose_artifacts:
+          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+      - xenial_no_artifacts:
+          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+    scenario:
+      - "ironic"
+      - "swift"
+    action:
+      - deploy:
+          FLAVOR: "7"
+    # This is the build that will be triggered by the push trigger job
+    trigger_build: 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+      - 'PM-push-trigger_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+- project:
     name: "rpc-openstack-master-rc-mnaio-postmerge"
     repo_name: "rpc-openstack"
     repo_url: "https://github.com/rcbops/rpc-openstack"
@@ -197,6 +222,7 @@
       - xenial_mnaio_loose_artifacts
       - xenial_mnaio_no_artifacts
     scenario:
+      - "ironic"
       - "swift"
     action:
       - deploy:
@@ -246,7 +272,6 @@
     branch: "newton"
     jira_project_key: "RO"
     image:
-      - xenial_mnaio
       - xenial_mnaio_loose_artifacts
     scenario:
       - "ironic"


### PR DESCRIPTION
1. As the MNAIO test jobs currently do not execute any
   form of functional testing (eg: tempest), the AIO
   test execution is added to the master-rc branch.

2. As the Ironic MNAIO test jobs appear to have stabilised
   for the master branch, they're added to the master-rc
   branch too.

3. As the MNAIO tests always deploy the latest base OS
   packages, a strict mode deployment cannot work. As such
   the strict mode MNAIO test execution for the newton
   branch is removed.

Issue: [RO-3868](https://rpc-openstack.atlassian.net/browse/RO-3868)