### PR TITLE
RE-1190 Remove remote prefix for release PR tests

### DIFF
--- a/job_dsl/release.groovy
+++ b/job_dsl/release.groovy
@@ -12,7 +12,7 @@ common.globalWraps(){
       List source_repo = env.ghprbGhRepository.split("/")
       env.ORG = source_repo[0]
       env.REPO = source_repo[1]
-      env.RC_BRANCH = "origin/pr/${env.ghprbPullId}/merge"
+      env.RC_BRANCH = "pr/${env.ghprbPullId}/merge"
     }
     withCredentials([
       string(


### PR DESCRIPTION
The remote prefix is improper, given that the release
tooling will add the remote prefix when executing. All
we want here is the correct ref.

Issue: [RE-1190](https://rpc-openstack.atlassian.net/browse/RE-1190)