### PR TITLE
RE-1466 Correct diskimage name

### DIFF
--- a/nodepool/files/nodepool.yml
+++ b/nodepool/files/nodepool.yml
@@ -44,7 +44,7 @@ providers:
         config-drive: true
       - name: ubuntu-trusty
         config-drive: true
-      - name: rpco-14.2-xenial-base
+      - name: rpco-14.2-xenial-artifacts
         config-drive: true
     pools:
       - name: main


### PR DESCRIPTION
The node label was used instead of the diskimage name.
This patch corrects it.

Issue: [RE-1466](https://rpc-openstack.atlassian.net/browse/RE-1466)