### PR TITLE
RE-1516 Wait for up to 10 mins for SSH connectivity

### DIFF
--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -88,8 +88,9 @@
       debug:
         msg: "Generated inventory: {{ lookup('file', inventory_path+'/hosts')}}"
 
-    - name: Wait for SSH to be available on all hosts
+    - name: Wait for SSH to be available on all hosts (10 min timeout)
       wait_for:
+        timeout: 600
         port: 22
         host: "{{ instance.server.accessIPv4 }}"
 


### PR DESCRIPTION
OnMetal hosts take ~5 mins to be connectible via SSH. We
set the timeout to 10 mins to give it some breathing room.

Issue: [RE-1516](https://rpc-openstack.atlassian.net/browse/RE-1516)