### PR TITLE
RE-1387 Allow Jenkins access to Zookeeper

### DIFF
--- a/playbooks/setup_nodepool.yml
+++ b/playbooks/setup_nodepool.yml
@@ -139,6 +139,14 @@
       notify:
         - Restart zookeeper
 
+    - name: Configure firewall to allow access to zookeeper from additional hosts
+      ufw:
+        rule: allow
+        from_ip: "{{ item }}"
+      with_items: "{{ zookeeper_access_list }}"
+      notify:
+        - Restart zookeeper
+
     - name: Configure firewall to allow cluster traffic (ipv6)
       ufw:
         rule: allow
@@ -240,4 +248,3 @@
     - name: Setup log rotation
       include_role:
         name: openstack.logrotate
-

--- a/playbooks/vars/nodepool.yml
+++ b/playbooks/vars/nodepool.yml
@@ -17,6 +17,10 @@ zookeeper_debian_apt_install: yes
 # set the host group for zookeeper's cluster
 zookeeper_hosts: "{{ groups['nodepool_server'] }}"
 
+# Additional Hosts which can access the zookeeper cluster
+zookeeper_access_list:
+  - 74.205.74.100 # CIT Jenkins master (NAT)
+
 # log rotation
 logrotate_configs:
   - name: nodepool-builder


### PR DESCRIPTION
The Jenkins nodepool plugin communicates with nodepool via Zookeeper,
so the Jenkins master must have access to the zookeeper cluster in
order to use nodes from nodepool.

Issue: [RE-1387](https://rpc-openstack.atlassian.net/browse/RE-1387)