### PR TITLE
RE-1397 Add ArtifactBuilder to protected prefix to avoid clean up

### DIFF
--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -9,7 +9,7 @@
             Hours. Instances older than this will be removed.
       - string:
           name: "PROTECTED_PREFIX"
-          default: "long-running-slave|influx-|WEBHOOK-PROXY|webhook-proxy|nodepool|repo-server-"
+          default: "long-running-slave|influx-|WEBHOOK-PROXY|webhook-proxy|nodepool|repo-server-|ArtifactBuilder"
           description: |
             Instances that match this prefix regex will not be cleaned up.
       - string:


### PR DESCRIPTION
The artifact builder is a long-lived node, so it should never
be cleaned up.

Issue: [RE-1397](https://rpc-openstack.atlassian.net/browse/RE-1397)