### PR TITLE
RI-254 Remove unnecessary PM jobs and adjust timer

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -193,11 +193,13 @@
     repo_url: "https://github.com/rcbops/rpc-openstack"
     branch: "master"
     jira_project_key: "RO"
+    # We have an MNAIO equivalent of this PM job, but we need to keep
+    # this for the push triggering for snapshot building.
+    CRON: "@monthly"
     image:
       - xenial_no_artifacts:
           IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
     scenario:
-      - "ironic"
       - "swift"
     action:
       - deploy:
@@ -242,11 +244,13 @@
     repo_url: "https://github.com/rcbops/rpc-openstack"
     branch: "pike"
     jira_project_key: "RO"
+    # We have an MNAIO equivalent of this PM job, but we need to keep
+    # this for the push triggering for snapshot building.
+    CRON: "@monthly"
     image:
       - xenial_no_artifacts:
           IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
     scenario:
-      - "ironic"
       - "swift"
     action:
       - deploy:
@@ -293,11 +297,13 @@
     repo_url: "https://github.com/rcbops/rpc-openstack"
     branch: "pike-rc"
     jira_project_key: "RO"
+    # We have an MNAIO equivalent of this PM job, but we need to keep
+    # this for the push triggering for snapshot building.
+    CRON: "@monthly"
     image:
       - xenial_no_artifacts:
           IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
     scenario:
-      - "ironic"
       - "swift"
     action:
       - deploy:
@@ -351,6 +357,9 @@
           IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
       - xenial_loose_artifacts:
           IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+          # We have an MNAIO equivalent of this PM job, but we need to keep
+          # this for the push triggering for snapshot building.
+          CRON: "@monthly"
       - trusty:
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
       - trusty_loose_artifacts:
@@ -396,6 +405,9 @@
           IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
       - xenial_loose_artifacts:
           IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+          # We have an MNAIO equivalent of this PM job, but we need to keep
+          # this for the push triggering for snapshot building.
+          CRON: "@monthly"
       - trusty:
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
       - trusty_loose_artifacts:


### PR DESCRIPTION
This commit does the following:

1. Removes the ironic PM AIO jobs for master, pike, and pike-rc since
   we have equivalent PM MNAIO jobs for these. At present we have no
   immediate use for ironic snapshot images, so there's no point
   leaving the ironic PM AIO jobs around for this.
2. Sets a @monthly CRON value for the PM swift AIO jobs on master, pike
   and pike-rc so that these jobs are effectively only run when the
   branches are pushed to (again, we have equivalent PM MNAIO jobs for
   these).
3. Similar to #2, we do this for the PM xenial_loose_artifacts newton
   and newton-rc AIO jobs since we have this combintation running as
   PM MNAIO jobs.

Issue: [RI-254](https://rpc-openstack.atlassian.net/browse/RI-254)