### PR TITLE
RE-1328 Fix job artifact upload to use the RE hook

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -293,25 +293,33 @@ def String gen_instance_name(String prefix="AUTO"){
   return instance_name
 }
 
-def archive_artifacts(){
+def archive_artifacts(Map args = [:]){
   stage('Compress and Publish Artifacts'){
-    if (env.RE_HOOK_RESULT_DIR != null){
-      dir(env.RE_HOOK_RESULT_DIR) {
-        junit allowEmptyResults: true, testResults: '*.xml'
-      }
+
+    archive_name = args.get("archive_name", "artifacts_${env.BUILD_TAG}.tar.bz2")
+    artifacts_dir = args.get("artifacts_dir", "${env.WORKSPACE}/artifacts")
+    report_dir = args.get("report_dir", "${env.WORKSPACE}/artifacts_report")
+    results_dir = args.get("results_dir", "${env.WORKSPACE}/results")
+
+    dir(results_dir) {
+      junit allowEmptyResults: true, testResults: "*.xml"
     }
+
     pubcloud.uploadToSwift(
+      archive_name: archive_name,
       container: "jenkins_logs",
+      path: artifacts_dir,
+      report_dir: report_dir
     )
     publishHTML(
       allowMissing: true,
       alwaysLinkToLastBuild: true,
       keepAll: true,
-      reportDir: 'artifacts_report',
+      reportDir: report_dir,
       reportFiles: 'index.html',
       reportName: 'Build Artifact Links'
     )
-  }
+  } // stage
 }
 
 List get_cloud_creds(){

--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -237,8 +237,8 @@ def runonpubcloud(Map args=[:], Closure body){
 }
 
 def uploadToSwift(Map args){
-  if(fileExists("${WORKSPACE}/artifacts")){
-    print("WORKSPACE/artifacts directory found, Preparing to upload artifacts.")
+  if (fileExists(args.path)) {
+    print("Directory ${args.path} found. Uploading contents.")
     withCredentials(common.get_cloud_creds()) {
       clouds_cfg = common.writeCloudsCfg(
         username: env.PUBCLOUD_USERNAME,
@@ -248,14 +248,17 @@ def uploadToSwift(Map args){
         common.venvPlaybook(
           playbooks: ["rpc-gating/playbooks/upload_to_swift.yml"],
           vars: [
+            archive_name: args.archive_name,
+            artifacts_dir: args.path,
             container: args.container,
-            description_file: args.description_file
+            description_file: args.description_file,
+            report_dir: args.report_dir
           ]
         ) // venvPlaybook
       } // withEnv
     } // withCredentials
   } else {
-    print("WORKSPACE/artifacts not found, skipping artifact upload")
+    print("Directory ${args.path} not found. Skipping upload.")
   }
 }
 

--- a/playbooks/upload_to_swift.yml
+++ b/playbooks/upload_to_swift.yml
@@ -4,9 +4,9 @@
   gather_facts: False
   tasks:
     - name: Create archive
-      command: "tar -cjf {{ archive_name }} {{ artifacts_dir }}"
+      command: "tar -cjf {{ archive_name }} {{ artifacts_dir | basename }}"
       args:
-        chdir: "{{ artifacts_parent_dir }}"
+        chdir: "{{ artifacts_dir | dirname }}"
       tags:
         - skip_ansible_lint
 
@@ -37,7 +37,7 @@
     - name: Upload file to Cloud Files
       command: "swift upload {{ container }} {{ archive_name }} --header 'X-Delete-After:2592000'"
       args:
-        chdir: "{{ artifacts_parent_dir }}"
+        chdir: "{{ artifacts_dir | dirname }}"
       no_log: true
       environment:
         OS_AUTH_TOKEN: "{{ auth_token }}"
@@ -82,9 +82,3 @@
   vars:
     region: "DFW"
     cloud_name: "public_cloud"
-    build_tag: "{{ lookup('env','BUILD_TAG') }}"
-    archive_name: "artifacts_{{ build_tag }}.tar.bz2"
-    workspace: "{{ lookup('env', 'WORKSPACE') }}"
-    artifacts_parent_dir: "{{ workspace }}"
-    artifacts_dir: "artifacts"
-    report_dir: "{{ artifacts_parent_dir }}/artifacts_report"

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -175,7 +175,10 @@
             }}
             throw e
           }} finally {{
-            common.archive_artifacts()
+            common.archive_artifacts(
+              artifacts_dir: "${{env.RE_HOOK_ARTIFACT_DIR}}",
+              results_dir: "${{env.RE_HOOK_RESULT_DIR}}"
+            )
           }} // try
         }} // standard_job_slave
       }} // globalWraps

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -193,7 +193,10 @@
             }} finally {{
               common.safe_jira_comment("${{currentBuild.result}}: [${{env.BUILD_TAG}}|${{env.BUILD_URL}}]",
                                        env.RE_JOB_REPO_NAME)
-              common.archive_artifacts()
+              common.archive_artifacts(
+                artifacts_dir: "${{env.RE_HOOK_ARTIFACT_DIR}}",
+                results_dir: "${{env.RE_HOOK_RESULT_DIR}}"
+              )
             }} // try
           }} // standard job slave
         }} // if run test

--- a/rpc_jobs/unit/artefact_publish.yml
+++ b/rpc_jobs/unit/artefact_publish.yml
@@ -20,7 +20,11 @@
 
         stage("Upload"){
           pubcloud.uploadToSwift(
+            archive_name: "artifacts_${BUILD_TAG}.tar.bz2",
+            artifacts_dir: "${WORKSPACE}/artifacts",
             container: "jenkins_logs",
+            path: "${WORKSPACE}/artifacts",
+            report_dir: "${WORKSPACE}/artifacts_report"
           )
         }
 


### PR DESCRIPTION
Currently the job artifact upload assumes the directory
where the artifacts live, rather than making use of the
implemented hook to find out where it is.

This patch make the uploadToSwift function generic,
requiring only a path to find the stuff to upload. The
archive_artifacts function is then changed to make it
take parameters for the paths for the results/artifacts,
but to fall back to a set of default paths if they are
not provided.

The standard jobs are then changed to provide the correct
paths to the function so that the hooks are properly
implemented.

Issue: [RE-1328](https://rpc-openstack.atlassian.net/browse/RE-1328)