### PR TITLE
RE-1210 Fix skipping aborted-build issue creation

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1134,4 +1134,13 @@ void globalWraps(Closure body){
   } // timestamps
 }
 
+Boolean isUserAbortedBuild() {
+  if (currentBuild.rawBuild.getAction(InterruptedBuildAction.class)) {
+    userAborted = true
+  } else {
+    userAborted = false
+  }
+  return userAborted
+}
+
 return this

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -156,19 +156,11 @@
           }} catch (e) {{
             print(e)
             currentBuild.result="FAILURE"
-            // Try and ascertain the cause of the exception.
-            // If it was caused by a user, its a manual abort and
-            // an issue shouldn't be created. If it was created by
-            // SYSTEM or the exception doesn't contain enough information
-            // then an issue should be created.
-            String user
-            try {{
-              user = e.getCauses()[0].getUser().toString()
-            }} catch (f){{
-              user = 'SYSTEM'
-            }}
-            if(user == 'SYSTEM' && JIRA_PROJECT_KEY != ''){{
+            if (! common.isUserAbortedBuild() && JIRA_PROJECT_KEY != '') {{
+              print("Creating build failure issue.")
               common.build_failure_issue(JIRA_PROJECT_KEY)
+            }} else {{
+              print("Skipping build failure issue creation.")
             }}
             throw e
           }} finally {{


### PR DESCRIPTION
If a post-merge build is aborted by a user, the failure should not be
recorded in an issue. This change adds a new function to test if the
build was manually aborted, by looking for a specific interrupt action
as described in Jenkins issue JENKINS-28822 [1].

The code replaced in this commit does not work, the exception does not
have a `getCauses` method which results in `user` always being set to
`"SYSTEM"`.

[1] https://issues.jenkins-ci.org/browse/JENKINS-28822

Test builds (search for "build failure issue" to see log entry):
Script failure: https://rpc.jenkins.cit.rackspace.net/job/PM_rpc-openstack-master-xenial_loose_artifacts-swift-deploy-gh-testing/10/consoleFull
User aborted: https://rpc.jenkins.cit.rackspace.net/job/PM_rpc-openstack-master-xenial_loose_artifacts-swift-deploy-gh-testing/9/consoleFull

Issue: [RE-1210](https://rpc-openstack.atlassian.net/browse/RE-1210)