### PR TITLE
RE-1384 Add component dependency update support

### DIFF
--- a/rpc_jobs/dummy_pipeline.yml
+++ b/rpc_jobs/dummy_pipeline.yml
@@ -1,0 +1,19 @@
+- project:
+    name: "rpc-product-1-dependency-update"
+    repo_name: "rpc-product-1"
+    repo_url: "https://github.com/mattt416/rpc-product-1"
+    branch:
+      - "master"
+    jira_project_key: "RE"
+    component_dependencies_update: "true"
+    third_party_dependencies_update: "false"
+    trigger:
+      - PR:
+          CRON: ""
+          branches: "{branch}"
+          NUM_TO_KEEP: 10
+      - PM:
+          branches: "do_not_build_on_pr"
+          READ_ONLY_TEST: false
+    jobs:
+      - '{trigger}-Dep-Update_{repo_name}-{branch}'

--- a/rpc_jobs/standard_job_dep_update.yml
+++ b/rpc_jobs/standard_job_dep_update.yml
@@ -4,6 +4,8 @@
     NUM_TO_KEEP: 30
     READ_ONLY_TEST: true
     SLAVE_TYPE: "container"
+    component_dependencies_update: "false"
+    third_party_dependencies_update: "true"
     name: '{trigger}-Dep-Update_{repo_name}-{branch}'
     project-type: pipeline
     pipeline-scm:
@@ -64,3 +66,9 @@
           SLAVE_CONTAINER_DOCKERFILE_REPO: "{SLAVE_CONTAINER_DOCKERFILE_REPO}"
           SLAVE_CONTAINER_DOCKERFILE_PATH: "{SLAVE_CONTAINER_DOCKERFILE_PATH}"
           SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS: "{SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS}"
+      - string:
+          name: "COMPONENT_DEPENDENCIES_UPDATE"
+          default: "{component_dependencies_update}"
+      - string:
+          name: "THIRD_PARTY_DEPENDENCIES_UPDATE"
+          default: "{third_party_dependencies_update}"

--- a/scripts/dep_update.sh
+++ b/scripts/dep_update.sh
@@ -4,21 +4,37 @@
 # Create pr if required
 # Run post hook
 run_hook(){
-  if [[ -x "$1" ]]
+  if [[ ${THIRD_PARTY_DEPENDENCIES_UPDATE} == "true" ]]
   then
-    $1 || {
-      echo "Hook script failed: $1"
-      exit 1
-    }
-  else
-    if [[ "$1" =~ .*/run ]]
+    if [[ -x "$1" ]]
     then
-      echo "Run hook $1 not found."
-      exit 1
+      $1 || {
+        echo "Hook script failed: $1"
+        exit 1
+      }
+    else
+      if [[ "$1" =~ .*/run ]]
+      then
+        echo "Run hook $1 not found."
+        exit 1
+      fi
     fi
   fi
 }
 cd ${WORKSPACE}/repo
+
+start_sha=$(git rev-parse --verify HEAD)
+
+if [[ "${COMPONENT_DEPENDENCIES_UPDATE}" == 'true' ]]; then
+  apt-get update
+  apt-get install -y python3-pip
+  pip3 install 'git+https://github.com/mattt416/rpc-metadata#rpc_component&subdirectory=rpc_component'
+  component --releases-repo 'https://github.com/mattt416/rpc-metadata' dependency update-requirements
+  if [[ ${start_sha} == $(git rev-parse --verify HEAD) ]]; then
+    echo "No component dependency updates found."
+  fi
+fi
+
 run_hook "gating/update_dependencies/pre"
 run_hook "gating/update_dependencies/run"
 
@@ -27,23 +43,18 @@ if [[ "${READ_ONLY_TEST:-true}" == "true" ]]; then
   exit 0
 fi
 
-if [[ -z "$(git status -s)" ]]
-then
-  echo "Repo is clean, prep script made no changes to be committed."
-else
-  echo "Repo is dirty, preparing to propose changes."
-  # split URL into array separated by '/'s
-  IFS='/ ' read -r -a url_split <<< "${REPO_URL}"
-  # owner/org is whatever is between the second and third / in the url
-  owner="${url_split[3]}"
-  # repo is anything after owner/
-  repo=${REPO_URL#https://github.com/${owner}/}
-  ssh_url="git@github.com:${owner}/${repo}"
-  message="This change is the result of running gating/update_dependencies/*
-  See update_dependencies in https://rpc-openstack.atlassian.net/wiki/spaces/RE/pages/19005457/RE+for+Projects for more details."
+# split URL into array separated by '/'s
+IFS='/ ' read -r -a url_split <<< "${REPO_URL}"
+# owner/org is whatever is between the second and third / in the url
+owner="${url_split[3]}"
+# repo is anything after owner/
+repo=${REPO_URL#https://github.com/${owner}/}
+ssh_url="git@github.com:${owner}/${repo}"
 
-  # Get / Create Jira issue
+if [[ -n "$(git status -s)" ]] || [[ ${start_sha} != $(git rev-parse --verify HEAD) ]]; then
   echo "Looking for Jira issue, will create if not found."
+  issue_message="This issue was generated automatically by the Jenkins job ${RE_JOB_NAME}.
+  See update_dependencies in https://rpc-openstack.atlassian.net/wiki/spaces/RE/pages/19005457/RE+for+Projects for more details."
   jira_summary="Update ${repo}:${BRANCH} dependencies"
   issue=$(python ${WORKSPACE}/rpc-gating/scripts/jirautils.py \
         --user "${JIRA_USER}" \
@@ -51,19 +62,28 @@ else
         get_or_create_issue \
           --project "${JIRA_PROJECT_KEY}" \
           --summary "${jira_summary}" \
-          --description "${message}" \
+          --description "${issue_message}" \
           --label RE_DEP_UPDATE \
           --label jenkins \
           --label "${repo}_${branch}"
   )
   echo "Issue: ${issue}"
+fi
 
-  echo "Committing changes"
-  pr_branch="${issue}_${BRANCH}_dep_update"
-  title="${issue} Update ${BRANCH} dependencies"
+if [[ -z "$(git status -s)" ]]
+then
+  echo "Repo is clean, prep script made no changes to be committed."
+else
+  echo "Repo is dirty, committing changes."
+  title="${issue} Update ${BRANCH} third-party dependencies"
+  message="This change is the result of running gating/update_dependencies/*
+  See update_dependencies in https://rpc-openstack.atlassian.net/wiki/spaces/RE/pages/19005457/RE+for+Projects for more details."
   git commit -a -m "${title}" -m "${message}"
+fi
 
+if [[ ${start_sha} != $(git rev-parse --verify HEAD) ]]; then
   echo "Pushing changes to repo branch"
+  pr_branch="${issue}_${BRANCH}_dep_update"
   git push -f "$ssh_url" "HEAD:${pr_branch}"
 
   # Create PR from pushed commit.
@@ -76,8 +96,10 @@ else
     create_pr \
       --source-branch "${pr_branch}"\
       --target-branch "${BRANCH}" \
-      --title "${title}" \
-      --body "${message}"
+      --title "${issue} Update ${BRANCH} dependencies" \
+      --body "Automated dependency update pull request, see individual commits for details."
+else
+  echo "No pull request created, update scripts did not discover any dependency changes."
 fi
 
 run_hook "gating/update_dependencies/post"


### PR DESCRIPTION
This change adds support for testing component dependency updates. By
default this feature is not enabled but can be specified in the project
definition with `component_dependencies_update: "true"`. Currently this
feature is still being tested and should not be used outside of that
test work.

This change also allows for the use of update_dependencies/run updates
to be disabled with `third_party_dependencies_update: "false"`.

Issue: [RE-1384](https://rpc-openstack.atlassian.net/browse/RE-1384)