### PR TITLE
RE-1359 Add missing Pike dep_update/hardening jobs

### DIFF
--- a/rpc_jobs/dep_update.yml
+++ b/rpc_jobs/dep_update.yml
@@ -9,6 +9,10 @@
           JIRA_PROJECT_KEY: "RO"
       - rpc-openstack:
           URL: "https://github.com/rcbops/rpc-openstack"
+          BRANCH: "pike"
+          JIRA_PROJECT_KEY: "RO"
+      - rpc-openstack:
+          URL: "https://github.com/rcbops/rpc-openstack"
           BRANCH: "newton"
           JIRA_PROJECT_KEY: "RO"
     trigger:

--- a/rpc_jobs/hardening.yml
+++ b/rpc_jobs/hardening.yml
@@ -14,7 +14,8 @@
       - "swift"
     action:
       - "deploy_master"
-      - "deploy_master-rc"
+      - "deploy_pike"
+      - "deploy_pike-rc"
       - "deploy_newton"
       - "deploy_newton-rc"
     jobs:


### PR DESCRIPTION
In https://github.com/rcbops/rpc-gating/pull/663 there were
some additional jobs missing to cater to the new pike/pike-rc
branches. This patch adds them too.

Issue: [RE-1359](https://rpc-openstack.atlassian.net/browse/RE-1359)