### PR TITLE
ASC-475 Add system action to green field newton

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -386,6 +386,11 @@
     scenario:
       - "swift"
     action:
+      - system:
+          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+          FLAVOR: "onmetal-io1"
+          REGIONS: "IAD"
+          FALLBACK_REGIONS: ""
       - deploy:
           IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
           FLAVOR: "onmetal-io1"
@@ -436,6 +441,11 @@
     scenario:
       - "swift"
     action:
+      - system:
+          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+          FLAVOR: "onmetal-io1"
+          REGIONS: "IAD"
+          FALLBACK_REGIONS: ""
       - deploy:
           IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
           FLAVOR: "onmetal-io1"


### PR DESCRIPTION
This commit adds the `system` action to newton and newton-rc green
field matrices. This action is performed in conjunction with the
`xenial_mnaio_no_artifacts` image. The `system` and `deploy` actions
are filtered in order to only create one new job per branch to match
the other branch jobs for the `system` action.

Therefore, only the following jobs are created:
https://rpc.jenkins.cit.rackspace.net/job/PM_rpc-openstack-newton-xenial_mnaio_no_artifacts-swift-system
https://rpc.jenkins.cit.rackspace.net/job/PM_rpc-openstack-newton-rc-xenial_mnaio_no_artifacts-swift-system

Issue: [ASC-475](https://rpc-openstack.atlassian.net/browse/ASC-475)