### PR TITLE
RE-1190 Use correct repo/ref for release PR tests

### DIFF
--- a/job_dsl/release.groovy
+++ b/job_dsl/release.groovy
@@ -9,10 +9,10 @@ common.globalWraps(){
     // of the environment variables automatically as
     // they will not be provided by a human.
     if ( env.ghprbPullId != null ) {
-      List source_repo = env.ghprbAuthorRepoGitUrl.split("/")
-      env.ORG = source_repo[-2]
-      env.REPO = source_repo[-1].tokenize(".")[0]
-      env.RC_BRANCH = env.ghprbSourceBranch
+      List source_repo = env.ghprbGhRepository.split("/")
+      env.ORG = source_repo[0]
+      env.REPO = source_repo[1]
+      env.RC_BRANCH = "origin/pr/${env.ghprbPullId}/merge"
     }
     withCredentials([
       string(

--- a/rpc_jobs/standard_job_premerge_release.yml
+++ b/rpc_jobs/standard_job_premerge_release.yml
@@ -79,6 +79,7 @@
                 --repo "${{REPO}}" \
                 clone \
                   --ref "${{RC_BRANCH}}" \
+                  --refspec '+refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* +refs/heads/*:refs/heads/* +refs/pull/*:refs/remotes/origin/pr/*' \
                 generate_release_notes \
                     --script "optional:gating/generate_release_notes/pre" \
                     --script "gating/generate_release_notes/run" \


### PR DESCRIPTION
The current method of PR testing for releases uses
the remote fork for the test, instead of using the
target repo and the PR ref. This results in the test
failing in all kinds of exciting ways when the remote
fork does not contain the correct refs for the tooling
to be able do what it's supposed to do.

This patch ensures that the parameters passed to the
tooling are more appropriate and will ensure that all
the correct refs are there.

Issue: [RE-1190](https://rpc-openstack.atlassian.net/browse/RE-1190)