### PR TITLE
RE-1418 Fix issue link job when using remote forks

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -473,7 +473,7 @@ void clone_repo(String directory, String ssh_key, String repo, String ref, Strin
       git remote add origin "${repo}"
       # Don't quote refspec as it should be separate args to git.
       # only log errors
-      git fetch --tags origin ${refspec} > /dev/null
+      git fetch --quiet --tags origin ${refspec}
       git checkout ${ref}
       git submodule update --init
     """

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -618,7 +618,7 @@ def get_jira_issue_key(String repo_path="rpc-openstack"){
     returnStdout: true,
     script: """#!/bin/bash -e
       cd ${repo_path}
-      git log --pretty=%B origin/${ghprbTargetBranch}..origin/${ghprbSourceBranch}""")
+      git log --pretty=%B origin/${ghprbTargetBranch}..origin/pr/${ghprbPullId}/merge}""")
   print("Looking for Jira issue keys in the following commits: ${commits}")
   try{
     String key = (commits =~ key_regex)[0]

--- a/pipeline_steps/github.groovy
+++ b/pipeline_steps/github.groovy
@@ -33,21 +33,20 @@ def create_issue(
  * Update the description of the current GitHub pull request with a link to
  * the Jira issue.
  */
-void add_issue_url_to_pr(String upstream="upstream"){
+void add_issue_url_to_pr(){
   List org_repo = env.ghprbGhRepository.split("/")
   String org = org_repo[0]
   String repo = org_repo[1]
-
   Integer pull_request_number = env.ghprbPullId as Integer
 
+  // clone the target repo with all github PR refs
   dir(repo) {
-    git branch: env.ghprbSourceBranch, url: env.ghprbAuthorRepoGitUrl
-    sh """#!/bin/bash
-      set -x
-      git remote add ${upstream} https://github.com/${org}/${repo}.git
-      git remote update
-    """
+    common.clone_with_pr_refs()
   }
+
+  // try to derive the issue number from the contents
+  // of the comparison between the target branch and
+  // the PR
   String issue_key = common.get_jira_issue_key(repo)
 
   withCredentials([


### PR DESCRIPTION
The issue link job currently does not work properly when
executing from a fork. While the current mechanism is ok
it can be simplified to use the other existing clone
function which includes refs, and the function to find
the JIRA issues can then use the pr merge ref.

This simplifies the system, negating the need to add more
remotes and ensuring that everything required is in place.