### PR TITLE
RE-1412 Add bzip package install to nodepool elements

### DIFF
--- a/nodepool/elements/jenkins-slave/package-installs.yaml
+++ b/nodepool/elements/jenkins-slave/package-installs.yaml
@@ -1,3 +1,4 @@
-git-core:
-default-jre-headless:
+bzip2:
 curl:
+default-jre-headless:
+git-core:


### PR DESCRIPTION
Without this package, the rpc-gating venv tarball cannot
be extracted.

We also sort the packages installed alphabetically to make
them easier to find.

Issue: [RE-1412](https://rpc-openstack.atlassian.net/browse/RE-1412)