### PR TITLE
RE-1449 Lint XML before running junit step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04
-RUN apt-get update && apt-get install -y groovy2 python-pip build-essential python-dev libssl-dev curl libffi-dev sudo git-core
+RUN apt-get update && apt-get install -y groovy2 python-pip build-essential python-dev libssl-dev curl libffi-dev sudo git-core libxml2-utils
 COPY requirements.txt /requirements.txt
 COPY test-requirements.txt /test-requirements.txt
 COPY constraints.txt /constraints.txt

--- a/Dockerfile.standard_job
+++ b/Dockerfile.standard_job
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=ubuntu:16.04
 FROM ${BASE_IMAGE}
-RUN apt-get update && apt-get install -y groovy2 python-pip build-essential python-dev libssl-dev curl libffi-dev sudo git-core
+RUN apt-get update && apt-get install -y groovy2 python-pip build-essential python-dev libssl-dev curl libffi-dev sudo git-core libxml2-utils
 COPY requirements.txt /requirements.txt
 COPY test-requirements.txt /test-requirements.txt
 COPY constraints.txt /constraints.txt

--- a/nodepool/files/elements/jenkins-slave/package-installs.yaml
+++ b/nodepool/files/elements/jenkins-slave/package-installs.yaml
@@ -2,3 +2,4 @@ bzip2:
 curl:
 openjdk-8-jre-headless:
 git-core:
+libxml2-utils:

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -320,7 +320,7 @@ def archive_artifacts(Map args = [:]){
           Integer xmlStatus = sh(
             returnStatus: true,
             script: """#!/bin/bash -xe
-              /usr/bin/xmllint ${file} || mv ${file} ${file}-broken
+              /usr/bin/xmllint ${file} > /dev/null || mv ${file} ${file}-broken
             """
           )
         }

--- a/playbooks/setup_jenkins_slave.yml
+++ b/playbooks/setup_jenkins_slave.yml
@@ -59,6 +59,7 @@
       with_items:
         - git-core
         - openjdk-8-jre-headless
+        - libxml2-utils
 
     - name: Create Jenkins user
       user:


### PR DESCRIPTION
Currently, if bad XML ends up in the result dir and jenkins parses it
with the junit step, then jenkins will mark the build as UNSTABLE.

To avoid builds failing because of this situation, we first run xmllint
against the XML files and then only run the junit step if no errors
were found.

We also install libxml2-utils (which provides xmllint) in Docker
containers, pubcloud single use slaves, and nodepool instances.

Issue: [RE-1449](https://rpc-openstack.atlassian.net/browse/RE-1449)