### PR TITLE
RLM-1405 Adds Major/Leap jobs for M2N

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -55,6 +55,7 @@
       - "swift"
     action:
       - "mitaka_to_newton_major"
+      - "mitaka_to_newton_leap"
       - "liberty_to_newton_leap"
       - "r12.2.8_to_newton_leap"
       - "r12.2.5_to_newton_leap"
@@ -66,6 +67,10 @@
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
     exclude:
+      - image: "xenial_aio"
+        action: "mitaka_to_newton_major"
+      - image: "xenial_aio"
+        action: "mitaka_to_newton_leap"
       - image: "xenial_aio"
         action: "liberty_to_newton_leap"
       - image: "xenial_aio"
@@ -126,6 +131,8 @@
     scenario:
       - "swift"
     action:
+      - "mitaka_to_newton_major"
+      - "mitaka_to_newton_leap"
       - "liberty_to_newton_leap"
       - "r12.2.8_to_newton_leap"
       - "r12.2.5_to_newton_leap"


### PR DESCRIPTION
Adds Major and Leap jobs for MNAIO and AIO to test
functionality and timing for both methods.

Also excludes Xenial Mitaka jobs since we only support
Trusty.

Issue: [RLM-1405](https://rpc-openstack.atlassian.net/browse/RLM-1405)