### PR TITLE
RE-1491 Update use of rpc_component

### DIFF
--- a/constraints_rpc_component.txt
+++ b/constraints_rpc_component.txt
@@ -1,0 +1,3 @@
+GitPython==2.1.9
+git+https://github.com/rcbops/rpc_component@776c7d7ddc96fd62b503c78c980256906db5a6fd#egg=rpc_component
+schema==0.6.7

--- a/rpc_jobs/standard_job_release.yml
+++ b/rpc_jobs/standard_job_release.yml
@@ -28,16 +28,13 @@
           sh """#!/bin/bash -xe
               virtualenv --python python3 .venv3
               set +x; . .venv3/bin/activate; set -x
-              pip install -c constraints.txt -r requirements.txt
-              pushd rpc_component
-                  pip install .
-              popd
+              pip install -c '${env.WORKSPACE}/rpc-gating/constraints_rpc_component.txt' rpc_component
           """
           String component_text = sh (script: """#!/bin/bash -xe
               set +x; . .venv3/bin/activate; set -x
               src_branch="origin/master"
               pr_branch="HEAD"
-              component --releases-dir . compare --from \${src_branch} --to \${pr_branch} --verify version || true
+              component --releases-dir . compare --from \${src_branch} --to \${pr_branch} --verify release || true
           """,
           returnStdout: true)
 
@@ -49,7 +46,7 @@
 
             String component = component_yaml['name']
             String series = component_yaml['release']['series']
-            String sha = component_yaml['release']['version']['sha']
+            String sha = component_yaml['release']['sha']
 
             List jobNames = Hudson.instance.getAllItems(org.jenkinsci.plugins.workflow.job.WorkflowJob)*.fullName
 
@@ -164,10 +161,7 @@
           sh """#!/bin/bash -xe
             virtualenv --python python3 .venv3
             set +x; . .venv3/bin/activate; set -x
-            pip install -c constraints.txt -r requirements.txt
-            pushd rpc_component
-                pip install .
-            popd
+            pip install -c '${env.WORKSPACE}/rpc-gating/constraints_rpc_component.txt' rpc_component
           """
           component = readYaml text: component_text
           println "=== component CLI standard out ==="
@@ -179,8 +173,8 @@
               src_branch="origin/master"
               pr_branch="HEAD"
               component --releases-dir .\
-                 component --component-name ${component["name"]}\
-                 get --version ${component["release"]["version"]["version"]} --pred || true
+                 release --component-name ${component["name"]}\
+                 get --version ${component["release"]["version"]} --pred || true
             """,
             returnStdout: true
           )
@@ -193,8 +187,8 @@
 
         ORG=component["repo_url"].split("/")[3]
         REPO=component["name"]
-        VERSION=component["release"]["version"]["version"]
-        PREVIOUS_VERSION=pred_component["release"]["version"]["version"]
+        VERSION=component["release"]["version"]
+        PREVIOUS_VERSION=pred_component["release"]["version"]
         RELEASE_NOTES_FILE="${WORKSPACE}/artifacts/release_notes"
         MAINLINE=component["release"]["series"]
         RC_BRANCH="${MAINLINE}-rc"

--- a/scripts/dep_update.sh
+++ b/scripts/dep_update.sh
@@ -28,7 +28,7 @@ start_sha=$(git rev-parse --verify HEAD)
 if [[ "${COMPONENT_DEPENDENCIES_UPDATE}" == 'true' ]]; then
   apt-get update
   apt-get install -y python3-pip
-  pip3 install 'git+https://github.com/mattt416/rpc-metadata#rpc_component&subdirectory=rpc_component'
+  pip3 install -c "${WORKSPACE}/rpc-gating/constraints_rpc_component.txt" rpc_component
   component --releases-repo 'https://github.com/mattt416/rpc-metadata' dependency update-requirements
   if [[ ${start_sha} == $(git rev-parse --verify HEAD) ]]; then
     echo "No component dependency updates found."


### PR DESCRIPTION
rpc_component has been moved from mattt416/rpc-metadata to
rcbops/rpc_component. This change updates the use of rpc_component to
pin it to the latest available version.

In addition a few breaking changes have been addressed so that the new
version works where used. These changes centre around more consistent
use of the terms release and version.

Issue: [RE-1491](https://rpc-openstack.atlassian.net/browse/RE-1491)