### PR TITLE
RE-1362 Update nodepool implementation

### DIFF
--- a/nodepool/role_requirements.yml
+++ b/nodepool/role_requirements.yml
@@ -1,16 +1,16 @@
 - name: AnsibleShipyard.zookeeper
   scm: git
   src: https://github.com/AnsibleShipyard/ansible-zookeeper
-  version: 769c5e974a50291e8556b789e57f809d87063262
+  version: "v0.21.0"
 - name: openstack.nodepool
   scm: git
   src: https://github.com/openstack/ansible-role-nodepool
-  version: 6757bae61fd541595ff4e1eb63aef557ea586707
+  version: 8636c62f6f15cee2231b68c31a415dd66700646c
 - name: openstack.diskimage-builder
   scm: git
   src: https://github.com/openstack/ansible-role-diskimage-builder
-  version: 63c794fddb026b405d7f0730011ae9887b48c698
+  version: c88354aeff0437beebde0009223b700c64347c3f
 - name: openstack.logrotate
   scm: git
   src: https://github.com/openstack/ansible-role-logrotate
-  version: 2aea7ee54c8f2b61a29c5d06fd69e77d16173899
+  version: 519057ecdf43945c2a91259805a5fb7a7f53335a

--- a/playbooks/vars/nodepool.yml
+++ b/playbooks/vars/nodepool.yml
@@ -2,17 +2,11 @@
 # the location of the nodepool config file source
 nodepool_file_nodepool_yaml_src: "{{ lookup('env', 'WORKSPACE') }}/rpc-gating/nodepool/nodepool-config.yml"
 
-# where to clone the nodepool git repo to on the target
-nodepool_git_dest: "{{ ansible_user_dir }}/src/git.openstack.org/openstack-infra/nodepool"
-
 # which version of nodepool to clone
-nodepool_git_version: d20a13da9dba90e357cd91a9aa58fd8c6b5f2e2d # HEAD of 'feature/zuulv3' as of 7 Nov 2017
-
-# where to clone the diskimage-builder git repo to on the target
-diskimage_builder_git_dest: "{{ ansible_user_dir }}/src/git.openstack.org/openstack/diskimage-builder"
+nodepool_git_version: 3de0b20faa6f90437eb62c56ec23c59c6e15b5fa # HEAD of 'master' as of 20 Mar 2018
 
 # which version of diskimage-builder to clone
-diskimage_builder_git_version: bc6c928bb960729e8df60562adafe2d50a1f55ec # HEAD of 'master' as of 7 Nov 2017
+diskimage_builder_git_version: "2.12.1" # Current release as of 22 Mar 2018
 
 # where to source the diskimage-builder elements from
 diskimage_builder_elements_src: "{{ lookup('env', 'WORKSPACE') }}/rpc-gating/nodepool/elements"


### PR DESCRIPTION
This patch updates the nodepool implementation to the current
versions/SHA's available.

1. 'nodepool_git_dest' and 'diskimage_builder_git_dest' from
   the respective ansible roles now use the value we had as
   a default, so the overrides in our vars are no longer
   necessary.

2. All role and service versions have been updated.

This implementation has been verified to work, including
upgrading it in a like test environment.

Issue: [RE-1362](https://rpc-openstack.atlassian.net/browse/RE-1362)