### PR TITLE
RE-1415 Add JAVA_HOME env var to default environment

### DIFF
--- a/nodepool/elements/jenkins-slave/install.d/20-jenkins-slave
+++ b/nodepool/elements/jenkins-slave/install.d/20-jenkins-slave
@@ -54,6 +54,11 @@ chmod 0440 /etc/sudoers.d/jenkins
 visudo -c || die "Error setting jenkins sudo!"
 
 ##
+## Set the JAVA_HOME env var
+##
+echo "JAVA_HOME=\"$(find /usr/lib/jvm -mindepth 1 -maxdepth 1 -type d)\"" >> /etc/environment
+
+##
 ## Finalise
 ##
 


### PR DESCRIPTION
In order to ensure that java applications work properly
we set the environment variable as a default. To ensure
that we use whatever the current location is, we use a
find instead of a static path.

Issue: [RE-1415](https://rpc-openstack.atlassian.net/browse/RE-1415)