### PR TITLE
Fix warning for jinja2 brackets

### DIFF
--- a/playbooks/setup_jenkins_slave.yml
+++ b/playbooks/setup_jenkins_slave.yml
@@ -76,7 +76,7 @@
         state: present
         regexp: 'jenkins'
         line: 'jenkins ALL=(ALL) NOPASSWD: ALL'
-      when: "{{ allow_jenkins_sudo }}"
+      when: allow_jenkins_sudo | bool
 
     - name: Copy constraints file over to cloud server
       copy:


### PR DESCRIPTION
This patch removes the jinja2 brackets from the when argument to
avoid Ansible warnings.

Issue: [RE-1210](https://rpc-openstack.atlassian.net/browse/RE-1210)