### PR TITLE
RE-1487 Add component registration support

### DIFF
--- a/rpc_jobs/standard_job_release.yml
+++ b/rpc_jobs/standard_job_release.yml
@@ -24,7 +24,7 @@
       common.globalWraps(){
         dir("${env.WORKSPACE}/rpc-metadata") {
           common.clone_with_pr_refs()
-          common.runReleasesPullRequestWorkflow("origin/master", "HEAD")
+          common.runReleasesPullRequestWorkflow("origin/master", "HEAD", "RE")
         } // dir
       } // globalWraps
 

--- a/scripts/add_component_gate_trigger_job.sh
+++ b/scripts/add_component_gate_trigger_job.sh
@@ -1,0 +1,60 @@
+#!/bin/bash -xue
+
+cd "${REPO_DIR}"
+if [[ ! $(grep -s 'Component-Gate-Trigger_{repo_name}' "${PROJECTS_FILE}") ]] ; then
+  cat << EOF >> "${PROJECTS_FILE}"
+
+- project:
+    name: "${COMPONENT_NAME}"
+    repo_name: "${COMPONENT_NAME}"
+    repo_url: "${COMPONENT_REPO_URL}"
+
+    jobs:
+      - 'Component-Gate-Trigger_{repo_name}'
+EOF
+
+  issue_message="This issue was generated automatically as part of registering a new component."
+  issue_summary="Add new component gate trigger job for ${COMPONENT_NAME}"
+  issue=$(python ${WORKSPACE}/rpc-gating/scripts/jirautils.py \
+        --user "${JIRA_USER}" \
+        --password "${JIRA_PASS}" \
+        get_or_create_issue \
+          --project "${JIRA_PROJECT_KEY}" \
+          --summary "${issue_summary}" \
+          --description "${issue_message}" \
+          --label COMPONENT_GATE_TRIGGER \
+          --label "${COMPONENT_NAME}" \
+  )
+  echo "Issue: ${issue}"
+
+  orig_branch="${issue}/master/0"
+  git branch "${orig_branch}"
+  pr_branch="${issue}/master/1"
+  git checkout -b "${pr_branch}" "origin/master"
+
+  title="${issue} Add new component gate trigger job"
+  message="A new component, ${COMPONENT_NAME}, has been registered. This change
+adds the component gate trigger job to ensure pull requests can be
+merged."
+  git add "${PROJECTS_FILE}"
+  git commit -m "${title}" -m "${message}"
+
+  echo "Pushing changes to repo branch"
+  ssh_url="$(git remote get-url --push origin | sed 's|https://github.com/|git@github.com:|')"
+  git push "$ssh_url" "${pr_branch}"
+
+  git checkout "${orig_branch}"
+
+  echo "Creating PR"
+  owner="$(echo ${ssh_url} | cut -d: -f2 | cut -d/ -f1)"
+  repo="$(echo ${ssh_url} | cut -d: -f2 | cut -d/ -f2 | cut -d. -f1)"
+  python ${WORKSPACE}/rpc-gating/scripts/ghutils.py \
+    --org "$owner" \
+    --repo "$repo" \
+    --debug \
+    create_pr \
+      --source-branch "${pr_branch}"\
+      --target-branch "master" \
+      --title "${title}" \
+      --body "${message}"
+fi


### PR DESCRIPTION
This change extends the standard release job to allow new components to
be added to the releases repo.

In addition, when a new component is registered this change creates a
pull request to rpc-gating to get the gate trigger job set up, the
trigger job is used to gate a component's pull requests.

Issue: [RE-1487](https://rpc-openstack.atlassian.net/browse/RE-1487)

Test pull request - https://github.com/rcbops/rpc-gating/pull/850
Test issue - https://rpc-openstack.atlassian.net/browse/RE-1528