### PR TITLE
RE-1463 Revert g1-8 to working label and p2-15 to old config

### DIFF
--- a/nodepool/files/nodepool.yml
+++ b/nodepool/files/nodepool.yml
@@ -11,22 +11,22 @@ zookeeper-servers:
 
 labels:
   - name: ubuntu-xenial
-    min-ready: 0
+    min-ready: 3
     max-ready-age: 3600
   - name: ubuntu-trusty
-    min-ready: 0
+    min-ready: 3
     max-ready-age: 3600
   - name: ubuntu-xenial-g1-8
-    min-ready: 3
+    min-ready: 1
     max-ready-age: 3600
   - name: ubuntu-trusty-g1-8
-    min-ready: 3
+    min-ready: 0
     max-ready-age: 3600
   - name: ubuntu-xenial-p2-15
-    min-ready: 3
+    min-ready: 1
     max-ready-age: 3600
   - name: ubuntu-trusty-p2-15
-    min-ready: 3
+    min-ready: 0
     max-ready-age: 3600
 
 providers:

--- a/rpc_jobs/dummy_pipeline.yml
+++ b/rpc_jobs/dummy_pipeline.yml
@@ -87,7 +87,7 @@
 
     image:
       - "xenial":
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
 
     scenario:
       - "functional"
@@ -108,7 +108,7 @@
 
     image:
       - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
 
     scenario:
       - 'functional'
@@ -166,7 +166,7 @@
 
     image:
       - "xenial":
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
 
     scenario:
       - "functional"
@@ -187,7 +187,7 @@
 
     image:
       - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
 
     scenario:
       - 'functional'
@@ -245,7 +245,7 @@
 
     image:
       - "xenial":
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
 
     scenario:
       - "functional"
@@ -266,7 +266,7 @@
 
     image:
       - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
 
     scenario:
       - 'functional'
@@ -289,7 +289,7 @@
 
     image:
       - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
 
     scenario:
       - 'functional'
@@ -312,7 +312,7 @@
 
     image:
       - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
 
     scenario:
       - 'functional'
@@ -335,7 +335,7 @@
 
     image:
       - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
 
     scenario:
       - 'functional'

--- a/rpc_jobs/rpc_ceph.yml
+++ b/rpc_jobs/rpc_ceph.yml
@@ -13,7 +13,7 @@
 
     image:
       - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
 
     # rpc-ceph ignores that setting for now
     scenario:
@@ -45,9 +45,10 @@
 
     scenario:
       - functional:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
       - rpco_newton:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-p2-15"
+          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+          FLAVOR: "performance2-15"
 
     # rpc-ceph ignores that setting for now
     action:

--- a/rpc_jobs/rpc_eng_ops.yml
+++ b/rpc_jobs/rpc_eng_ops.yml
@@ -5,7 +5,7 @@
     branch: "master"
     image:
       - "xenial":
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
     scenario: "embedded"
     action:
       - "deploy"

--- a/rpc_jobs/rpc_hummingbird.yml
+++ b/rpc_jobs/rpc_hummingbird.yml
@@ -9,7 +9,7 @@
 
     image:
       - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
 
     # rpc-hummingbird ignores that setting for now
     scenario:
@@ -36,7 +36,7 @@
 
     image:
       - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
 
     scenario:
       - "functional"

--- a/rpc_jobs/rpc_maas.yml
+++ b/rpc_jobs/rpc_maas.yml
@@ -9,17 +9,18 @@
       - "xenial"
     scenario:
       - master:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-p2-15"
+          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+          FLAVOR: "performance2-15"
           TRIGGER_PR_PHRASE_ONLY: true
       - pike:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
       - ocata:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
           TRIGGER_PR_PHRASE_ONLY: true
       - newton:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
       - ceph:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
     action:
       - "deploy"
     credentials: "cloud_creds"
@@ -35,7 +36,7 @@
       - "master.*"
     image:
       - trusty:
-          SLAVE_TYPE: "nodepool-ubuntu-trusty-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-trusty"
     scenario:
       - newton
       - mitaka

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -14,7 +14,8 @@
       | ^gating/update_dependencies/
     image:
       - xenial_no_artifacts:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-p2-15"
+          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+          FLAVOR: "performance2-15"
     scenario:
       - ironic:
           TRIGGER_PR_PHRASE_ONLY: true
@@ -61,7 +62,8 @@
       | ^gating/update_dependencies/
     image:
       - xenial_no_artifacts:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-p2-15"
+          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+          FLAVOR: "performance2-15"
     scenario:
       - ironic:
           TRIGGER_PR_PHRASE_ONLY: true

--- a/rpc_jobs/rpc_role_logstash.yml
+++ b/rpc_jobs/rpc_role_logstash.yml
@@ -9,7 +9,7 @@
 
     image:
       - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
 
     # rpc-role-logstash ignores that setting for now
     scenario:

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -5,7 +5,7 @@
     branch:     "master"
     image:
       - "xenial":
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
     scenario:   "functional"
     action:     "test"
     jira_project_key: "RE"

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -10,7 +10,7 @@
       - "master"
     image:
       - "xenial":
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
     scenario:
       - "lint"
     action:

--- a/rpc_jobs/unit/re_unit_tests.yml
+++ b/rpc_jobs/unit/re_unit_tests.yml
@@ -49,7 +49,7 @@
             ]
           )
         },
-        "nodepool-ubuntu-xenial-g1-8 Instance": {
+        "nodepool-ubuntu-xenial Instance": {
           build(
             job: "RE-unit-test-slave-types",
             wait: true,
@@ -62,12 +62,12 @@
               [
                 $class: 'StringParameterValue',
                 name: 'SLAVE_TYPE',
-                value: 'nodepool-ubuntu-xenial-g1-8'
+                value: 'nodepool-ubuntu-xenial'
               ]
             ]
           )
         },
-        "nodepool-ubuntu-trusty-g1-8 Instance": {
+        "nodepool-ubuntu-trusty Instance": {
           build(
             job: "RE-unit-test-slave-types",
             wait: true,
@@ -80,7 +80,7 @@
               [
                 $class: 'StringParameterValue',
                 name: 'SLAVE_TYPE',
-                value: 'nodepool-ubuntu-trusty-g1-8'
+                value: 'nodepool-ubuntu-trusty'
               ]
             ]
           )

--- a/rpc_jobs/unit/wrappers.yml
+++ b/rpc_jobs/unit/wrappers.yml
@@ -8,7 +8,7 @@
     parameters:
       - rpc_gating_params
       - standard_job_params:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial"
           SLAVE_CONTAINER_DOCKERFILE_REPO: "{SLAVE_CONTAINER_DOCKERFILE_REPO}"
           SLAVE_CONTAINER_DOCKERFILE_PATH: "{SLAVE_CONTAINER_DOCKERFILE_PATH}"
           SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS: "{SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS}"


### PR DESCRIPTION
Something is not quite right when trying to use the new labels
so we switch to using the old labels for the g1-8 flavor, and
revert the job configuration to use the old mechanism for the
p2-15 jobs until we can work out the issue.

We also adjust the min-ready settings to accommodate this new
strategy.

Issue: [RE-1463](https://rpc-openstack.atlassian.net/browse/RE-1463)