### PR TITLE
RLM-1471 Adds incremental test of Newton to Queens

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -193,3 +193,20 @@
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
     CRON: "@weekly"
+
+- project:
+    name: "rpc-upgrades-aio-newton-head-incremental"
+    repo_name: "rpc-upgrades"
+    repo_url: "https://github.com/rcbops/rpc-upgrades"
+    image:
+      - xenial_aio:
+          FLAVOR: "performance2-15"
+          IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
+    scenario:
+      - "swift"
+    action:
+      - "newton_to_queens_incremental"
+    jira_project_key: "RLM"
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+    CRON: "@weekly"


### PR DESCRIPTION
Adds incremental AIO test for newton to queens using
incremental upgrades script from each branch in OSA.

Don't merge until https://github.com/rcbops/rpc-upgrades/pull/165 is merged.

Issue: [RLM-1471](https://rpc-openstack.atlassian.net/browse/RLM-1471)