### PR TITLE
RE-1373 Issue link job should execute from PR

### DIFF
--- a/rpc_jobs/pull_request_issue_link.yml
+++ b/rpc_jobs/pull_request_issue_link.yml
@@ -32,10 +32,10 @@
           days-to-keep: 7
     parameters:
       - rpc_gating_params
-      - string:
-          name: REPO
-          default: "{repo}"
     dsl: |
+      if ("{repo}" == "rpc_gating"){{
+        env.RPC_GATING_BRANCH = "origin/pr/${{env.ghprbPullId}}/merge"
+      }}
       library "rpc-gating@${{RPC_GATING_BRANCH}}"
       common.globalWraps(){{
         github.add_issue_url_to_pr()


### PR DESCRIPTION
Currently, if a change is made to rpc-gating the issue link job uses
the default RPC_GATING_BRACH (master). This is generally fine except
it will not detect issues being introduced to the pipeline scripts
until after they have merged.

This commit simply updates pull_request_issue_link.yml to set
RPC_GATING_BRANCH to `origin/pr/${{env.ghprbPullId}}/merge` when
the repo in question is `rpc-gating`. Additionally, we remove the
REPO parameter since we can just reference `{repo}` instead.

Issue: [RE-1373](https://rpc-openstack.atlassian.net/browse/RE-1373)