### PR TITLE
RE-1463 Extend nodepool usage to more PR jobs

### DIFF
--- a/nodepool/files/nodepool.yml
+++ b/nodepool/files/nodepool.yml
@@ -11,13 +11,13 @@ zookeeper-servers:
 
 labels:
   - name: ubuntu-xenial
-    min-ready: 3
+    min-ready: 0
     max-ready-age: 3600
   - name: ubuntu-trusty
-    min-ready: 3
+    min-ready: 0
     max-ready-age: 3600
   - name: ubuntu-xenial-g1-8
-    min-ready: 1
+    min-ready: 3
     max-ready-age: 3600
   - name: ubuntu-trusty-g1-8
     min-ready: 0
@@ -44,7 +44,7 @@ providers:
         config-drive: true
     pools: &provider_pools_block
       - name: main
-        max-servers: 10
+        max-servers: 20
         availability-zones: []
         labels:
           - name: ubuntu-xenial

--- a/rpc_jobs/dummy_pipeline.yml
+++ b/rpc_jobs/dummy_pipeline.yml
@@ -87,7 +87,7 @@
 
     image:
       - "xenial":
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
 
     scenario:
       - "functional"
@@ -108,7 +108,7 @@
 
     image:
       - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
 
     scenario:
       - 'functional'
@@ -166,7 +166,7 @@
 
     image:
       - "xenial":
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
 
     scenario:
       - "functional"
@@ -187,7 +187,7 @@
 
     image:
       - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
 
     scenario:
       - 'functional'
@@ -245,7 +245,7 @@
 
     image:
       - "xenial":
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
 
     scenario:
       - "functional"
@@ -266,7 +266,7 @@
 
     image:
       - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
 
     scenario:
       - 'functional'
@@ -289,7 +289,7 @@
 
     image:
       - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
 
     scenario:
       - 'functional'
@@ -312,7 +312,7 @@
 
     image:
       - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
 
     scenario:
       - 'functional'
@@ -335,7 +335,7 @@
 
     image:
       - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
 
     scenario:
       - 'functional'

--- a/rpc_jobs/rpc_ceph.yml
+++ b/rpc_jobs/rpc_ceph.yml
@@ -13,7 +13,7 @@
 
     image:
       - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
 
     # rpc-ceph ignores that setting for now
     scenario:
@@ -45,10 +45,9 @@
 
     scenario:
       - functional:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
       - rpco_newton:
-          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
-          FLAVOR: "performance2-15"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-p2-15"
 
     # rpc-ceph ignores that setting for now
     action:

--- a/rpc_jobs/rpc_eng_ops.yml
+++ b/rpc_jobs/rpc_eng_ops.yml
@@ -5,7 +5,7 @@
     branch: "master"
     image:
       - "xenial":
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
     scenario: "embedded"
     action:
       - "deploy"

--- a/rpc_jobs/rpc_hummingbird.yml
+++ b/rpc_jobs/rpc_hummingbird.yml
@@ -9,7 +9,7 @@
 
     image:
       - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
 
     # rpc-hummingbird ignores that setting for now
     scenario:
@@ -36,7 +36,7 @@
 
     image:
       - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
 
     scenario:
       - "functional"

--- a/rpc_jobs/rpc_maas.yml
+++ b/rpc_jobs/rpc_maas.yml
@@ -9,18 +9,17 @@
       - "xenial"
     scenario:
       - master:
-          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
-          FLAVOR: "performance2-15"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-p2-15"
           TRIGGER_PR_PHRASE_ONLY: true
       - pike:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
       - ocata:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
           TRIGGER_PR_PHRASE_ONLY: true
       - newton:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
       - ceph:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
     action:
       - "deploy"
     credentials: "cloud_creds"
@@ -36,7 +35,7 @@
       - "master.*"
     image:
       - trusty:
-          SLAVE_TYPE: "nodepool-ubuntu-trusty"
+          SLAVE_TYPE: "nodepool-ubuntu-trusty-g1-8"
     scenario:
       - newton
       - mitaka

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -14,8 +14,7 @@
       | ^gating/update_dependencies/
     image:
       - xenial_no_artifacts:
-          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
-          FLAVOR: "performance2-15"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-p2-15"
     scenario:
       - ironic:
           TRIGGER_PR_PHRASE_ONLY: true
@@ -62,8 +61,7 @@
       | ^gating/update_dependencies/
     image:
       - xenial_no_artifacts:
-          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
-          FLAVOR: "performance2-15"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-p2-15"
     scenario:
       - ironic:
           TRIGGER_PR_PHRASE_ONLY: true

--- a/rpc_jobs/rpc_role_logstash.yml
+++ b/rpc_jobs/rpc_role_logstash.yml
@@ -9,7 +9,7 @@
 
     image:
       - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
 
     # rpc-role-logstash ignores that setting for now
     scenario:

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -5,7 +5,7 @@
     branch:     "master"
     image:
       - "xenial":
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
     scenario:   "functional"
     action:     "test"
     jira_project_key: "RE"

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -10,7 +10,7 @@
       - "master"
     image:
       - "xenial":
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
     scenario:
       - "lint"
     action:

--- a/rpc_jobs/unit/re_unit_tests.yml
+++ b/rpc_jobs/unit/re_unit_tests.yml
@@ -49,7 +49,7 @@
             ]
           )
         },
-        "nodepool-ubuntu-xenial Instance": {
+        "nodepool-ubuntu-xenial-g1-8 Instance": {
           build(
             job: "RE-unit-test-slave-types",
             wait: true,
@@ -62,12 +62,12 @@
               [
                 $class: 'StringParameterValue',
                 name: 'SLAVE_TYPE',
-                value: 'nodepool-ubuntu-xenial'
+                value: 'nodepool-ubuntu-xenial-g1-8'
               ]
             ]
           )
         },
-        "nodepool-ubuntu-trusty Instance": {
+        "nodepool-ubuntu-trusty-g1-8 Instance": {
           build(
             job: "RE-unit-test-slave-types",
             wait: true,
@@ -80,7 +80,7 @@
               [
                 $class: 'StringParameterValue',
                 name: 'SLAVE_TYPE',
-                value: 'nodepool-ubuntu-trusty'
+                value: 'nodepool-ubuntu-trusty-g1-8'
               ]
             ]
           )

--- a/rpc_jobs/unit/wrappers.yml
+++ b/rpc_jobs/unit/wrappers.yml
@@ -8,7 +8,7 @@
     parameters:
       - rpc_gating_params
       - standard_job_params:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
           SLAVE_CONTAINER_DOCKERFILE_REPO: "{SLAVE_CONTAINER_DOCKERFILE_REPO}"
           SLAVE_CONTAINER_DOCKERFILE_PATH: "{SLAVE_CONTAINER_DOCKERFILE_PATH}"
           SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS: "{SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS}"


### PR DESCRIPTION
Now that the issue of nodepool rejecting jobs for labels which
end with a number [a] is resolved, we can revert 935af07.

This extends the use of nodepool to more jobs and a broader set
of flavors, allowing us to monitor these for stability before
moving on to the next stage of job migrations.

[a] rpc-openstack.atlassian.net/browse/RE-1502

In order to cater to nodepool now handling almost all PR jobs,
we adjust the quotas.

1. We set max-servers in the main pool for each region to 20,
   providing a total maximum of 60 servers from the main pool
   which will be handling non-container tests for PR's.

2. We set the min-ready for the ubuntu-xenial and ubuntu-trusty
   nodes to 0 as they're being phased out and replaced with the
   more explicitly named (according to flavor profile)
   ubuntu-xenial-g1-8 and ubuntu-trusty-g1-8.

3. We leave the ubuntu-trusty-g1-8 and ubuntu-trusty-p2-15
   min-servers at 0 (this makes it build nodes on-demand rather
   than keep one ready) as these profiles are very rarely used.

4. We leave the min-ready for ubuntu-xenial-p2-15 at 1 as it is
   relatively rarely used (only by three jobs), and having 3
   available (1 x 3 regions) at all times is more than enough.

5. We up the ubuntu-xenial-g1-8 min-ready to 3 as it is the most
   commonly used. This provides 9 ready nodes at any time.

Issue: [RE-1463](https://rpc-openstack.atlassian.net/browse/RE-1463)