### PR TITLE
RE-1355 Fix dep_update JIRA label

### DIFF
--- a/scripts/dep_update.sh
+++ b/scripts/dep_update.sh
@@ -65,7 +65,7 @@ if [[ -n "$(git status -s)" ]] || [[ ${start_sha} != $(git rev-parse --verify HE
           --description "${issue_message}" \
           --label RE_DEP_UPDATE \
           --label jenkins \
-          --label "${repo}_${branch}"
+          --label "${repo}_${BRANCH}"
   )
   echo "Issue: ${issue}"
 fi


### PR DESCRIPTION
This change fixes the label string to reference the correct variable.
Without this change the label was taking the form `some-repo_` when it
should be `some-repo_a-branch`.

Issue: [RE-1355](https://rpc-openstack.atlassian.net/browse/RE-1355)