### PR TITLE
RLM-1449 Remove mitaka_to_newton_leap jobs

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -55,7 +55,6 @@
       - "swift"
     action:
       - "mitaka_to_newton_major"
-      - "mitaka_to_newton_leap"
       - "liberty_to_newton_leap"
       - "r12.2.8_to_newton_leap"
       - "r12.2.5_to_newton_leap"
@@ -134,7 +133,6 @@
       - "swift"
     action:
       - "mitaka_to_newton_major"
-      - "mitaka_to_newton_leap"
       - "liberty_to_newton_leap"
       - "r12.2.8_to_newton_leap"
       - "r12.2.5_to_newton_leap"


### PR DESCRIPTION
mitaka_to_newton will utilize major upgrade.

Issue: [RLM-1449](https://rpc-openstack.atlassian.net/browse/RLM-1449)