### PR TITLE
RE-1452 Ensure master is included in cleanup

### DIFF
--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -33,12 +33,14 @@
           // Only return nodes whose name starts with one
           // of these expressions. Single use slaves won't match
           // so are filtered out.
-          node -> node.name =~ /^(long-|master|rpc-jenkins-n)/
+          node -> node.name =~ /^(long-|rpc-jenkins-n)/
         }.collect {
           // node objects are not serializable so return a list
           // of names instead :(
           node -> node.name
-        }
+        // master isn't in jenkins.model.Jenkins.instance.nodes so
+        // add it to the filtered list.
+        } + "master"
       }
 
       // end of functions

--- a/scripts/workspace_cleanup.sh
+++ b/scripts/workspace_cleanup.sh
@@ -3,5 +3,5 @@
 echo "Removing Workspaces that haven't been modified in the last 2 days"
 set -xe
 cd /var/lib/jenkins/workspace \
-  && find . -maxdepth 1 -ctime +2 \
+  && find . -maxdepth 1 -mindepth 1 -ctime +2 \
     |while read old; do rm -rf "$old"; done


### PR DESCRIPTION
Master now runs build summary in docker. As docker is being used,
its important that docker cleanup is run regularly. However a bug
in the periodic cleanup job means that cleanup is not running on
master.

This commit ensures that cleanup does indeed run on the master.

Issue: [RE-1452](https://rpc-openstack.atlassian.net/browse/RE-1452)