### PR TITLE
RE-1463 Add PM jobs tor rpc-role-logstash and rpc-maas

### DIFF
--- a/rpc_jobs/rpc_maas.yml
+++ b/rpc_jobs/rpc_maas.yml
@@ -69,3 +69,24 @@
       - "tox-test"
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
+
+- project:
+    name: "rpc-maas-master-postmerge"
+    repo_name: "rpc-maas"
+    repo_url: "https://github.com/rcbops/rpc-maas"
+    branch: "master"
+    CRON: "@weekly"
+    image:
+      - "xenial":
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+      - "trusty":
+          SLAVE_TYPE: "nodepool-ubuntu-trusty-g1-8"
+    scenario:
+      - pike
+      - newton
+      - ceph
+    action:
+      - "deploy"
+    credentials: "cloud_creds"
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'

--- a/rpc_jobs/rpc_role_logstash.yml
+++ b/rpc_jobs/rpc_role_logstash.yml
@@ -46,28 +46,18 @@
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
-# NOTE(mattt): There's currently no PM job setup for this role, so leaving
-#              this disabled until the project owner requests periodic
-#              testing.
-#- project:
-#    name: "rpc-role-logstash-post-merge"
-#
-#    repo_name: "rpc-role-logstash"
-#    repo_url: "https://github.com/rcbops/rpc-role-logstash"
-#
-#    image:
-#      - xenial:
-#          FLAVOR: "general1-8"
-#          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
-#
-#    # rpc-role-logstash ignores that setting for now
-#    scenario:
-#      - "functional"
-#
-#    # rpc-role-logstash ignores that setting for now
-#    action:
-#      - "test"
-#
-#    # Link to the standard pre-merge-template
-#    jobs:
-#      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+- project:
+    name: "rpc-role-logstash-postmerge"
+    repo_name: "rpc-role-logstash"
+    repo_url: "https://github.com/rcbops/rpc-role-logstash"
+    branch: "master"
+    CRON: "@weekly"
+    image:
+      - "xenial":
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+    scenario:
+      - functional
+    action:
+      - test
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'


### PR DESCRIPTION
In order to make on-demand testing easier, and to highlight
bit-rot, we add PM jobs for rpc-maas and rpc-role-logstash.

Issue: [RE-1463](https://rpc-openstack.atlassian.net/browse/RE-1463)