### PR TITLE
RE-1310 Release Improvements

### DIFF
--- a/rpc_jobs/release.yml
+++ b/rpc_jobs/release.yml
@@ -53,6 +53,9 @@
                 --repo "${REPO}" \
                 clone \
                     --ref "${RC_BRANCH}" \
+                publish_tag \
+                    --ref "${RC_BRANCH}" \
+                    --version "${VERSION}" \
                 generate_release_notes \
                     --version "${VERSION}" \
                     --prev-version "${PREVIOUS_VERSION}" \
@@ -60,9 +63,6 @@
                     --script "gating/generate_release_notes/run" \
                     --script "optional:gating/generate_release_notes/post" \
                     --out-file "${RELEASE_NOTES_FILE}" \
-                publish_tag \
-                    --ref "${RC_BRANCH}" \
-                    --version "${VERSION}" \
                 create_release \
                     --version "${VERSION}" \
                     --bodyfile "${RELEASE_NOTES_FILE}" \


### PR DESCRIPTION
Two improvements to assist with future releases:

* Ensure that create tag happens before release notes are generated so that the new tag can be compared against the previous tag when generating release notes.

Issue: [RE-1310](https://rpc-openstack.atlassian.net/browse/RE-1310)