### PR TITLE
RE-1422 Fix cleanup for long running nodes

### DIFF
--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -48,7 +48,7 @@
         def nodes = getLongRunningNodes()
         def parallel_steps = [:]
         for (int i=0; i<nodes.size(); i++){
-          nodeName = nodes[i]
+          def nodeName = nodes[i]
           parallel_steps['node_'+nodeName] = {
             common.use_node(nodeName){
               try {


### PR DESCRIPTION
Periodic cleanup is supposed to run a series of cleanups on all
long running slaves, one of which is to remove old docker containers.
However jobs started to fail as docker ran out of thin pool space.
On investigation it became clear that old docker containers were not
being removed. Executing the cleanup script manually successfully
removed old containers, and the cleanup job appeared to show
the script running correctly. The bug was that the cleanup script
was running N times on the same node, where N is the number of long
running slaves, rather than once against each node.

This is because of a variable scoping bug. The cleanup job loops over
the long running nodes in order to build a dictionary of tasks,
these tasks are then executed in parallel. However the nodeName variable
was globally scoped, so when the parallel tasks were executed, they
always used the last loop value. The remedy is to scope the nodeName
variable to within the loop its defined in, then each parallel
branch/closure will have a unique version of that variable.

Issue: [RE-1422](https://rpc-openstack.atlassian.net/browse/RE-1422)