### PR TITLE
RE-1329 Compress Logs

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1091,6 +1091,8 @@ void setTriggerVars(){
 // add wrappers that should be used for all jobs.
 // max log size is in MB
 void globalWraps(Closure body){
+  // Compress logs at the end of each run.
+  properties([compressBuildLog()])
   // global timeout is long, so individual jobs can set shorter timeouts and
   // still have to cleanup, archive atefacts etc.
   timestamps{

--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -117,4 +117,23 @@
             throw e
           }
         } // internal_slave
+        stage("Master Log Compression"){
+          node("master"){
+            // Note that already compressed logs will be skipped as they
+            // get renamed .gz .
+            // This only affects the stage logs used for blue ocean,
+            // console logs are compressed using a plugin activated via
+            // common.globalWraps.
+            // Logs newer than 1 day are skipped to prevent compressing
+            // the logs from running builds.
+            sh """#!/bin/bash
+              cd /var/lib/jenkins/jobs
+              find . -regex '.+/builds/[0-9]+/[0-9]+\\.log' -mtime +1 \\
+                |while read stagelog; do
+                  echo $stagelog
+                  gzip $stagelog
+                done
+            """
+          }
+        }
       } // globalWraps


### PR DESCRIPTION
This commit ensures console logs are zipped when a job terminates.
This will affect all future jobs, current jobs are currentbly being
compressed by a bash loop. This relies on a plugin which has already
been installed.

Issue: [RE-1329](https://rpc-openstack.atlassian.net/browse/RE-1329)