### PR TITLE
RE-1240 Build Gating venv improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.swp
 *.pyc
 .lintvenv
+.venv/
 playbooks/roles/geerlingguy.nginx/
 playbooks/roles/jnv.unattended-upgrades/
 playbooks/roles/willshersystems.sshd/

--- a/rpc_jobs/build_gating_venv.yml
+++ b/rpc_jobs/build_gating_venv.yml
@@ -81,6 +81,14 @@
                 # Install ansible roles
                 mkdir -p rpc-gating/playbooks/roles
                 ansible-galaxy install -r rpc-gating/role_requirements.yml -p rpc-gating/playbooks/roles
+
+                # Tar venv and roles
+                pushd rpc-gating; SHA=\$(git rev-parse HEAD); popd
+                archive="rpcgatingvenv_\${SHA}.tbz"
+                find .venv -name \\*.pyc -delete
+                echo "\${PWD}/.venv" > .venv/original_venv_path
+                echo \$SHA > .venv/venv_sha
+                tar cjfp \$archive .venv rpc-gating/playbooks/roles
                 """
               } // container
 
@@ -88,15 +96,6 @@
               // credentials files does not work within docker (used for ssh key)
               withCredentials(artifact_build.get_rpc_repo_creds()) {
                 sh """#!/bin/bash -xeu
-                  # Tar venv and roles
-                  pushd rpc-gating
-                    SHA=\$(git rev-parse HEAD)
-                  popd
-                  archive="rpcgatingvenv_\${SHA}.tbz"
-                  find .venv -name \\*.pyc -delete
-                  echo "\${PWD}/.venv" > .venv/original_venv_path
-                  echo \$SHA > .venv/venv_sha
-                  tar cjfp \$archive .venv rpc-gating/playbooks/roles
 
                   # Add ssh host key
                   grep "\${REPO_HOST}" ~/.ssh/known_hosts \
@@ -106,13 +105,15 @@
                   REPO_PATH="/var/www/repo/rpcgating/venvs"
 
                   # Upload generated version
+                  pushd rpc-gating; SHA=\$(git rev-parse HEAD); popd
+                  archive="rpcgatingvenv_\${SHA}.tbz"
                   scp -i \$REPO_USER_KEY \$archive \$REPO_USER@\$REPO_HOST:\$REPO_PATH
 
                   # Generate index
                   ssh -i \$REPO_USER_KEY \$REPO_USER@\$REPO_HOST "cd \$REPO_PATH; ls -1 *tbz > index"
 
-                  # Keep 10 newest archives, remove the rest.
-                  ssh -i \$REPO_USER_KEY \$REPO_USER@\$REPO_HOST "cd \$REPO_PATH && ls -t1 *tbz |tail -n +11 |while read f; do echo "'removing \$f'"; rm "'\$f'"; done"
+                  # Keep 100 newest archives, remove the rest.
+                  ssh -i \$REPO_USER_KEY \$REPO_USER@\$REPO_HOST "cd \$REPO_PATH && ls -t1 *tbz |tail -n +101 |while read f; do echo "'removing \$f'"; rm "'\$f'"; done"
                 """
               }
             } finally {


### PR DESCRIPTION
- Moved archive creation to inside the container to avoid any external "file changed" issues previously discovered
- Increased the number of venvs to keep from 10 to 100

Issue: [RE-1240](https://rpc-openstack.atlassian.net/browse/RE-1240)