### PR TITLE
RE-1481 Remove /var/lib/jenkins/workspace/*@tmp

### DIFF
--- a/scripts/rax_instance_clean.sh
+++ b/scripts/rax_instance_clean.sh
@@ -112,6 +112,7 @@ rm -f /root/.nano_history
 rm -f /root/.lesshst
 rm -f /root/.ssh/authorized_keys.bak*
 rm -f /root/.ssh/known_hosts
+rm -rf /var/lib/jenkins/workspace/*@tmp
 for k in $(find /var/log -type f); do
     echo > $k
 done


### PR DESCRIPTION
The temporary jenkins workspace dirs can contain sensitive files, but
don't appear to be cleaned up automatically.

This commit simply removes any tmp dirs from /var/lib/jenkins/workspace
prior to shutting down so that restoring a snapshot won't have any
sensitive files lingering in it.

Issue: [RE-1481](https://rpc-openstack.atlassian.net/browse/RE-1481)