### PR TITLE
RE-1419 Add nodepool-ubuntu-trusty node unit test

### DIFF
--- a/rpc_jobs/unit/re_unit_tests.yml
+++ b/rpc_jobs/unit/re_unit_tests.yml
@@ -49,7 +49,7 @@
             ]
           )
         },
-        "Nodepool Instance": {
+        "nodepool-ubuntu-xenial Instance": {
           build(
             job: "RE-unit-test-slave-types",
             wait: true,
@@ -63,6 +63,24 @@
                 $class: 'StringParameterValue',
                 name: 'SLAVE_TYPE',
                 value: 'nodepool-ubuntu-xenial'
+              ]
+            ]
+          )
+        },
+        "nodepool-ubuntu-trusty Instance": {
+          build(
+            job: "RE-unit-test-slave-types",
+            wait: true,
+            parameters: [
+              [
+                $class: 'StringParameterValue',
+                name: 'RPC_GATING_BRANCH',
+                value: env.RPC_GATING_BRANCH
+              ],
+              [
+                $class: 'StringParameterValue',
+                name: 'SLAVE_TYPE',
+                value: 'nodepool-ubuntu-trusty'
               ]
             ]
           )


### PR DESCRIPTION
Currently the unit test only verifies that Ubuntu
Xenial nodes work. We should also verify that the
Trusty nodes are working.

Issue: [RE-1419](https://rpc-openstack.atlassian.net/browse/RE-1419)