### PR TITLE
RE-1415 Only install openjdk-8-jre-headless

### DIFF
--- a/playbooks/setup_jenkins_slave.yml
+++ b/playbooks/setup_jenkins_slave.yml
@@ -58,24 +58,12 @@
       delay: 2
       with_items:
         - git-core
-        - default-jre-headless
-
-    - name: Install openjdk-8-jre-headless
-      apt:
-        pkg: "{{ item }}"
-        state: installed
-        update_cache: yes
-      register: install_packages
-      until: install_packages | success
-      retries: 5
-      delay: 2
-      with_items:
         - openjdk-8-jre-headless
-      when: ansible_distribution_release | lower == 'trusty'
 
-    - name: Set default java to java-1.8.0-openjdk-amd64
-      command: update-java-alternatives -s java-1.8.0-openjdk-amd64
-      when: ansible_distribution_release | lower == 'trusty'
+    - name: Set default JAVA_HOME environment variable
+      lineinfile:
+        path: /etc/environment
+        line: 'export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"'
 
     - name: Create Jenkins user
       user:
@@ -174,7 +162,3 @@
       until: jenkins_response|success
       retries: 5
       delay: 10
-
-    - name: Set default java back to java-1.7.0-openjdk-amd64
-      command: update-java-alternatives -s java-1.7.0-openjdk-amd64
-      when: ansible_distribution_release | lower == 'trusty'


### PR DESCRIPTION
Since #703 has since merged (and only installs openjdk-8-jre-headless
on both trusty and xenial), this commit has been created to update
setup_jenkins_slave.yml to do the same thing.  This should ensure
that we have consistent nodes irrespective of nodepool or legacy boot
method.

NOTE: We also add a task to set set the default JAVA_HOME to the
installed jdk, otherwise the groovy syntax check fails as groovy looks
for java under /usr/lib/jvm/default-java/bin/java. This doesn't
exist as we no longer install default-jre-headless or run
update-java-alternatives to point the default to
java-1.8.0-openjdk-amd64.

Issue: [RE-1415](https://rpc-openstack.atlassian.net/browse/RE-1415)