### PR TITLE
RI-255 Don't add JAVA_HOME to /etc/environment

### DIFF
--- a/gating/common/run_lint.sh
+++ b/gating/common/run_lint.sh
@@ -7,4 +7,5 @@ sudo apt-get update && sudo apt-get install -y \
 pip install -c constraints.txt -r requirements.txt
 pip install -c constraints.txt -r test-requirements.txt
 
+export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
 RPC_GATING_LINT_USE_VENV=no ./lint.sh

--- a/playbooks/setup_jenkins_slave.yml
+++ b/playbooks/setup_jenkins_slave.yml
@@ -60,11 +60,6 @@
         - git-core
         - openjdk-8-jre-headless
 
-    - name: Set default JAVA_HOME environment variable
-      lineinfile:
-        path: /etc/environment
-        line: 'export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"'
-
     - name: Create Jenkins user
       user:
         name: jenkins


### PR DESCRIPTION
It turns out that openstack-ansible copies the host's /etc/environment
to each container's /etc/environment, and having JAVA_HOME set in the
logstash container is interfering w/ the installation of logstash.

Rather than setting JAVA_HOME, we simply set export it in
gating/common/run_lint.sh instead so that groovy can find a suitable
java executable.

Issue: [RI-255](https://rpc-openstack.atlassian.net/browse/RI-255)