### PR TITLE
RE-1169 Make use of Docker more customisable

### DIFF
--- a/Dockerfile.standard_job
+++ b/Dockerfile.standard_job
@@ -1,4 +1,5 @@
-FROM ubuntu:16.04
+ARG BASE_IMAGE=ubuntu:16.04
+FROM ${BASE_IMAGE}
 RUN apt-get update && apt-get install -y groovy2 python-pip build-essential python-dev libssl-dev curl libffi-dev sudo git-core
 COPY requirements.txt /requirements.txt
 COPY test-requirements.txt /test-requirements.txt

--- a/rpc_jobs/defaults.yml
+++ b/rpc_jobs/defaults.yml
@@ -8,6 +8,9 @@
     FALLBACK_REGIONS: "IAD"
     # standard_job_params
     SLAVE_TYPE: "instance"
+    SLAVE_CONTAINER_DOCKERFILE_REPO: "RE"
+    SLAVE_CONTAINER_DOCKERFILE_PATH: "./Dockerfile.standard_job"
+    SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS: "BASE_IMAGE=ubuntu:16.04"
     # Misc
     CRON: "H H(9-21) * * 1-5"
     credentials: ""

--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -110,3 +110,27 @@
             Standard jobs can be run on different types of slave. The default
             for this parameter is set to "instance" for a compute instances. To
             use a Docker container set this parameter to "container".
+      - choice:
+          name: "SLAVE_CONTAINER_DOCKERFILE_REPO"
+          choices:
+            - "RE"
+            - "PROJECT"
+          description: >
+            This parameter, which defaults to "RE", determines where to look
+            for the Dockerfile specified in SLAVE_CONTAINER_DOCKERFILE_PATH.
+            "RE" searches within rpc-gating, and "PROJECT" searches within the
+            project in test.
+      - string:
+          name: "SLAVE_CONTAINER_DOCKERFILE_PATH"
+          default: "{SLAVE_CONTAINER_DOCKERFILE_PATH}"
+          description: >
+            This is the relative path of the Dockerfile to build from. This
+            defaults to "./Dockerfile.standard_job".
+      - string:
+          name: "SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS"
+          default: "{SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS}"
+          description: >
+            This is a list of space-separated build args to pass to docker
+            build. This defaults to "BASE_IMAGE=ubuntu:16.04", which is
+            specifically applicable to the "./Dockerfile.standard_job" in
+            rpc-gating.

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -63,6 +63,9 @@
           description: Branch of the repo under test
       - standard_job_params:
           SLAVE_TYPE: "{SLAVE_TYPE}"
+          SLAVE_CONTAINER_DOCKERFILE_REPO: "{SLAVE_CONTAINER_DOCKERFILE_REPO}"
+          SLAVE_CONTAINER_DOCKERFILE_PATH: "{SLAVE_CONTAINER_DOCKERFILE_PATH}"
+          SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS: "{SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS}"
     triggers:
       - timed: "@daily"
 

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -55,6 +55,9 @@
               Destroy Slave
       - standard_job_params:
           SLAVE_TYPE: "{SLAVE_TYPE}"
+          SLAVE_CONTAINER_DOCKERFILE_REPO: "{SLAVE_CONTAINER_DOCKERFILE_REPO}"
+          SLAVE_CONTAINER_DOCKERFILE_PATH: "{SLAVE_CONTAINER_DOCKERFILE_PATH}"
+          SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS: "{SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS}"
       - string:
           name: skip_pattern
           default: "{skip_pattern}"

--- a/rpc_jobs/unit/re_unit_tests.yml
+++ b/rpc_jobs/unit/re_unit_tests.yml
@@ -67,7 +67,7 @@
             ]
           )
         },
-        "Standard Slave Container": {
+        "Standard 'RE' Container (No Build Args)": {
           build(
             job: "RE-unit-test-slave-types",
             wait: true,
@@ -82,6 +82,52 @@
                 name: 'SLAVE_TYPE',
                 value: 'container'
               ]
+            ]
+          )
+        },
+        "Standard 'RE' Container (Custom Build Args)": {
+          build(
+            job: "RE-unit-test-slave-types",
+            wait: true,
+            parameters: [
+              [
+                $class: 'StringParameterValue',
+                name: 'RPC_GATING_BRANCH',
+                value: env.RPC_GATING_BRANCH
+              ],
+              [
+                $class: 'StringParameterValue',
+                name: 'SLAVE_TYPE',
+                value: 'container'
+              ],
+              [
+                $class: 'StringParameterValue',
+                name: 'SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS',
+                value: 'BASE_IMAGE=ubuntu:17.10'
+              ]
+            ]
+          )
+        },
+        "Standard 'PROJECT' Container (No Build Args)": {
+          build(
+            job: "RE-unit-test-slave-types",
+            wait: true,
+            parameters: [
+              [
+                $class: 'StringParameterValue',
+                name: 'RPC_GATING_BRANCH',
+                value: env.RPC_GATING_BRANCH
+              ],
+              [
+                $class: 'StringParameterValue',
+                name: 'SLAVE_TYPE',
+                value: 'container'
+              ],
+              [
+                $class: 'StringParameterValue',
+                name: 'SLAVE_CONTAINER_DOCKERFILE_REPO',
+                value: 'PROJECT'
+              ],
             ]
           )
         },

--- a/rpc_jobs/unit/single_use_slave.yml
+++ b/rpc_jobs/unit/single_use_slave.yml
@@ -16,6 +16,9 @@
       - rpc_gating_params
       - standard_job_params:
           SLAVE_TYPE: "instance"
+          SLAVE_CONTAINER_DOCKERFILE_REPO: "RE"
+          SLAVE_CONTAINER_DOCKERFILE_PATH: "./Dockerfile.standard_job"
+          SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS: "BASE_IMAGE=ubuntu:16.04"
       - string:
           name: STAGES
           default: "Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
@@ -30,23 +33,48 @@
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
       common.globalWraps(){
+        // NOTE(mattt): These vars are required in common.standard_job_slave()
+        // when this job is testing a custom dockerfile.
+        env.REPO_URL = "https://github.com/rcbops/rpc-gating"
+        env.BRANCH = "${RPC_GATING_BRANCH}"
+        env.RE_JOB_REPO_NAME = "rpc-gating"
+
         common.standard_job_slave(env.SLAVE_TYPE){
-          String virt_type = sh(script: """#!/bin/bash
-            systemd-detect-virt
+          String inside_container = sh(script: """#!/bin/bash
+            test -f /.dockerenv && echo "yes" || echo "no"
+          """, returnStdout: true).trim()
+
+          String distro = sh(script: """#!/bin/bash
+            source /etc/lsb-release
+            echo \${DISTRIB_RELEASE}
           """, returnStdout: true).trim()
 
           sh """
-            echo "I'm a ${env.SLAVE_TYPE} slave, running ${virt_type}"
+            echo "I'm an Ubuntu ${distro} ${env.SLAVE_TYPE} slave"
           """
 
           // NOTE(mattt): If env.SLAVE_TYPE is set to an unrecognized type, an
           // exception will be raised in common.standard_job_slave()
           stage("Ensure virt type matches env.SLAVE_TYPE") {
             if (env.SLAVE_TYPE == "instance") {
-              assert virt_type == "xen"
+              assert inside_container == "no"
             } else {
-              assert virt_type == "docker"
-            }
-          }
-        }
-      }
+              assert inside_container == "yes"
+            } // if
+          } // stage
+
+          stage("Ensure args are correctly passed into `docker build`") {
+            if (env.SLAVE_TYPE == "container" && env.SLAVE_CONTAINER_DOCKERFILE_REPO == "RE") {
+              if (env.SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS == "BASE_IMAGE=ubuntu:16.04") {
+                assert distro == "16.04"
+              } else if (env.SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS == "BASE_IMAGE=ubuntu:17.10") {
+                assert distro == "17.10"
+              } else {
+                throw new Exception("Unexpected env.SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS passed into test")
+              }
+            } else {
+              print 'Skipped as env.SLAVE_TYPE != "container" or env.SLAVE_CONTAINER_DOCKERFILE_REPO != "RE"'
+            } // if
+          } // stage
+        } // standard_job_slave
+      } // globalWraps


### PR DESCRIPTION
In most cases, it's irrelevant which base image we use for creating a
container, however an ops-fabric test requires an ubuntu:17.10
container and subsequent tests call python3.6, which is not available
in the standard ubuntu base container image we use for all tests.

This review introduces the following three new parameters:

SLAVE_CONTAINER_DOCKERFILE_REPO
SLAVE_CONTAINER_DOCKERFILE_PATH
SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS

SLAVE_CONTAINER_DOCKERFILE_REPO allows you to use the Dockerfile inside
rpc-gating (`RE`), or the project in test (`PROJECT`).

SLAVE_CONTAINER_DOCKERFILE_PATH allows you to specify the location and
name of the Dockerfile, relative to the root of rpc-gating or the clone
of the project in test.

SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS allows you to pass in custom
build args to `docker build`, and in the case of rpc-gating's
Dockerfile.standard_job you can specify which base image to use in the
build.

NOTE: We remove the systemd-detect-virt call in
rpc_jobs/unit/single_use_slave.yml since systemd does not appear to be
installed on ubuntu:17.10. Instead, we check for the existence of the
/.dockerenv file to determine if we're inside a container. This may not
be the most reliable long-term test since Docker may remove this file,
however for now it seems to work.

Issue: [RE-1169](https://rpc-openstack.atlassian.net/browse/RE-1169)