### PR TITLE
RE-1359 Add missing RPC-O Pike PR release test

### DIFF
--- a/rpc_jobs/standard_job_premerge_release.yml
+++ b/rpc_jobs/standard_job_premerge_release.yml
@@ -6,6 +6,9 @@
           BRANCH: "master"
       - rpc-openstack:
           URL: "https://github.com/rcbops/rpc-openstack"
+          BRANCH: "pike"
+      - rpc-openstack:
+          URL: "https://github.com/rcbops/rpc-openstack"
           BRANCH: "newton"
     jobs:
       - 'RE-Release-PR_{repo}-{BRANCH}'


### PR DESCRIPTION
The test to validate that a patch will not break the
release scripts is missing.

Issue: [RE-1359](https://rpc-openstack.atlassian.net/browse/RE-1359)