### PR TITLE
RE-1489 Remove CIT reference from recheck triggers

### DIFF
--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -77,7 +77,7 @@
           org-list:
             - rcbops
           github-hooks: true
-          trigger-phrase: '.*recheck(_cit)?_all.*|.*recheck(_cit)?_artifact.*'
+          trigger-phrase: '.*recheck_all.*|.*recheck_artifact.*'
           only-trigger-phrase: false
           white-list-target-branches:
             - "{branches}"

--- a/rpc_jobs/standard_job_dep_update.yml
+++ b/rpc_jobs/standard_job_dep_update.yml
@@ -35,7 +35,7 @@
           org-list:
             - rcbops
           github-hooks: true
-          trigger-phrase: '.*recheck_(cit_)?all.*|.*recheck_(cit_)?dep_update.*'
+          trigger-phrase: '.*recheck_all.*|.*recheck_dep_update.*'
           only-trigger-phrase: false
           white-list-target-branches:
             - "{branches}"

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -68,7 +68,7 @@
           org-list:
             - rcbops
           github-hooks: true
-          trigger-phrase: '.*recheck_(cit_)?all.*|.*recheck_(cit_)?{image}_{scenario}_{action}.*'
+          trigger-phrase: '.*recheck_all.*|.*recheck_{image}_{scenario}_{action}.*'
           only-trigger-phrase: "{obj:TRIGGER_PR_PHRASE_ONLY}"
           white-list-target-branches: "{branches}"
           auth-id: "github_account_rpc_jenkins_svc"

--- a/rpc_jobs/standard_job_premerge_release.yml
+++ b/rpc_jobs/standard_job_premerge_release.yml
@@ -37,7 +37,7 @@
           org-list:
             - rcbops
           github-hooks: true
-          trigger-phrase: '.*recheck_(cit_)?all.*|.*recheck_(cit_)?release.*'
+          trigger-phrase: '.*recheck_all.*|.*recheck_release.*'
           only-trigger-phrase: false
           white-list-target-branches:
             - "{BRANCH}"

--- a/rpc_jobs/unit/re_unit_tests.yml
+++ b/rpc_jobs/unit/re_unit_tests.yml
@@ -7,7 +7,7 @@
           org-list:
             - rcbops
           github-hooks: true
-          trigger-phrase: '.*recheck_(cit_)?all.*|.*recheck_(cit_)?unit_?tests.*'
+          trigger-phrase: '.*recheck_all.*|.*recheck_unit_?tests.*'
           only-trigger-phrase: false
           auth-id: "github_account_rpc_jenkins_svc"
           status-context: 'CIT/re_unit_tests'


### PR DESCRIPTION
I suspect we added this when we had multiple jenkins instances running
at the same time, but this is no longer necessary.

We will need to communicate this change to users and merge on a set
date to avoid any surprises.

Issue: [RE-1489](https://rpc-openstack.atlassian.net/browse/RE-1489)