### PR TITLE
RE-1329 Fix interpolation escape and move console log compression to periodic cleanup

### DIFF
--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -121,14 +121,11 @@
           node("master"){
             // Note that already compressed logs will be skipped as they
             // get renamed .gz .
-            // This only affects the stage logs used for blue ocean,
-            // console logs are compressed using a plugin activated via
-            // common.globalWraps.
             // Logs newer than 1 day are skipped to prevent compressing
             // the logs from running builds.
             sh """#!/bin/bash
               cd /var/lib/jenkins/jobs
-              find . -regex '.+/builds/[0-9]+/[0-9]+\\.log' -mtime +1 \\
+              find . -regex '.+/builds/[0-9]+/\\([0-9]+\\.\\)?log' -mtime +1 \\
                 |while read stagelog; do
                   echo \$stagelog
                   gzip \$stagelog

--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -130,8 +130,8 @@
               cd /var/lib/jenkins/jobs
               find . -regex '.+/builds/[0-9]+/[0-9]+\\.log' -mtime +1 \\
                 |while read stagelog; do
-                  echo $stagelog
-                  gzip $stagelog
+                  echo \$stagelog
+                  gzip \$stagelog
                 done
             """
           }


### PR DESCRIPTION
These variables are bash variables not groovy variables, so the dollar
signs should escaped.

Issue: [RE-1329](https://rpc-openstack.atlassian.net/browse/RE-1329)