### PR TITLE
ASC-384 add qtest creds to more branches

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -391,6 +391,8 @@
           FLAVOR: "onmetal-io1"
           REGIONS: "IAD"
           FALLBACK_REGIONS: ""
+    # Required by RPC-ASC team to upload test results qTest
+    credentials: "rpc_asc_creds"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
@@ -439,6 +441,8 @@
           FLAVOR: "onmetal-io1"
           REGIONS: "IAD"
           FALLBACK_REGIONS: ""
+    # Required by RPC-ASC team to upload test results qTest
+    credentials: "rpc_asc_creds"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 


### PR DESCRIPTION
This commit increases the number of branches that have
credentials to publish to qtest.  The desired state is that
all branches that run system tests should be able to publish
test results to qtest.

Issue: [ASC-384](https://rpc-openstack.atlassian.net/browse/ASC-384)