### PR TITLE
RE-1505 Remove large values from summary data

### DIFF
--- a/scripts/build_summary/build_summary_gh.py
+++ b/scripts/build_summary/build_summary_gh.py
@@ -84,6 +84,16 @@ def summary(jobsdir, newerthan, jsonfile):
                 .format(jsonfile=jsonfile))
             traceback.print_exc(file=sys.stderr)
 
+    # Current production data.json has some extremely long failure detail
+    # fields. This commit includes a change to failure.py to ensure
+    # that doesn't happen in future. However to deal with the problem
+    # on disk, we load and truncate the fields here.
+    # At the end of this run, the data file will be rewritten with
+    # truncated values, so this fix code will only be needed once.
+    for b in data['builds']:
+        for f in b['failures']:
+            f['detail'] = f['detail'][:1000]
+
     # create set of build ids so we don't scan builds
     # we already have summary information about
     build_dict = {"{jn}_{bn}".format(jn=b['job_name'], bn=b['build_num']):

--- a/scripts/build_summary/failure.py
+++ b/scripts/build_summary/failure.py
@@ -37,7 +37,10 @@ class Failure(ABC):
     def get_serialisation_dict(self):
         return {
             "type": type(self).__name__,
-            "detail": self.detail,
+            # limit the detail field to 1000 chars, to prevent logs
+            # with super long lines from causing the data file to
+            # baloon
+            "detail": self.detail[:1000],
             "description": self.description,
             "build": self.build.get_serialisation_dict_without_failure_ref(),
             "category": self.category


### PR DESCRIPTION
Currently build summary is very laggy becuase data.json is very
large. Its large because some jobs have very long lines (an
entire RPCO run in one case). And that entire line is getting
embedded into the data.json file.

This commit puts an 1000 char limit on the detail field.

Issue: [RE-1505](https://rpc-openstack.atlassian.net/browse/RE-1505)