### PR TITLE
RE-1464 Move all MNAIO jobs to use nodepool

### DIFF
--- a/nodepool/files/nodepool.yml
+++ b/nodepool/files/nodepool.yml
@@ -28,24 +28,30 @@ labels:
   - name: ubuntu-trusty-p2-15
     min-ready: 0
     max-ready-age: 3600
+  - name: ubuntu-xenial-om-io1
+    min-ready: 1
+    max-ready-age: 3600
 
 providers:
   - name: pubcloud-iad
     region-name: 'IAD'
     cloud: public_cloud
-    boot-timeout: 120
+    boot-timeout: 3600
     hostname-format: nodepool-{label.name}-{provider.name}-{node.id}
+    cloud-images: &provider_cloudimage_block
+      - name: ubuntu-xenial-onmetal
+        image-name: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
     image-name-format: nodepool-{image_name}-{timestamp}
     diskimages: &provider_diskimage_block
       - name: ubuntu-xenial
         config-drive: true
       - name: ubuntu-trusty
         config-drive: true
-    pools: &provider_pools_block
+    pools:
       - name: main
         max-servers: 20
         availability-zones: []
-        labels:
+        labels: &provider_pools_main_labels_block
           - name: ubuntu-xenial
             diskimage: ubuntu-xenial
             flavor-name: general1-8
@@ -76,6 +82,15 @@ providers:
             flavor-name: performance2-15
             key-name: jenkins
             console-log: true
+      - name: onmetal
+        max-servers: 5
+        availability-zones: []
+        labels: &provider_pools_onmetal_labels_block
+          - name: ubuntu-xenial-om-io1
+            cloud-image: ubuntu-xenial-onmetal
+            flavor-name: onmetal-io1
+            key-name: jenkins
+            console-log: true
 
   - name: pubcloud-dfw
     region-name: 'DFW'
@@ -84,7 +99,10 @@ providers:
     hostname-format: nodepool-{label.name}-{provider.name}-{node.id}
     image-name-format: nodepool-{image_name}-{timestamp}
     diskimages: *provider_diskimage_block
-    pools: *provider_pools_block
+      - name: main
+        max-servers: 20
+        availability-zones: []
+        labels: *provider_pools_main_labels_block
 
   - name: pubcloud-ord
     region-name: 'ORD'
@@ -93,7 +111,10 @@ providers:
     hostname-format: nodepool-{label.name}-{provider.name}-{node.id}
     image-name-format: nodepool-{image_name}-{timestamp}
     diskimages: *provider_diskimage_block
-    pools: *provider_pools_block
+      - name: main
+        max-servers: 20
+        availability-zones: []
+        labels: *provider_pools_main_labels_block
 
 diskimages:
   - name: ubuntu-xenial

--- a/nodepool/files/nodepool.yml
+++ b/nodepool/files/nodepool.yml
@@ -10,12 +10,6 @@ zookeeper-servers:
     port: 2181
 
 labels:
-  - name: ubuntu-xenial
-    min-ready: 0
-    max-ready-age: 3600
-  - name: ubuntu-trusty
-    min-ready: 0
-    max-ready-age: 3600
   - name: ubuntu-xenial-g1-8
     min-ready: 3
     max-ready-age: 3600
@@ -52,16 +46,6 @@ providers:
         max-servers: 20
         availability-zones: []
         labels: &provider_pools_main_labels_block
-          - name: ubuntu-xenial
-            diskimage: ubuntu-xenial
-            flavor-name: general1-8
-            key-name: jenkins
-            console-log: true
-          - name: ubuntu-trusty
-            diskimage: ubuntu-trusty
-            flavor-name: general1-8
-            key-name: jenkins
-            console-log: true
           - name: ubuntu-xenial-g1-8
             diskimage: ubuntu-xenial
             flavor-name: general1-8

--- a/nodepool/files/nodepool.yml
+++ b/nodepool/files/nodepool.yml
@@ -33,7 +33,6 @@ providers:
   - name: pubcloud-iad
     region-name: 'IAD'
     cloud: public_cloud
-    api-timeout: 60
     boot-timeout: 120
     hostname-format: nodepool-{label.name}-{provider.name}-{node.id}
     image-name-format: nodepool-{image_name}-{timestamp}
@@ -81,7 +80,6 @@ providers:
   - name: pubcloud-dfw
     region-name: 'DFW'
     cloud: public_cloud
-    api-timeout: 60
     boot-timeout: 120
     hostname-format: nodepool-{label.name}-{provider.name}-{node.id}
     image-name-format: nodepool-{image_name}-{timestamp}
@@ -91,7 +89,6 @@ providers:
   - name: pubcloud-ord
     region-name: 'ORD'
     cloud: public_cloud
-    api-timeout: 60
     boot-timeout: 120
     hostname-format: nodepool-{label.name}-{provider.name}-{node.id}
     image-name-format: nodepool-{image_name}-{timestamp}

--- a/rpc_jobs/hardening.yml
+++ b/rpc_jobs/hardening.yml
@@ -6,10 +6,7 @@
     jira_project_key: "RQE"
     image:
       - xenial_mnaio_loose_artifacts:
-          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
-          FLAVOR: "onmetal-io1"
-          REGIONS: "IAD"
-          FALLBACK_REGIONS: ""
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io1"
     scenario:
       - "swift"
     action:

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -216,19 +216,14 @@
     jira_project_key: "RO"
     image:
       - xenial_mnaio_no_artifacts:
-          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
-          FLAVOR: "onmetal-io1"
-          REGIONS: "IAD"
-          FALLBACK_REGIONS: ""
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io1"
     scenario:
-      - "ironic"
-      - "swift"
+      - ironic
+      - swift
     action:
       - system
       - deploy
     exclude:
-      - action: system
-        image: xenial_mnaio_loose_artifacts
       - action: system
         scenario: ironic
     # Required by RPC-ASC team to upload test results qTest
@@ -266,21 +261,14 @@
     branch: "pike"
     jira_project_key: "RO"
     image:
-      - xenial_mnaio_no_artifacts
+      - xenial_mnaio_no_artifacts:
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io1"
     scenario:
-      - "ironic"
-      - "swift"
+      - ironic
+      - swift
     action:
-      - system:
-          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
-          FLAVOR: "onmetal-io1"
-          REGIONS: "IAD"
-          FALLBACK_REGIONS: ""
-      - deploy:
-          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
-          FLAVOR: "onmetal-io1"
-          REGIONS: "IAD"
-          FALLBACK_REGIONS: ""
+      - system
+      - deploy
     exclude:
       - action: system
         scenario: ironic
@@ -319,24 +307,15 @@
     branch: "pike-rc"
     jira_project_key: "RO"
     image:
-      - xenial_mnaio_no_artifacts
+      - xenial_mnaio_no_artifacts:
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io1"
     scenario:
-      - "ironic"
-      - "swift"
+      - ironic
+      - swift
     action:
-      - system:
-          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
-          FLAVOR: "onmetal-io1"
-          REGIONS: "IAD"
-          FALLBACK_REGIONS: ""
-      - deploy:
-          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
-          FLAVOR: "onmetal-io1"
-          REGIONS: "IAD"
-          FALLBACK_REGIONS: ""
+      - system
+      - deploy
     exclude:
-      - action: system
-        image: xenial_mnaio_loose_artifacts
       - action: system
         scenario: ironic
     # Required by RPC-ASC team to upload test results qTest
@@ -380,20 +359,13 @@
     branch: "newton"
     jira_project_key: "RO"
     image:
-      - xenial_mnaio_loose_artifacts
+      - xenial_mnaio_loose_artifacts:
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io1"
     scenario:
-      - "swift"
+      - swift
     action:
-      - system:
-          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
-          FLAVOR: "onmetal-io1"
-          REGIONS: "IAD"
-          FALLBACK_REGIONS: ""
-      - deploy:
-          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
-          FLAVOR: "onmetal-io1"
-          REGIONS: "IAD"
-          FALLBACK_REGIONS: ""
+      - system
+      - deploy
     # Required by RPC-ASC team to upload test results qTest
     credentials: "rpc_asc_creds"
     jobs:
@@ -435,20 +407,13 @@
     branch: "newton-rc"
     jira_project_key: "RO"
     image:
-      - xenial_mnaio_loose_artifacts
+      - xenial_mnaio_loose_artifacts:
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io1"
     scenario:
-      - "swift"
+      - swift
     action:
-      - system:
-          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
-          FLAVOR: "onmetal-io1"
-          REGIONS: "IAD"
-          FALLBACK_REGIONS: ""
-      - deploy:
-          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
-          FLAVOR: "onmetal-io1"
-          REGIONS: "IAD"
-          FALLBACK_REGIONS: ""
+      - system
+      - deploy
     # Required by RPC-ASC team to upload test results qTest
     credentials: "rpc_asc_creds"
     jobs:

--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -71,7 +71,7 @@
       - "r12.2.5_to_newton_leap"
       - "r12.2.2_to_newton_leap"
       - "r12.1.2_to_newton_leap"
-      - "kilo_to_newton_leap" 
+      - "kilo_to_newton_leap"
       - "r14.7.0_to_newton_minor"
     jira_project_key: "RLM"
     jobs:
@@ -136,10 +136,7 @@
     image:
       # in mnaio builds, the OS equals the VMs OS
       - trusty_mnaio:
-          FLAVOR: "onmetal-io1"
-          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
-          REGIONS: "IAD"
-          FALLBACK_REGIONS: ""
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io1"
     scenario:
       - "swift"
     action:
@@ -163,10 +160,7 @@
     image:
       # in mnaio builds, the OS equals the VMs OS
       - trusty_mnaio:
-          FLAVOR: "onmetal-io1"
-          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
-          REGIONS: "IAD"
-          FALLBACK_REGIONS: ""
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io1"
     scenario:
       - "swift"
     action:


### PR DESCRIPTION
In this PR we implement the configuration required for nodepool to prepare onmetal hosts, and we switch the jobs over to make them use the nodes. A conservative max servers number is used to start with. We can update this later to the correct quota number.