### PR TITLE
(ASC-143) Add mnaio system test job

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -179,11 +179,21 @@
       - "ironic"
       - "swift"
     action:
+      - system:
+          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+          FLAVOR: "onmetal-io1"
+          REGIONS: "IAD"
+          FALLBACK_REGIONS: ""
       - deploy:
           IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
           FLAVOR: "onmetal-io1"
           REGIONS: "IAD"
           FALLBACK_REGIONS: ""
+    exclude:
+      - action: system
+        image: xenial_mnaio_loose_artifacts
+      - action: system
+        scenario: ironic
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 


### PR DESCRIPTION
This commit adds 'system' as a scenario to
`rpc-openstack-master-mnaio-postmerge` project and a filter to ensure
that it only creates a single jobs for
`PM_rpc-openstack-master-xenial_mnaio_no_artifacts-system-deploy`.

This job is will be the proof of concept job for running system level
testing on rpc-openstack. Hooks for taking advantage of the `system`
scenario have not yet been implemented in the `rpc-openstack` repo.

Issue: [ASC-143](https://rpc-openstack.atlassian.net/browse/ASC-143)