### PR TITLE
RE-1434 Expose failures compressing logs

### DIFF
--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -125,11 +125,15 @@
             // the logs from running builds.
             sh """#!/bin/bash
               cd /var/lib/jenkins/jobs
-              find . -regex '.+/builds/[0-9]+/\\([0-9]+\\.\\)?log' -mtime +1 \\
-                |while read stagelog; do
+              while read stagelog; do
                   echo \$stagelog
                   gzip \$stagelog
-                done
+                  _rc=\$?
+                  if [ \$_rc -ne '0' ]; then
+                    rc=\$_rc
+                  fi
+              done < <(find . -regex '.+/builds/[0-9]+/\\([0-9]+\\.\\)?log' -mtime +1)
+              exit \${rc:-0}
             """
           }
         }


### PR DESCRIPTION
The script to compress logs in the periodic_cleanup only registers a
failure in the while loop if it happens on the last pass. This change
ensure that any failures are reported by the first build that detects
them and are consistent between builds.

Issue: [RE-1434](https://rpc-openstack.atlassian.net/browse/RE-1434)