### PR TITLE
RE-1466 Add nodepool config for RPC-O artifacted base images

### DIFF
--- a/nodepool/files/elements/rpco-artifacts-ubuntu-minimal/element-deps
+++ b/nodepool/files/elements/rpco-artifacts-ubuntu-minimal/element-deps
@@ -1,0 +1,3 @@
+debootstrap
+package-installs
+ubuntu-common

--- a/nodepool/files/elements/rpco-artifacts-ubuntu-minimal/element-provides
+++ b/nodepool/files/elements/rpco-artifacts-ubuntu-minimal/element-provides
@@ -1,0 +1,1 @@
+operating-system

--- a/nodepool/files/elements/rpco-artifacts-ubuntu-minimal/environment.d/10-ubuntu-environment
+++ b/nodepool/files/elements/rpco-artifacts-ubuntu-minimal/environment.d/10-ubuntu-environment
@@ -1,0 +1,31 @@
+export DISTRO_NAME=ubuntu
+export DIB_RELEASE=${DIB_RELEASE:-xenial}
+export DIB_DEBIAN_COMPONENTS=${DIB_DEBIAN_COMPONENTS:-main,universe}
+export DIB_DISTRIBUTION_MIRROR=${DIB_DISTRIBUTION_MIRROR:-http://mirror.rackspace.com/ubuntu}
+export RCBOPS_REPO_URL="http://rpc-repo.rackspace.com"
+export RCBOPS_REPO_APT_URL="${RCBOPS_REPO_URL}/apt-mirror/integrated"
+export RCBOPS_REPO_KEY_URL="${RCBOPS_REPO_URL}/apt-mirror/rcbops-release-signing-key.asc"
+export RPC_RELEASE=${RPC_RELEASE:-r14.2.0}
+
+# For the image build, we only make use of the base
+# repo for the base set of packages from the original
+# release. All updates, backports and security patches
+# come from the RPC-O apt repo source.
+DIB_APT_SOURCES_CONF_DEFAULT=\
+"default:deb ${DIB_DISTRIBUTION_MIRROR} ${DIB_RELEASE} ${DIB_DEBIAN_COMPONENTS//,/}
+rpco:deb ${RCBOPS_REPO_APT_URL} ${RPC_RELEASE}-${DIB_RELEASE} main
+"
+export DIB_APT_SOURCES_CONF=${DIB_APT_SOURCES_CONF:-${DIB_APT_SOURCES_CONF_DEFAULT}}
+
+# Use the RPCO keyring for package validation
+DIB_APT_KEYRING=${RCBOPS_REPO_KEY_URL}
+
+# We need to make sure that python is installed
+# so that DIB can use it. We also ensure that
+# curl is used so that the root.d stage can use
+# it.
+export DIB_DEBOOTSTRAP_EXTRA_ARGS="--include=python,curl"
+
+# We're installing python2, so we force it to be
+# used by DIB for the build.
+export DIB_PYTHON_VERSION="2"

--- a/nodepool/files/elements/rpco-artifacts-ubuntu-minimal/package-installs.yaml
+++ b/nodepool/files/elements/rpco-artifacts-ubuntu-minimal/package-installs.yaml
@@ -1,0 +1,2 @@
+linux-image-generic:
+initramfs-tools:

--- a/nodepool/files/elements/rpco-artifacts-ubuntu-minimal/root.d/75-ubuntu-minimal-baseinstall
+++ b/nodepool/files/elements/rpco-artifacts-ubuntu-minimal/root.d/75-ubuntu-minimal-baseinstall
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+# The bash environment variables used here should be coming from
+# the environment.d script.
+
+# Add the base repo source
+sudo bash -c "cat << EOF >${TARGET_ROOT}/etc/apt/sources.list
+deb ${DIB_DISTRIBUTION_MIRROR} ${DIB_RELEASE} ${DIB_DEBIAN_COMPONENTS//,/ }
+EOF"
+
+# Make sure that the sources.list.d directory exists
+# (it was removed by the debootstrap element)
+sudo bash -c "mkdir ${TARGET_ROOT}/etc/apt/sources.list.d"
+
+# Add the RPC-O apt repo source
+sudo bash -c "cat << EOF >${TARGET_ROOT}/etc/apt/sources.list.d/rpco.list
+deb ${RCBOPS_REPO_APT_URL} ${RPC_RELEASE}-${DIB_RELEASE} main
+EOF"
+
+sudo mount -t proc none ${TARGET_ROOT}/proc
+sudo mount -t sysfs none ${TARGET_ROOT}/sys
+trap "sudo umount ${TARGET_ROOT}/proc; sudo umount ${TARGET_ROOT}/sys" EXIT
+
+# Install the RPC-O apt repo key
+sudo bash -c "curl --silent --fail ${RCBOPS_REPO_KEY_URL} |\
+              sudo chroot ${TARGET_ROOT} apt-key add -"
+
+apt_get="sudo chroot ${TARGET_ROOT} /usr/bin/apt-get" # dib-lint: safe_sudo
+
+# Need to update to retrieve the signed Release file
+$apt_get update
+
+$apt_get clean
+$apt_get dist-upgrade -y
+
+$apt_get install -y busybox sudo

--- a/nodepool/files/nodepool.yml
+++ b/nodepool/files/nodepool.yml
@@ -25,6 +25,9 @@ labels:
   - name: ubuntu-xenial-om-io2
     min-ready: 0
     max-ready-age: 3600
+  - name: rpco-14.2-xenial-base
+    min-ready: 0
+    max-ready-age: 3600
 
 providers:
   - name: pubcloud-iad
@@ -40,6 +43,8 @@ providers:
       - name: ubuntu-xenial
         config-drive: true
       - name: ubuntu-trusty
+        config-drive: true
+      - name: rpco-14.2-xenial-base
         config-drive: true
     pools:
       - name: main
@@ -64,6 +69,11 @@ providers:
           - name: ubuntu-trusty-p2-15
             diskimage: ubuntu-trusty
             flavor-name: performance2-15
+            key-name: jenkins
+            console-log: true
+          - name: rpco-14.2-xenial-base
+            diskimage: rpco-14.2-xenial-artifacts
+            flavor-name: 7
             key-name: jenkins
             console-log: true
       - name: onmetal
@@ -147,6 +157,29 @@ diskimages:
       - vm
       - jenkins-slave
     release: trusty
+    env-vars:
+      TMPDIR: /opt/nodepool/dib_tmp
+      DIB_CHECKSUM: '1'
+      DIB_IMAGE_CACHE: /opt/nodepool/dib_cache
+      DIB_GRUB_TIMEOUT: '0'
+      DIB_DISTRIBUTION_MIRROR: 'http://mirror.rackspace.com/ubuntu'
+      DIB_DEBIAN_COMPONENTS: 'main,universe'
+  - name: rpco-14.2-xenial-artifacts
+    # Build fresh images every 24 hrs.
+    # This ensures that any merged config changes
+    # to the diskimage-build scripts or diskimage
+    # config take effect within a reasonable time.
+    rebuild-age: 86400
+    formats:
+      - vhd
+    elements:
+      - rpco-artifacts-ubuntu-minimal
+      - growroot
+      - openssh-server
+      - simple-init
+      - vm
+      - jenkins-slave
+    release: xenial
     env-vars:
       TMPDIR: /opt/nodepool/dib_tmp
       DIB_CHECKSUM: '1'


### PR DESCRIPTION
In order to implement the ability for nodepool to build a base
image which is usable for RPC-O newton strict artifact builds,
we add the appropriate diskimage-builder elements and config
to build an image using the apt artifact repository, and the
appropriate nodepool config to ensure that we are able to
request nodes using this image.

We deliberately do not want to convert any jobs over to using
this image yet as we need to confirm that the nodes provided
with this image are usable and do not break the tests.

Issue: [RE-1466](https://rpc-openstack.atlassian.net/browse/RE-1466)