### PR TITLE
RE-1359 Adjust gate jobs for Queens/Pike

### DIFF
--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -3,9 +3,9 @@
     # Note: branch is the branch for periodics to build
     #       branches is the branch pattern to match for PR Jobs.
     series:
-      - master:
-          branch: master
-          branches: "master.*"
+      - pike:
+          branch: pike
+          branches: "pike.*"
       - newton:
           branch: newton
           branches: "newton.*"
@@ -25,7 +25,7 @@
       Connect Slave,
       Cleanup,
       Destroy Slave
-    branch: master
+    branch: pike
     PULL_FROM_MIRROR: "YES"
     PUSH_TO_MIRROR: "NO"
 
@@ -91,7 +91,7 @@
       library "rpc-gating@${{RPC_GATING_BRANCH}}"
       common.globalWraps(){{
         image_list = [
-          master: [
+          pike: [
               "Ubuntu 16.04.2 LTS prepared for RPC deployment"
           ],
           newton: [

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -47,6 +47,54 @@
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
 - project:
+    name: "rpc-openstack-pike-premerge"
+    repo_name: "rpc-openstack"
+    repo_url: "https://github.com/rcbops/rpc-openstack"
+    series: "pike"
+    branches:
+      - "pike.*"
+    skip_pattern: |
+      \.md$
+      | \.rst$
+      | ^releasenotes/
+      | ^gating/generate_release_notes/
+      | ^gating/post_merge_test/
+      | ^gating/update_dependencies/
+    image:
+      - xenial_no_artifacts:
+          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+    scenario:
+      - ironic:
+          TRIGGER_PR_PHRASE_ONLY: true
+      - "swift"
+    action:
+      - deploy:
+          FLAVOR: "performance2-15"
+    jobs:
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
+
+- project:
+    name: "rpc-openstack-pike-tox-premerge"
+    repo_name: "rpc-openstack"
+    repo_url: "https://github.com/rcbops/rpc-openstack"
+    series: "pike"
+    branches:
+      - "pike.*"
+    image:
+      - container:
+          SLAVE_TYPE: "container"
+    scenario:
+      - "ansible-lint"
+      - "ansible-syntax"
+      - "bashate"
+      - "pep8"
+      - "releasenotes"
+    action:
+      - "tox-test"
+    jobs:
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
+
+- project:
     name: "rpc-openstack-newton-premerge"
     repo_name: "rpc-openstack"
     repo_url: "https://github.com/rcbops/rpc-openstack"
@@ -148,10 +196,6 @@
     branch: "master"
     jira_project_key: "RO"
     image:
-      - xenial_strict_artifacts:
-          IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
-      - xenial_loose_artifacts:
-          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
       - xenial_no_artifacts:
           IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
     scenario:
@@ -171,6 +215,57 @@
     repo_name: "rpc-openstack"
     repo_url: "https://github.com/rcbops/rpc-openstack"
     branch: "master"
+    jira_project_key: "RO"
+    image:
+      - xenial_mnaio_no_artifacts:
+          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+          FLAVOR: "onmetal-io1"
+          REGIONS: "IAD"
+          FALLBACK_REGIONS: ""
+    scenario:
+      - "ironic"
+      - "swift"
+    action:
+      - system
+      - deploy
+    exclude:
+      - action: system
+        image: xenial_mnaio_loose_artifacts
+      - action: system
+        scenario: ironic
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+- project:
+    name: "rpc-openstack-pike-aio-postmerge"
+    repo_name: "rpc-openstack"
+    repo_url: "https://github.com/rcbops/rpc-openstack"
+    branch: "pike"
+    jira_project_key: "RO"
+    image:
+      - xenial_strict_artifacts:
+          IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
+      - xenial_loose_artifacts:
+          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+      - xenial_no_artifacts:
+          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+    scenario:
+      - "ironic"
+      - "swift"
+    action:
+      - deploy:
+          FLAVOR: "7"
+    # This is the build that will be triggered by the push trigger job
+    trigger_build: 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+      - 'PM-push-trigger_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+- project:
+    name: "rpc-openstack-pike-mnaio-postmerge"
+    repo_name: "rpc-openstack"
+    repo_url: "https://github.com/rcbops/rpc-openstack"
+    branch: "pike"
     jira_project_key: "RO"
     image:
       - xenial_mnaio_loose_artifacts
@@ -198,10 +293,10 @@
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
 - project:
-    name: "rpc-openstack-master-rc-aio-postmerge"
+    name: "rpc-openstack-pike-rc-aio-postmerge"
     repo_name: "rpc-openstack"
     repo_url: "https://github.com/rcbops/rpc-openstack"
-    branch: "master-rc"
+    branch: "pike-rc"
     jira_project_key: "RO"
     image:
       - xenial_strict_artifacts:
@@ -223,10 +318,10 @@
       - 'PM-push-trigger_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
 - project:
-    name: "rpc-openstack-master-rc-mnaio-postmerge"
+    name: "rpc-openstack-pike-rc-mnaio-postmerge"
     repo_name: "rpc-openstack"
     repo_url: "https://github.com/rcbops/rpc-openstack"
-    branch: "master-rc"
+    branch: "pike-rc"
     jira_project_key: "RO"
     image:
       - xenial_mnaio_loose_artifacts


### PR DESCRIPTION
RPC-O master will now become Queens, and Pike will be branched.
This caters for the following changes:

1. Adjust the artifact build jobs to only run against Newton
   and Pike branches. If any Queens artifact work is done then
   the jobs can be adjusted later. Queens will start with no
   artifact support.

2. Adjust the RPC-O jobs for master to only run without artifacts.

3. Adjust all current master/master-rc jobs that are Pike orientated
   to run against the pike/pike-rc branches.

4. There will be no jobs for a master-rc branch until there is a
   Queens RC, so we just rename all the master-rc branch to pike-rc.

Issue: [RE-1359](https://rpc-openstack.atlassian.net/browse/RE-1359)