### PR TITLE
RI-255 Don't add JAVA_HOME to /etc/environment

### DIFF
--- a/nodepool/files/elements/jenkins-slave/install.d/20-jenkins-slave
+++ b/nodepool/files/elements/jenkins-slave/install.d/20-jenkins-slave
@@ -54,11 +54,6 @@ chmod 0440 /etc/sudoers.d/jenkins
 visudo -c || die "Error setting jenkins sudo!"
 
 ##
-## Set the JAVA_HOME env var
-##
-echo "JAVA_HOME=\"$(find /usr/lib/jvm -mindepth 1 -maxdepth 1 -type d)\"" >> /etc/environment
-
-##
 ## Finalise
 ##
 


### PR DESCRIPTION
It turns out that openstack-ansible copies the host's /etc/environment
to each container's /etc/environment, and having JAVA_HOME set in the
logstash container is interfering w/ the installation of logstash.

In [1] we took care of the reason this was put here, so we can remove
this safely now.

[1] 230d77015d041234fa054ac12dd64db2b95236e8

Issue: [RI-255](https://rpc-openstack.atlassian.net/browse/RI-255)