### PR TITLE
RE-1408 Fix grafyaml import and dashboard URL

### DIFF
--- a/grafana/grafyaml/dashboard-nodepool.yaml
+++ b/grafana/grafyaml/dashboard-nodepool.yaml
@@ -8,7 +8,7 @@ dashboard:
           content: |
             **This dashboard is managed by [Grafyaml](http://docs.openstack.org/infra/system-config/grafyaml.html).**
 
-            If you would like to make changes to this dashboard, please see the grafyaml directory in [rpc-gating](https://github.com/rcbops/rpc-gating/blob/master/grafana/grafyaml/nodepool.yml).
+            If you would like to make changes to this dashboard, please see the grafyaml directory in [rpc-gating](https://github.com/rcbops/rpc-gating/tree/master/grafana/grafyaml).
           type: text
     - title: Nodes
       showTitle: true

--- a/grafana/setup_grafana.yml
+++ b/grafana/setup_grafana.yml
@@ -101,6 +101,7 @@
       no_log: True
       when:
         - grafyaml_api_key is defined
+        - grafyaml_api_key != ""
 
     - name: Install nginx web server
       package:

--- a/rpc_jobs/setup_grafana.yml
+++ b/rpc_jobs/setup_grafana.yml
@@ -34,8 +34,9 @@
       common.globalWraps(){
         try{
           common.withRequestedCredentials(
-            "cloud_creds, id_rsa_cloud10_jenkins_file,"
-            + "RE_GRAFANA_ADMIN_PASSWORD"
+            "cloud_creds, id_rsa_cloud10_jenkins_file, "
+            + "RE_GRAFANA_ADMIN_PASSWORD, "
+            + "RE_GRAFANA_GRAFYAML_API_KEY"
           ){
             stage("Prepare Ansible Roles"){
               // Getting the roles is a bit flaky sometimes, so we


### PR DESCRIPTION
This PR fixes the following:

- The URL in the dashboard is incorrect.
- The credentials are not available to the job to use.
- The grafyaml import job fails if the key is not present.

Issue: [RE-1408](https://rpc-openstack.atlassian.net/browse/RE-1408)