### PR TITLE
RE-1516 Revert MNAIO jobs to not use nodepool

### DIFF
--- a/nodepool/files/nodepool.yml
+++ b/nodepool/files/nodepool.yml
@@ -23,14 +23,14 @@ labels:
     min-ready: 0
     max-ready-age: 3600
   - name: ubuntu-xenial-om-io2
-    min-ready: 2
+    min-ready: 0
     max-ready-age: 3600
 
 providers:
   - name: pubcloud-iad
     region-name: 'IAD'
     cloud: public_cloud
-    boot-timeout: 3600
+    boot-timeout: 600
     hostname-format: nodepool-{label.name}-{provider.name}-{node.id}
     cloud-images: &provider_cloudimage_block
       - name: ubuntu-xenial-onmetal
@@ -79,7 +79,7 @@ providers:
   - name: pubcloud-dfw
     region-name: 'DFW'
     cloud: public_cloud
-    boot-timeout: 3600
+    boot-timeout: 600
     hostname-format: nodepool-{label.name}-{provider.name}-{node.id}
     cloud-images: *provider_cloudimage_block
     image-name-format: nodepool-{image_name}-{timestamp}

--- a/rpc_jobs/hardening.yml
+++ b/rpc_jobs/hardening.yml
@@ -6,7 +6,10 @@
     jira_project_key: "RQE"
     image:
       - xenial_mnaio_loose_artifacts:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          FLAVOR: "onmetal-io2"
+          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+          REGIONS: "IAD"
+          FALLBACK_REGIONS: "DFW"
     scenario:
       - "swift"
     action:

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -216,7 +216,10 @@
     jira_project_key: "RO"
     image:
       - xenial_mnaio_no_artifacts:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          FLAVOR: "onmetal-io2"
+          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+          REGIONS: "IAD"
+          FALLBACK_REGIONS: "DFW"
     scenario:
       - ironic
       - swift
@@ -262,7 +265,10 @@
     jira_project_key: "RO"
     image:
       - xenial_mnaio_no_artifacts:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          FLAVOR: "onmetal-io2"
+          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+          REGIONS: "IAD"
+          FALLBACK_REGIONS: "DFW"
     scenario:
       - ironic
       - swift
@@ -308,7 +314,10 @@
     jira_project_key: "RO"
     image:
       - xenial_mnaio_no_artifacts:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          FLAVOR: "onmetal-io2"
+          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+          REGIONS: "IAD"
+          FALLBACK_REGIONS: "DFW"
     scenario:
       - ironic
       - swift
@@ -360,7 +369,10 @@
     jira_project_key: "RO"
     image:
       - xenial_mnaio_loose_artifacts:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          FLAVOR: "onmetal-io2"
+          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+          REGIONS: "IAD"
+          FALLBACK_REGIONS: "DFW"
     scenario:
       - swift
     action:
@@ -408,7 +420,10 @@
     jira_project_key: "RO"
     image:
       - xenial_mnaio_loose_artifacts:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          FLAVOR: "onmetal-io2"
+          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+          REGIONS: "IAD"
+          FALLBACK_REGIONS: "DFW"
     scenario:
       - swift
     action:

--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -136,7 +136,10 @@
     image:
       # in mnaio builds, the OS equals the VMs OS
       - trusty_mnaio:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          FLAVOR: "onmetal-io2"
+          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+          REGIONS: "IAD"
+          FALLBACK_REGIONS: "DFW"
     scenario:
       - "swift"
     action:
@@ -160,7 +163,10 @@
     image:
       # in mnaio builds, the OS equals the VMs OS
       - trusty_mnaio:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          FLAVOR: "onmetal-io2"
+          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+          REGIONS: "IAD"
+          FALLBACK_REGIONS: "DFW"
     scenario:
       - "swift"
     action:


### PR DESCRIPTION
The nodepool provisioning is encountering some trouble with
onmetal provisioning due to quota calculations and also seems
to not work right with multiple pools. While we work out the
root cause and a solution for it, we revert to the previous
configuration - but add the ability to fall back from IAD to
DFW now that we're using the io2 flavor which is available in
both regions.

Issue: [RE-1516](https://rpc-openstack.atlassian.net/browse/RE-1516)