### PR TITLE
nodepool elements: Explicitly use jre 1.8

### DIFF
--- a/nodepool/elements/jenkins-slave/package-installs.yaml
+++ b/nodepool/elements/jenkins-slave/package-installs.yaml
@@ -1,4 +1,4 @@
 bzip2:
 curl:
-default-jre-headless:
+openjdk-8-jre-headless:
 git-core:

--- a/nodepool/elements/jenkins-slave/pre-install.d/20-add-openjdk-ppa-to-trusty
+++ b/nodepool/elements/jenkins-slave/pre-install.d/20-add-openjdk-ppa-to-trusty
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+source /etc/lsb-release
+if [[ "${DISTRIB_CODENAME}" == "trusty" ]]; then
+  add-apt-repository -y ppa:openjdk-r/ppa
+fi


### PR DESCRIPTION
Jenkins requires the JRE 1.8 in order to connect to
the slaves. In this patch we ensure that the PPA is
setup if the image being built is on Ubuntu Trusty
(it has no native/backport package) and we also
ensure that the package installed afterwards is
explicitly set the the right one instead of assuming
the default package gives us JRE 1.8 for xenial.

Issue: [RE-1415](https://rpc-openstack.atlassian.net/browse/RE-1415)