### PR TITLE
RE-1420 Transition rpc-gating tests to use nodepool

### DIFF
--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -3,7 +3,9 @@
     repo_name:  "rpc-gating"
     repo_url:   "https://github.com/rcbops/rpc-gating"
     branch:     "master"
-    image:      "xenial"
+    image:
+      - "xenial":
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
     scenario:   "functional"
     action:     "test"
     jira_project_key: "RE"

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -9,9 +9,9 @@
     branches:
       - "master"
     image:
-      - "xenial"
+      - "xenial":
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
     scenario:
-      - "functional"
       - "lint"
     action:
       - "test"


### PR DESCRIPTION
To increase the usage of nodepool, we transition some low-impact
tests to it.

Given that the 'functional' pre-merge test is duplicated in the
unit tests, we remove that.

Issue: [RE-1420](https://rpc-openstack.atlassian.net/browse/RE-1420)