### PR TITLE
RE-1463 Use http for mirror.rackspace.com

### DIFF
--- a/nodepool/files/nodepool.yml
+++ b/nodepool/files/nodepool.yml
@@ -120,7 +120,7 @@ diskimages:
       DIB_CHECKSUM: '1'
       DIB_IMAGE_CACHE: /opt/nodepool/dib_cache
       DIB_GRUB_TIMEOUT: '0'
-      DIB_DISTRIBUTION_MIRROR: 'https://mirror.rackspace.com/ubuntu'
+      DIB_DISTRIBUTION_MIRROR: 'http://mirror.rackspace.com/ubuntu'
       DIB_DEBIAN_COMPONENTS: 'main,universe'
   - name: ubuntu-trusty
     # Build fresh images every 24 hrs.
@@ -143,5 +143,5 @@ diskimages:
       DIB_CHECKSUM: '1'
       DIB_IMAGE_CACHE: /opt/nodepool/dib_cache
       DIB_GRUB_TIMEOUT: '0'
-      DIB_DISTRIBUTION_MIRROR: 'https://mirror.rackspace.com/ubuntu'
+      DIB_DISTRIBUTION_MIRROR: 'http://mirror.rackspace.com/ubuntu'
       DIB_DEBIAN_COMPONENTS: 'main,universe'


### PR DESCRIPTION
Using https for the mirror is pointless, and prevents
caching from having any useful effect. A recent RPC-O
test failed due to a TLS error communicating with the
mirror.

In order to reduce the chances of failure, and improve
caching performance in tests, we switch the image to
use http instead of https.

Issue: [RE-1463](https://rpc-openstack.atlassian.net/browse/RE-1463)