### PR TITLE
RE-1456 Pin os-client-config

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -44,6 +44,7 @@ nose==1.3.7
 oauthlib==2.0.3
 openstacksdk==0.9.19
 ordereddict==1.1
+os-client-config==1.30.0
 os-diskconfig-python-novaclient-ext==0.1.3
 os-networksv2-python-novaclient-ext==0.26
 os-virtual-interfacesv2-python-novaclient-ext==0.20


### PR DESCRIPTION
The latest version of os-client-config, 1.31.0 is incompatible with the
current version of shade being used. This change pins the package to fix
build failures.

Issue: [RE-1456](https://rpc-openstack.atlassian.net/browse/RE-1456)