### PR TITLE
RE-1345 Remove properties call in global wraps

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1116,8 +1116,6 @@ void setTriggerVars(){
 // add wrappers that should be used for all jobs.
 // max log size is in MB
 void globalWraps(Closure body){
-  // Compress logs at the end of each run.
-  properties([compressBuildLog()])
   // global timeout is long, so individual jobs can set shorter timeouts and
   // still have to cleanup, archive atefacts etc.
   timestamps{


### PR DESCRIPTION
Jobs have been mysteriously loosing their parameter definitions, and
my suspicion is that this call is overwriting all the properties set
in JJB rather than appending the log compression property to the list.

This may also be causing jobs to loose their github project affiliation
which could be contributing to problems with triggering.