### PR TITLE
RE-36 Force push-triggered builds into DFW

### DIFF
--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -32,6 +32,9 @@
       - trigger-builds:
         - project:
             - "{trigger_build}"
+          predefined-parameters: |
+            REGIONS=DFW
+            FALLBACK_REGIONS=
 
 - job-template:
     name: 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'


### PR DESCRIPTION
At present push-triggered jobs end up in multiple regions, which is
causing saved images to be spread across three regions.  We want to
force push-triggered jobs to go to DFW specifically so that we only
need to worry about saved images in DFW.

Issue: [RE-36](https://rpc-openstack.atlassian.net/browse/RE-36)