### PR TITLE
RE-36 Adjustable boot timeout & new snapshot jobs

### DIFF
--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -9,6 +9,7 @@
     inventory_path: "{{ lookup('env', 'WORKSPACE') }}/rpc-gating/playbooks/inventory"
     user_data_path: "{{ lookup('env', 'WORKSPACE') }}/rpc-gating/scripts/user_data_pubcloud.sh"
     cloud_name: "public_cloud"
+    boot_timeout: "{{ lookup('env', 'BOOT_TIMEOUT') | default(900, true) }}"
   tasks:
 
     # Region should be a CSV string.
@@ -48,7 +49,7 @@
         meta:
           build_config: core
         wait: yes
-        timeout: 900
+        timeout: "{{ boot_timeout }}"
       register: result
       with_items: "{{ regions_shuf + fallback_regions_shuff }}"
       when:

--- a/rpc_jobs/rpc_designate.yml
+++ b/rpc_jobs/rpc_designate.yml
@@ -50,6 +50,36 @@
 
     jira_project_key: "RI"
 
-    # Link to the standard pre-merge-template
+    # Link to the standard post-merge-template
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+ - project:
+    name: "rpc-designate-post-merge-snapshot"
+
+    repo_name: "rpc-designate"
+    # URL of the rpc-designate repository
+    repo_url: "https://github.com/rcbops/rpc-designate"
+
+    # Use image for RPC-O install
+    image:
+      - xenial_snapshot:
+          REGIONS: "DFW"
+          FALLBACK_REGIONS: ""
+          FLAVOR: "7"
+          BOOT_TIMEOUT: 1500
+
+    scenario:
+      - newton:
+          IMAGE: "rpc-r14.9.0-xenial-swift"
+      - pike:
+          IMAGE: "rpc-r16.2.0-xenial_no_artifacts-swift"
+    action:
+      - "deploy"
+
+    # Sending these failures to RE while we stabilise these images
+    jira_project_key: "RE"
+
+    # Link to the standard post-merge-template
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -45,6 +45,7 @@
     FLAVOR: "performance1-1"
     IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
     CRON: "@daily"
+    BOOT_TIMEOUT: 900
     properties:
       - build-discarder:
           num-to-keep: 14
@@ -78,6 +79,9 @@
       common.globalWraps(){{
 
         env.STAGES="Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
+        // BOOT_TIMEOUT is used inside an ansible playbook when creating cloud
+        // instances. Builds from snapshots need a significantly longer timeout.
+        env.BOOT_TIMEOUT = "{BOOT_TIMEOUT}"
 
         // Pass details about the job parameters through
         // to the target environment so that scripts can

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -26,6 +26,7 @@
     FLAVOR: "performance1-1"
     IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
     TRIGGER_PR_PHRASE_ONLY: false
+    BOOT_TIMEOUT: 900
     skip_pattern: ""
     properties:
       - build-discarder:
@@ -84,6 +85,10 @@
       }}
       library "rpc-gating@${{RPC_GATING_BRANCH}}"
       common.globalWraps(){{
+
+        // BOOT_TIMEOUT is used inside an ansible playbook when creating cloud
+        // instances. Builds from snapshots need a significantly longer timeout.
+        env.BOOT_TIMEOUT = "{BOOT_TIMEOUT}"
 
         // Pass details about the job parameters through
         // to the target environment so that scripts can


### PR DESCRIPTION
Booting from a saved image is significantly slower than from a base
image, and as such we need to make the timeout configurable.

The default remains 900 seconds, but we can now override this via
BOOT_TIMEOUT.

Additionally, we add some new rpc-designate periodic jobs which use
snapshot images. These jobs are purely for testing and we will look
at adding process and moving all rpc-designate's jobs over to these
images once they are running reliably.

Lastly, we update a comment in the rpc-designate-post-merge project
which was made mention of the pre-merge template and not the
post-merge template.

Issue: [RE-36](https://rpc-openstack.atlassian.net/browse/RE-36)