### PR TITLE
RE-1404 Use later snapshot in designate job

### DIFF
--- a/rpc_jobs/rpc_designate.yml
+++ b/rpc_jobs/rpc_designate.yml
@@ -74,7 +74,7 @@
       - newton:
           IMAGE: "rpc-r14.9.0-xenial-swift"
       - pike:
-          IMAGE: "rpc-r16.2.0-xenial_no_artifacts-swift"
+          IMAGE: "rpc-r16.1.0-xenial_no_artifacts-swift"
     action:
       - "deploy"
 


### PR DESCRIPTION
The PM_rpc-designate-master-xenial_snapshot-pike-deploy job has been
failing for a number of days as the image
rpc-r16.1.0-xenial_no_artifacts-swift is affected by [1]. This commit
updates the job to use a later saved image instead.

NOTE: The versions are slightly confusing as we changed version scheme
in pike, but rpc-r16.1.0-xenial_no_artifacts-swift is in fact newer
than rpc-r16.2.0-xenial_no_artifacts-swift.

[1] https://review.openstack.org/#/c/558229/