### PR TITLE
RE-1414 Update check to cater for nodepool slave type

### DIFF
--- a/rpc_jobs/unit/single_use_slave.yml
+++ b/rpc_jobs/unit/single_use_slave.yml
@@ -56,7 +56,7 @@
           // NOTE(mattt): If env.SLAVE_TYPE is set to an unrecognized type, an
           // exception will be raised in common.standard_job_slave()
           stage("Ensure virt type matches env.SLAVE_TYPE") {
-            if (env.SLAVE_TYPE == "instance") {
+            if ((env.SLAVE_TYPE == "instance") || (env.SLAVE_TYPE.startsWith("nodepool"))){
               assert inside_container == "no"
             } else {
               assert inside_container == "yes"


### PR DESCRIPTION
The current check does not understand the nodepool slave
type. This updates the check to cater for the new type.

Issue: [RE-1414](https://rpc-openstack.atlassian.net/browse/RE-1414)