### PR TITLE
Add RELEASE template and dummy repos

### DIFF
--- a/rpc_jobs/dummy_pipeline.yml
+++ b/rpc_jobs/dummy_pipeline.yml
@@ -190,7 +190,7 @@
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
 - project:
-    name: 'rpc-product-1-final-integration'
+    name: 'rpc-product-1-release'
 
     repo_name: 'rpc-product-1'
     repo_url: 'https://github.com/mattt416/rpc-product-1'
@@ -202,13 +202,19 @@
           FLAVOR: 'performance1-1'
           IMAGE: 'Ubuntu 16.04.2 LTS prepared for RPC deployment'
 
+    scenario:
+      - 'functional'
+
+    action:
+      - 'test'
+
     jira_project_key: 'RE'
 
     jobs:
-      - 'RELEASE_{repo_name}-{branch}'
+      - 'RELEASE_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
 - project:
-    name: 'rpc-component-1-final-integration'
+    name: 'rpc-component-1-release'
 
     repo_name: 'rpc-component-1'
     repo_url: 'https://github.com/mattt416/rpc-component-1'
@@ -220,13 +226,19 @@
           FLAVOR: 'performance1-1'
           IMAGE: 'Ubuntu 16.04.2 LTS prepared for RPC deployment'
 
+    scenario:
+      - 'functional'
+
+    action:
+      - 'test'
+
     jira_project_key: 'RE'
 
     jobs:
-      - 'RELEASE_{repo_name}-{branch}'
+      - 'RELEASE_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
 - project:
-    name: 'rpc-component-2-final-integration'
+    name: 'rpc-component-2-release'
 
     repo_name: 'rpc-component-2'
     repo_url: 'https://github.com/mattt416/rpc-component-2'
@@ -238,7 +250,13 @@
           FLAVOR: 'performance1-1'
           IMAGE: 'Ubuntu 16.04.2 LTS prepared for RPC deployment'
 
+    scenario:
+      - 'functional'
+
+    action:
+      - 'test'
+
     jira_project_key: 'RE'
 
     jobs:
-      - 'RELEASE_{repo_name}-{branch}'
+      - 'RELEASE_{repo_name}-{branch}-{image}-{scenario}-{action}'

--- a/rpc_jobs/dummy_pipeline.yml
+++ b/rpc_jobs/dummy_pipeline.yml
@@ -17,3 +17,228 @@
           READ_ONLY_TEST: false
     jobs:
       - '{trigger}-Dep-Update_{repo_name}-{branch}'
+
+- project:
+    name: 'rpc-metadata-pre-merge'
+
+    repo_name: 'rpc-metadata'
+    repo_url: 'https://github.com/mattt416/rpc-metadata'
+
+    branches:
+      - 'master'
+
+    image:
+      - container:
+          SLAVE_TYPE: "container"
+
+    scenario:
+      - 'lint'
+
+    action:
+      - 'test'
+
+    jira_project_key: 'RE'
+
+    jobs:
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
+
+- project:
+    name: 'rpc-product-1-pre-merge'
+
+    repo_name: 'rpc-product-1'
+    repo_url: 'https://github.com/mattt416/rpc-product-1'
+
+    branches:
+      - 'master'
+
+    image:
+      - xenial:
+          FLAVOR: 'performance1-1'
+          IMAGE: 'Ubuntu 16.04.2 LTS prepared for RPC deployment'
+
+    scenario:
+      - 'functional'
+
+    action:
+      - 'test'
+
+    jira_project_key: 'RE'
+
+    jobs:
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
+
+- project:
+    name: 'rpc-product-1-post-merge'
+
+    repo_name: 'rpc-product-1'
+    repo_url: 'https://github.com/mattt416/rpc-product-1'
+
+    branch: 'master'
+
+    image:
+      - xenial:
+          FLAVOR: 'performance1-1'
+          IMAGE: 'Ubuntu 16.04.2 LTS prepared for RPC deployment'
+
+    scenario:
+      - 'functional'
+
+    action:
+      - 'test'
+
+    jira_project_key: 'RE'
+
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+- project:
+    name: 'rpc-component-1-pre-merge'
+
+    repo_name: 'rpc-component-1'
+    repo_url: 'https://github.com/mattt416/rpc-component-1'
+
+    branches:
+      - 'master'
+
+    image:
+      - xenial:
+          FLAVOR: 'performance1-1'
+          IMAGE: 'Ubuntu 16.04.2 LTS prepared for RPC deployment'
+
+    scenario:
+      - 'functional'
+
+    action:
+      - 'test'
+
+    jira_project_key: 'RE'
+
+    jobs:
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
+
+- project:
+    name: 'rpc-component-1-post-merge'
+
+    repo_name: 'rpc-component-1'
+    repo_url: 'https://github.com/mattt416/rpc-component-1'
+
+    branch: 'master'
+
+    image:
+      - xenial:
+          FLAVOR: 'performance1-1'
+          IMAGE: 'Ubuntu 16.04.2 LTS prepared for RPC deployment'
+
+    scenario:
+      - 'functional'
+
+    action:
+      - 'test'
+
+    jira_project_key: 'RE'
+
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+- project:
+    name: 'rpc-component-2-pre-merge'
+
+    repo_name: 'rpc-component-2'
+    repo_url: 'https://github.com/mattt416/rpc-component-2'
+
+    branches:
+      - 'master'
+
+    image:
+      - xenial:
+          FLAVOR: 'performance1-1'
+          IMAGE: 'Ubuntu 16.04.2 LTS prepared for RPC deployment'
+
+    scenario:
+      - 'functional'
+
+    action:
+      - 'test'
+
+    jira_project_key: 'RE'
+
+    jobs:
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
+
+- project:
+    name: 'rpc-component-2-post-merge'
+
+    repo_name: 'rpc-component-2'
+    repo_url: 'https://github.com/mattt416/rpc-component-2'
+
+    branch: 'master'
+
+    image:
+      - xenial:
+          FLAVOR: 'performance1-1'
+          IMAGE: 'Ubuntu 16.04.2 LTS prepared for RPC deployment'
+
+    scenario:
+      - 'functional'
+
+    action:
+      - 'test'
+
+    jira_project_key: 'RE'
+
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+- project:
+    name: 'rpc-product-1-final-integration'
+
+    repo_name: 'rpc-product-1'
+    repo_url: 'https://github.com/mattt416/rpc-product-1'
+
+    branch: 'master'
+
+    image:
+      - xenial:
+          FLAVOR: 'performance1-1'
+          IMAGE: 'Ubuntu 16.04.2 LTS prepared for RPC deployment'
+
+    jira_project_key: 'RE'
+
+    jobs:
+      - 'RELEASE_{repo_name}-{branch}'
+
+- project:
+    name: 'rpc-component-1-final-integration'
+
+    repo_name: 'rpc-component-1'
+    repo_url: 'https://github.com/mattt416/rpc-component-1'
+
+    branch: 'master'
+
+    image:
+      - xenial:
+          FLAVOR: 'performance1-1'
+          IMAGE: 'Ubuntu 16.04.2 LTS prepared for RPC deployment'
+
+    jira_project_key: 'RE'
+
+    jobs:
+      - 'RELEASE_{repo_name}-{branch}'
+
+- project:
+    name: 'rpc-component-2-final-integration'
+
+    repo_name: 'rpc-component-2'
+    repo_url: 'https://github.com/mattt416/rpc-component-2'
+
+    branch: 'master'
+
+    image:
+      - xenial:
+          FLAVOR: 'performance1-1'
+          IMAGE: 'Ubuntu 16.04.2 LTS prepared for RPC deployment'
+
+    jira_project_key: 'RE'
+
+    jobs:
+      - 'RELEASE_{repo_name}-{branch}'

--- a/rpc_jobs/standard_job_release.yml
+++ b/rpc_jobs/standard_job_release.yml
@@ -1,5 +1,5 @@
 - job-template:
-    name: 'RELEASE_{repo_name}-{branch}'
+    name: 'RELEASE_{repo_name}-{branch}-{image}-{scenario}-{action}'
     branch: "master"
     jira_project_key: ""
     project-type: pipeline
@@ -12,6 +12,17 @@
           num-to-keep: 14
       - github:
           url: "{repo_url}"
+      - inject:
+          properties-content: |
+            STAGES="Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
+            BOOT_TIMEOUT={BOOT_TIMEOUT}
+            RE_JOB_NAME={name}
+            RE_JOB_IMAGE={image}
+            RE_JOB_SCENARIO={scenario}
+            RE_JOB_ACTION={action}
+            RE_JOB_FLAVOR={FLAVOR}
+            RE_JOB_REPO_NAME={repo_name}
+            RE_JOB_BRANCH={branch}
     parameters:
       - rpc_gating_params
       - instance_params:

--- a/rpc_jobs/standard_job_release.yml
+++ b/rpc_jobs/standard_job_release.yml
@@ -1,0 +1,37 @@
+- job-template:
+    name: 'RELEASE_{repo_name}-{branch}'
+    branch: "master"
+    jira_project_key: ""
+    project-type: pipeline
+    concurrent: false
+    FLAVOR: "performance1-1"
+    IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+    BOOT_TIMEOUT: 900
+    properties:
+      - build-discarder:
+          num-to-keep: 14
+      - github:
+          url: "{repo_url}"
+    parameters:
+      - rpc_gating_params
+      - instance_params:
+          IMAGE: "{IMAGE}"
+          FLAVOR: "{FLAVOR}"
+          REGIONS: "{REGIONS}"
+          FALLBACK_REGIONS: "{FALLBACK_REGIONS}"
+      - string:
+          name: REPO_URL
+          default: "{repo_url}"
+          description: Url of the repo under test
+      - string:
+          name: BRANCH
+          default: "{branch}"
+          description: Branch of the repo under test
+      - standard_job_params:
+          SLAVE_TYPE: "{SLAVE_TYPE}"
+          SLAVE_CONTAINER_DOCKERFILE_REPO: "{SLAVE_CONTAINER_DOCKERFILE_REPO}"
+          SLAVE_CONTAINER_DOCKERFILE_PATH: "{SLAVE_CONTAINER_DOCKERFILE_PATH}"
+          SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS: "{SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS}"
+    dsl: |
+      library "rpc-gating@${{RPC_GATING_BRANCH}}"
+      common.stdJob("release", "{credentials}", "{jira_project_key}")


### PR DESCRIPTION
This commit adds the standard template for release testing.
Additionally, we add jobs for all dummy pipeline repos
(rpc-metadata, rpc-product-1, rpc-component-1, rpc-component-2) for PR,
PM, and RELEASE (where applicable).

Issue: [RE-1317](https://rpc-openstack.atlassian.net/browse/RE-1317)