### PR TITLE
RE-1376 Add rpc_asc_creds to creds_bundles

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -998,6 +998,7 @@ List build_creds_array(String list_of_cred_ids){
       "cloud_creds": ['dev_pubcloud_username',
                       'dev_pubcloud_api_key',
                       'dev_pubcloud_tenant_id'],
+      "rpc_asc_creds": ['RPC_ASC_QTEST_API_TOKEN'],
       "rpc_repo": ['RPC_REPO_IP',
                    'RPC_REPO_SSH_USERNAME_TEXT',
                    'RPC_REPO_SSH_USER_PRIVATE_KEY_FILE',
@@ -1020,6 +1021,10 @@ List build_creds_array(String list_of_cred_ids){
       "dev_pubcloud_tenant_id": string(
         credentialsId: "dev_pubcloud_tenant_id",
         variable: "PUBCLOUD_TENANT_ID"
+      ),
+      "RPC_ASC_QTEST_API_TOKEN": string(
+        credentialsId: "RPC_ASC_QTEST_API_TOKEN",
+        variable: "RPC_ASC_QTEST_API_TOKEN"
       ),
       "id_rsa_cloud10_jenkins_file": file(
         credentialsId: 'id_rsa_cloud10_jenkins_file',

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -231,6 +231,8 @@
         image: xenial_mnaio_loose_artifacts
       - action: system
         scenario: ironic
+    # Required by RPC-ASC team to upload test results qTest
+    credentials: "rpc_asc_creds"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
@@ -280,6 +282,8 @@
     exclude:
       - action: system
         scenario: ironic
+    # Required by RPC-ASC team to upload test results qTest
+    credentials: "rpc_asc_creds"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
@@ -331,6 +335,8 @@
         image: xenial_mnaio_loose_artifacts
       - action: system
         scenario: ironic
+    # Required by RPC-ASC team to upload test results qTest
+    credentials: "rpc_asc_creds"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 


### PR DESCRIPTION
This commit creates a new creds bundle called rpc_asc_creds, which
contains credential RPC_ASC_QTEST_API_TOKEN.  This is needed by
PR/PM master/pike/newton rpc-openstack jobs in order for test results
to get uploaded to qTest.

Issue: [RE-1376](https://rpc-openstack.atlassian.net/browse/RE-1376)