### PR TITLE
RE-1130 Add jenkins-slave & Ubuntu Trusty configuration

### DIFF
--- a/nodepool/elements/jenkins-slave/element-deps
+++ b/nodepool/elements/jenkins-slave/element-deps
@@ -1,0 +1,1 @@
+package-installs

--- a/nodepool/elements/jenkins-slave/extra-data.d/20-jenkins-user
+++ b/nodepool/elements/jenkins-slave/extra-data.d/20-jenkins-user
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+# the location to fetch the public keys from
+SSH_PUBLIC_KEYS_URL="https://raw.githubusercontent.com/rcbops/rpc-gating/master/keys/rcb.keys"
+
+# fetch the public keys and put them inside the chroot
+curl --connect-timeout 5 \
+     --retry 3 \
+     ${SSH_PUBLIC_KEYS_URL} > ${TMP_HOOKS_PATH}/ssh-public-keys

--- a/nodepool/elements/jenkins-slave/install.d/20-jenkins-slave
+++ b/nodepool/elements/jenkins-slave/install.d/20-jenkins-slave
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+##
+## Add jenkins user, group.
+##
+JENKINS_HOME="/var/lib/jenkins"
+groupadd jenkins
+useradd --gid jenkins \
+        --shell /bin/bash \
+        --home-dir ${JENKINS_HOME} \
+        --create-home jenkins
+
+##
+## Configure SSH
+##
+# this was copied from outside the chroot by extras.d
+_pub_key=/tmp/in_target.d/ssh-public-keys
+if [ ! -f $_pub_key ]; then
+    die "Can not find public keys!"
+fi
+
+mkdir -p ${JENKINS_HOME}/.ssh
+chmod 700 ${JENKINS_HOME}/.ssh
+
+cp ${_pub_key} ${JENKINS_HOME}/.ssh/authorized_keys
+chmod 644 ${JENKINS_HOME}/.ssh/authorized_keys
+
+##
+## Configure git
+##
+cat > ${JENKINS_HOME}/.gitconfig <<EOF
+[user]
+    name = rpc.jenkins.cit.rackspace.net
+    email = rpc-jenkins-svc@github.com
+[gitreview]
+    rebase = false
+    username = jenkins
+EOF
+
+##
+## Setup sudoers
+##
+cat > /etc/sudoers.d/jenkins << EOF
+jenkins ALL=(ALL) NOPASSWD:ALL
+EOF
+chmod 0440 /etc/sudoers.d/jenkins
+
+visudo -c || die "Error setting jenkins sudo!"
+
+##
+## Finalise
+##
+
+# ensure everything has the right owner
+chown -R jenkins:jenkins ${JENKINS_HOME}

--- a/nodepool/elements/jenkins-slave/package-installs.yaml
+++ b/nodepool/elements/jenkins-slave/package-installs.yaml
@@ -1,0 +1,2 @@
+git-core:
+default-jre-headless:

--- a/nodepool/nodepool-config.yml
+++ b/nodepool/nodepool-config.yml
@@ -2,6 +2,7 @@
 # Documentation reference:
 # https://docs.openstack.org/infra/nodepool/feature/zuulv3/configuration.html
 
+elements-dir: /opt/nodepool/elements
 images-dir: /opt/nodepool/images
 
 zookeeper-servers:
@@ -79,6 +80,7 @@ diskimages:
       - openssh-server
       - simple-init
       - vm
+      - jenkins-slave
     release: xenial
     env-vars:
       TMPDIR: /opt/nodepool/dib_tmp

--- a/nodepool/nodepool-config.yml
+++ b/nodepool/nodepool-config.yml
@@ -22,6 +22,18 @@ labels:
     # existing nodes that haven't been used will get recreated
     # every hour.
     max-ready-age: 3600
+  - name: ubuntu-trusty
+    # TODO(odyssey4me):
+    # This is a temporarily low setting as the nodes will
+    # not be used until the jenkins integration is complete.
+    # It is here purely to validate that everything is
+    # working as it should be.
+    min-ready: 3
+    # TODO(odyssey4me):
+    # This is purely here for test purposes to make sure any
+    # existing nodes that haven't been used will get recreated
+    # every hour.
+    max-ready-age: 3600
 
 providers:
   - name: pubcloud-iad
@@ -34,6 +46,8 @@ providers:
     diskimages: &provider_diskimage_block
       - name: ubuntu-xenial
         config-drive: true
+      - name: ubuntu-trusty
+        config-drive: true
     pools: &provider_pools_block
       - name: main
         max-servers: 2
@@ -41,6 +55,11 @@ providers:
         labels:
           - name: ubuntu-xenial
             diskimage: ubuntu-xenial
+            flavor-name: general1-8
+            key-name: jenkins
+            console-log: true
+          - name: ubuntu-trusty
+            diskimage: ubuntu-trusty
             flavor-name: general1-8
             key-name: jenkins
             console-log: true
@@ -82,6 +101,29 @@ diskimages:
       - vm
       - jenkins-slave
     release: xenial
+    env-vars:
+      TMPDIR: /opt/nodepool/dib_tmp
+      DIB_CHECKSUM: '1'
+      DIB_IMAGE_CACHE: /opt/nodepool/dib_cache
+      DIB_GRUB_TIMEOUT: '0'
+      DIB_DISTRIBUTION_MIRROR: 'https://mirror.rackspace.com/ubuntu'
+      DIB_DEBIAN_COMPONENTS: 'main,universe'
+  - name: ubuntu-trusty
+    # Build fresh images every 24 hrs.
+    # This ensures that any merged config changes
+    # to the diskimage-build scripts or diskimage
+    # config take effect within a reasonable time.
+    rebuild-age: 86400
+    formats:
+      - vhd
+    elements:
+      - ubuntu-minimal
+      - growroot
+      - openssh-server
+      - simple-init
+      - vm
+      - jenkins-slave
+    release: trusty
     env-vars:
       TMPDIR: /opt/nodepool/dib_tmp
       DIB_CHECKSUM: '1'

--- a/playbooks/setup_nodepool.yml
+++ b/playbooks/setup_nodepool.yml
@@ -223,6 +223,16 @@
       notify:
         - Restart nodepool-builder
 
+    - name: Copy the diskimage-builder elements
+      synchronize:
+        src: "{{ diskimage_builder_elements_src }}"
+        dest: "/opt/nodepool/"
+        delete: yes
+        rsync_opts:
+          - "--chown=nodepool:nodepool"
+      notify:
+        - Restart nodepool-builder
+
     - name: Setup nodepool services
       include_role:
         name: openstack.nodepool

--- a/playbooks/setup_openstack_instances.yml
+++ b/playbooks/setup_openstack_instances.yml
@@ -51,8 +51,8 @@
         wait: yes
         timeout: 900
       when:
-        - "instance['name'] in groups['all']"
-        - "{{ (instance['state'] | default('present') == 'absent' or (instance['state'] | default('present') == 'present' and 'volumes' in instance)) }}"
+        - instance['name'] in groups['all']
+        - (instance['state'] | default('present') == 'absent' or (instance['state'] | default('present') == 'present' and 'volumes' in instance))
       with_items: "{{ instance_list | default([]) }}"
       loop_control:
         loop_var: instance
@@ -89,7 +89,7 @@
         wait: yes
         timeout: 900
       when:
-        - "{{ item[0]['state'] | default('present') != 'absent' }}"
+        - item[0]['state'] | default('present') != 'absent'
       with_subelements:
         - "{{ instance_list | default([]) }}"
         - volumes
@@ -106,8 +106,8 @@
         wait: yes
         timeout: 900
       when:
-        - "{{ item[0]['state'] | default('present') == 'absent' }}"
-        - "{{ item[1]['state'] | default('present') == 'absent' }}"
+        - item[0]['state'] | default('present') == 'absent'
+        - item[1]['state'] | default('present') == 'absent'
       with_subelements:
         - "{{ instance_list | default([]) }}"
         - volumes
@@ -129,7 +129,7 @@
         wait: yes
         timeout: 900
       when:
-        - "{{ item[0]['state'] | default('present') != 'absent' and item[1]['state'] | default('present') != 'absent' }}"
+        - item[0]['state'] | default('present') != 'absent' and item[1]['state'] | default('present') != 'absent'
       with_subelements:
         - "{{ instance_list | default([]) }}"
         - volumes
@@ -146,7 +146,8 @@
         region_name: "{{ instance['region'] | default('IAD') }}"
         wait: yes
         timeout: 900
-      when: "{{ instance['name'] in groups['all'] }}"
+      when:
+        - instance['name'] in groups['all']
       with_items: "{{ instance_list | default([]) }}"
       loop_control:
         loop_var: instance

--- a/playbooks/vars/nodepool.yml
+++ b/playbooks/vars/nodepool.yml
@@ -14,6 +14,9 @@ diskimage_builder_git_dest: "{{ ansible_user_dir }}/src/git.openstack.org/openst
 # which version of diskimage-builder to clone
 diskimage_builder_git_version: bc6c928bb960729e8df60562adafe2d50a1f55ec # HEAD of 'master' as of 7 Nov 2017
 
+# where to source the diskimage-builder elements from
+diskimage_builder_elements_src: "{{ lookup('env', 'WORKSPACE') }}/rpc-gating/nodepool/elements"
+
 # enable installation of zookeeper from apt packages
 zookeeper_debian_apt_install: yes
 


### PR DESCRIPTION
In order to ensure that every nodepool instance is prepared for
jenkins to use it, some preparation of the instance image is
required. This patch adds an diskimage-builder element to do
the preparation, and to configure nodepool to use it.

Also, to ensure that Trusty nodes are available, the configuration
is added to build Trusty images and prepare Trusty nodes.

Issue: [RE-1130](https://rpc-openstack.atlassian.net/browse/RE-1130)