### PR TITLE
RE-1463 Adjust rpc-maas periodic jobs

### DIFF
--- a/rpc_jobs/rpc_maas.yml
+++ b/rpc_jobs/rpc_maas.yml
@@ -71,7 +71,7 @@
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
 - project:
-    name: "rpc-maas-master-postmerge"
+    name: "rpc-maas-master-xenial-postmerge"
     repo_name: "rpc-maas"
     repo_url: "https://github.com/rcbops/rpc-maas"
     branch: "master"
@@ -79,12 +79,27 @@
     image:
       - "xenial":
           SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
-      - "trusty":
-          SLAVE_TYPE: "nodepool-ubuntu-trusty-g1-8"
     scenario:
       - pike
       - newton
       - ceph
+    action:
+      - "deploy"
+    credentials: "cloud_creds"
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+- project:
+    name: "rpc-maas-master-trusty-postmerge"
+    repo_name: "rpc-maas"
+    repo_url: "https://github.com/rcbops/rpc-maas"
+    branch: "master"
+    CRON: "@weekly"
+    image:
+      - "trusty":
+          SLAVE_TYPE: "nodepool-ubuntu-trusty-g1-8"
+    scenario:
+      - newton
     action:
       - "deploy"
     credentials: "cloud_creds"


### PR DESCRIPTION
Currently we have pike, newton, and ceph all gating on a trusty image,
but pike only supports xenial and it appears that the ceph job is also
only run on xenial in the pre-merge tests.

This commit splits out the periodic tests into a separate trusty and
xenial project.

Issue: [RE-1463](https://rpc-openstack.atlassian.net/browse/RE-1463)