### PR TITLE
RE-1408 Fix misspelled credential

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1035,9 +1035,9 @@ List build_creds_array(String list_of_cred_ids){
         credentialsId: "RE_GRAFANA_ADMIN_PASSWORD",
         variable: "RE_GRAFANA_ADMIN_PASSWORD"
       ),
-      "GRAFANA_GRAFYAML_API_KEY": string(
-        credentialsId: "GRAFANA_GRAFYAML_API_KEY",
-        variable: "GRAFANA_GRAFYAML_API_KEY"
+      "RE_GRAFANA_GRAFYAML_API_KEY": string(
+        credentialsId: "RE_GRAFANA_GRAFYAML_API_KEY",
+        variable: "RE_GRAFANA_GRAFYAML_API_KEY"
       ),
       "RE_GRAPHITE_ADMIN_PASSWORD": string(
         credentialsId: "RE_GRAPHITE_ADMIN_PASSWORD",


### PR DESCRIPTION
The correct credential ID, variable and name is
RE_GRAFANA_GRAFYAML_API_KEY - the previous patch
missed the 'RE_' prefix.

Issue: [RE-1408](https://rpc-openstack.atlassian.net/browse/RE-1408)