### PR TITLE
RE-1424 Phobos VPN Service

### DIFF
--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -135,3 +135,19 @@
             build. This defaults to "BASE_IMAGE=ubuntu:16.04", which is
             specifically applicable to the "./Dockerfile.standard_job" in
             rpc-gating.
+
+- parameter:
+    name: phobos_params
+    parameters:
+      - string:
+          name: GATEWAY
+          default: from_creds
+          help: |
+            IP of Phobos VPN Gateway, if set to "from_creds", the gateway
+            IP will be pulled from the Jenkins Creds Store
+      - string:
+          name: PING_HOST
+          default: 172.20.4.10
+          help: |
+            Host that is only accessible via Phobos vpn, used to verify
+            connectivity

--- a/rpc_jobs/phobos_vpn_service.yml
+++ b/rpc_jobs/phobos_vpn_service.yml
@@ -1,0 +1,86 @@
+- job:
+    name: 'Phobos-VPN-Service'
+    project-type: workflow
+    parameters:
+      - rpc_gating_params
+      - phobos_params
+    properties:
+      - build-discarder:
+          days-to-keep: 3
+    dsl: |
+      library "rpc-gating@${RPC_GATING_BRANCH}"
+      if (env.GATEWAY == "from_creds"){
+        withCredentials([
+          string(
+            credentialsId: 'phobos_vpn_gateway',
+            variable: 'gw_from_creds'
+          ),
+        ]){
+          env.GATEWAY = gw_from_creds
+        }
+      }
+
+      def deploy_test(String label, String name){
+        stage("Template script ${name}"){
+          node(label){
+            withCredentials([
+              usernamePassword(
+                credentialsId: "phobos_vpn_ipsec",
+                usernameVariable: "ipsec_id",
+                passwordVariable: "ipsec_secret"
+              ),
+              usernamePassword(
+                credentialsId: "phobos_vpn_xauth",
+                usernameVariable: "xauth_user",
+                passwordVariable: "xauth_pass"
+              )
+            ]){
+            writeFile(
+              file: "/tmp/phobos_vpn_service.sh",
+              text: """
+              # install vpnc
+              yum -v -y install vpnc
+
+              # write out vpnc config file for phobos
+              mkdir -p /etc/vpnc
+              cat >/etc/vpnc/phobos.conf << 'EOF'
+      IPSec gateway ${gateway}
+
+      IKE Authmode psk
+
+      IPSec ID ${ipsec_id}
+      IPSec secret ${ipsec_secret}
+
+      Xauth username ${xauth_user}
+      Xauth password ${xauth_pass}
+      EOF
+
+              # write upstart config to keep vpnc running
+              cat > /etc/init/vpnc.conf << 'EOF'
+      description "Cisco VPN connection to phobos"
+      author      "RPC Release Engineering"
+
+      start on filesystem
+      stop on shutdown
+
+      expect fork
+      respawn
+      exec /usr/sbin/vpnc --pid-file /run/vpnc/phobos.pid /etc/vpnc/phobos.conf
+      EOF
+
+      # Start vpnc service
+      start vpnc
+
+      # test
+      ping -w 5 ${env.PING_HOST} && echo "Success!"
+      """)
+            }
+          }
+        }
+        stage("Manual script run ${name}"){
+          input(message: "Now manually run bash -x /tmp/phobos_vpn_service as root on ${name}")
+        }
+      }
+
+      deploy_test("master", "Master")
+      deploy_test("CentOS", "Slave")

--- a/rpc_jobs/unit/phobos_vpn.yml
+++ b/rpc_jobs/unit/phobos_vpn.yml
@@ -14,6 +14,7 @@
           REGIONS: "DFW ORD"
           FALLBACK_REGIONS: "IAD"
       - rpc_gating_params
+      - phobos_params
       - string:
           name: STAGES
           default: "Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
@@ -25,19 +26,6 @@
               Pause (use to hold instance for investigation before cleanup)
               Cleanup
               Destroy Slave
-      - string:
-          name: GATEWAY
-          default: from_creds
-          help: |
-            IP of Phobos VPN Gateway, if set to "from_creds", the gateway
-            IP will be pulled from the Jenkins Creds Store
-      - string:
-          name: PING_HOST
-          default: 172.20.4.10
-          help: |
-            Host that is only accessible via Phobos vpn, used to verify
-            connectivity
-
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
       if (env.GATEWAY == "from_creds"){


### PR DESCRIPTION
This service adds a job to create a background vpn service that runs
on the Jenkis nodes within the Rackspace firewall.

This is for two purposes:
1. Give the master access to phobos outside the context of a job
so that phobos can be used as a region

2. Give the slave access to phobos, so jobs can use it without
starting their own vpn instance.