### PR TITLE
RE-1489 Update issue link status-context

### DIFF
--- a/rpc_jobs/pull_request_issue_link.yml
+++ b/rpc_jobs/pull_request_issue_link.yml
@@ -23,7 +23,7 @@
           trigger-phrase: '.*recheck_all.*|.*recheck_issue_link.*'
           only-trigger-phrase: false
           auth-id: "github_account_rpc_jenkins_svc"
-          status-context: 'CIT/issue-link'
+          status-context: 'CIT/issue_link'
           cancel-builds-on-update: true
     properties:
       - github:


### PR DESCRIPTION
This commit updates the status-context for the issue link job to be
consistent with other status-contexts (underscore versus dash).

NOTE: Both rpc-openstack and rpc-gating have this job configured, but
neither have branches where this job is set to required. As such,
nothing should need to be done in GitHub once this merges.

Issue: [RE-1489](https://rpc-openstack.atlassian.net/browse/RE-1489)