### PR TITLE
RE-1169 Add unit test for container slaves

### DIFF
--- a/rpc_jobs/unit/re_unit_tests.yml
+++ b/rpc_jobs/unit/re_unit_tests.yml
@@ -49,15 +49,38 @@
             ]
           )
         },
-        "Single Use Slave": {
+        "Standard Slave Instance": {
           build(
-            job: "RE-unit-test-single-use-slave",
+            job: "RE-unit-test-slave-types",
             wait: true,
             parameters: [
               [
                 $class: 'StringParameterValue',
                 name: 'RPC_GATING_BRANCH',
                 value: env.RPC_GATING_BRANCH
+              ],
+              [
+                $class: 'StringParameterValue',
+                name: 'SLAVE_TYPE',
+                value: 'instance'
+              ]
+            ]
+          )
+        },
+        "Standard Slave Container": {
+          build(
+            job: "RE-unit-test-slave-types",
+            wait: true,
+            parameters: [
+              [
+                $class: 'StringParameterValue',
+                name: 'RPC_GATING_BRANCH',
+                value: env.RPC_GATING_BRANCH
+              ],
+              [
+                $class: 'StringParameterValue',
+                name: 'SLAVE_TYPE',
+                value: 'container'
               ]
             ]
           )

--- a/rpc_jobs/unit/single_use_slave.yml
+++ b/rpc_jobs/unit/single_use_slave.yml
@@ -1,5 +1,5 @@
 - job:
-    name: RE-unit-test-single-use-slave
+    name: RE-unit-test-slave-types
     project-type: workflow
     concurrent: true
     properties:
@@ -15,6 +15,10 @@
           FALLBACK_REGIONS: "IAD"
       - rpc_gating_params
       - string:
+          name: SLAVE_TYPE
+          default: container
+          description: "Type of slave to test, container or instance."
+      - string:
           name: STAGES
           default: "Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
           description: |
@@ -28,9 +32,9 @@
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
       common.globalWraps(){
-        pubcloud.runonpubcloud {
+        common.standard_job_slave(env.SLAVE_TYPE){
           sh """
-            echo "I'm running on a single use slave!"
+            echo "I'm a ${env.SLAVE_TYPE} slave"
           """
         }
       }

--- a/rpc_jobs/unit/single_use_slave.yml
+++ b/rpc_jobs/unit/single_use_slave.yml
@@ -14,10 +14,8 @@
           REGIONS: "DFW ORD"
           FALLBACK_REGIONS: "IAD"
       - rpc_gating_params
-      - string:
-          name: SLAVE_TYPE
-          default: container
-          description: "Type of slave to test, container or instance."
+      - standard_job_params:
+          SLAVE_TYPE: "instance"
       - string:
           name: STAGES
           default: "Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
@@ -33,8 +31,22 @@
       library "rpc-gating@${RPC_GATING_BRANCH}"
       common.globalWraps(){
         common.standard_job_slave(env.SLAVE_TYPE){
+          String virt_type = sh(script: """#!/bin/bash
+            systemd-detect-virt
+          """, returnStdout: true).trim()
+
           sh """
-            echo "I'm a ${env.SLAVE_TYPE} slave"
+            echo "I'm a ${env.SLAVE_TYPE} slave, running ${virt_type}"
           """
+
+          // NOTE(mattt): If env.SLAVE_TYPE is set to an unrecognized type, an
+          // exception will be raised in common.standard_job_slave()
+          stage("Ensure virt type matches env.SLAVE_TYPE") {
+            if (env.SLAVE_TYPE == "instance") {
+              assert virt_type == "xen"
+            } else {
+              assert virt_type == "docker"
+            }
+          }
         }
       }


### PR DESCRIPTION
RE-1169 requires upgrading the jenkins docker workflow plugin, to ensure
that the container standard slave type is still functioning after
this change and future changes, an additional unit test is added.

Issue: [RE-1169](https://rpc-openstack.atlassian.net/browse/RE-1169)