### PR TITLE
RE-1390 Add jre 8 ppa on trusty builds

### DIFF
--- a/playbooks/setup_jenkins_slave.yml
+++ b/playbooks/setup_jenkins_slave.yml
@@ -38,6 +38,15 @@
         timeout: "{{ jenkins_wait_params.timeout }}"
         sleep: "{{ jenkins_wait_params.sleep }}"
 
+    - name: Add OpenJDK PPA
+      apt_repository:
+        repo: ppa:openjdk-r/ppa
+      register: install_ppa
+      until: install_ppa | success
+      retries: 5
+      delay: 2
+      when: ansible_distribution_release | lower == 'trusty'
+
     - name: Install apt packages
       apt:
         pkg: "{{ item }}"
@@ -49,7 +58,7 @@
       delay: 2
       with_items:
         - git-core
-        - default-jre-headless
+        - openjdk-8-jre-headless
 
     - name: Create Jenkins user
       user:


### PR DESCRIPTION
It looks like the SSH Slaves Plugin was upgraded from 1.15 to 1.26,
which apparently now requires jre 1.8 which is not available on Trusty.

As it's unclear if this plugin can be safely rolled back, I've
added a jre 8 ppa when building on trusty as a temporary workaround.

If we have confirmation that the plugin can be rolled back (and that
takes place) then we can revert this commit.