### PR TITLE
RE-1526 Browsable Artifacts Attempt 2

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -293,12 +293,14 @@ def String gen_instance_name(String prefix="AUTO"){
   return instance_name
 }
 
+String container_name(){
+  return "jenkinsjob_"+env.JOB_NAME+"_"+env.BUILD_NUMBER
+}
+
 def archive_artifacts(Map args = [:]){
   stage('Compress and Publish Artifacts'){
 
-    archive_name = args.get("archive_name", "artifacts_${env.BUILD_TAG}.tar.bz2")
     artifacts_dir = args.get("artifacts_dir", "${env.WORKSPACE}/artifacts")
-    report_dir = args.get("report_dir", "${env.WORKSPACE}/artifacts_report")
     results_dir = args.get("results_dir", "${env.WORKSPACE}/results")
 
     dir(results_dir) {
@@ -330,19 +332,13 @@ def archive_artifacts(Map args = [:]){
     }
 
     pubcloud.uploadToSwift(
-      archive_name: archive_name,
-      container: "jenkins_logs",
-      path: artifacts_dir,
-      report_dir: report_dir
+      container: container_name(),
+      path: artifacts_dir
     )
-    publishHTML(
-      allowMissing: true,
-      alwaysLinkToLastBuild: true,
-      keepAll: true,
-      reportDir: report_dir,
-      reportFiles: 'index.html',
-      reportName: 'Build Artifact Links'
-    )
+    if(fileExists(file: "artifact_public_url")){
+      artifact_public_url = readFile(file: "artifact_public_url")
+      currentBuild.description = "<h2><a href='"+artifact_public_url+"'>Build Artifacts</a></h2>"
+    }
   } // stage
 }
 

--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -248,11 +248,10 @@ def uploadToSwift(Map args){
         common.venvPlaybook(
           playbooks: ["rpc-gating/playbooks/upload_to_swift.yml"],
           vars: [
-            archive_name: args.archive_name,
             artifacts_dir: args.path,
             container: args.container,
-            description_file: args.description_file,
-            report_dir: args.report_dir
+            job_name: env.JOB_NAME,
+            build_number: env.BUILD_NUMBER,
           ]
         ) // venvPlaybook
       } // withEnv

--- a/playbooks/templates/artifact/index.html
+++ b/playbooks/templates/artifact/index.html
@@ -1,0 +1,393 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>RE Artefacts</title>
+  <link href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons' rel="stylesheet" type="text/css">
+  <link href="https://unpkg.com/vuetify/dist/vuetify.min.css" rel="stylesheet" type="text/css"></link>
+  <link href="styles.css" rel="stylesheet" type="text/css">
+</head>
+<body>
+  <div id="app">
+    <v-app>
+      <v-navigation-drawer
+        fixed
+        :mini-variant="miniVariant"
+        :clipped="clipped"
+        v-model="drawer"
+        app
+      >
+        <v-list>
+          <v-list-tile :value="true" v-for="(item, i) in items" :key="item.title" :href="item.url">
+            <v-list-tile-action>
+              <v-icon light v-html="item.icon"></v-icon>
+            </v-list-tile-action>
+            <v-list-tile-content>
+              <v-list-tile-title v-text="item.title"></v-list-tile-title>
+            </v-list-tile-content>
+          </v-list-tile>
+        </v-list>
+      </v-navigation-drawer>
+      <v-toolbar fixed app :clipped-left="clipped">
+        <v-toolbar-side-icon @click.native.stop="drawer = !drawer"></v-toolbar-side-icon>
+        <v-toolbar-title v-text="title"></v-toolbar-title>
+        <v-spacer></v-spacer>
+      </v-toolbar>
+      <main>
+        <v-content>
+          <v-container fluid>
+            <v-layout column>
+              <downloadcard
+                :archives="this.archives"
+              ></downloadcard>
+              <filelist
+                :files="this.files"
+                :container_public_url="this.container_public_url"
+                :dataloaded="this.dataloaded"
+                :archive_base_name="this.archive_base_name"
+              ></filelist>
+            </v-layout>
+          </v-container>
+        </v-content>
+      </main>
+      <v-footer :fixed="fixed" app>
+        <span>&copy; Rackspace 2018</span>
+      </v-footer>
+    </v-app>
+  </div>
+
+  <script src="https://unpkg.com/vue/dist/vue.js"></script>
+  <script src="https://unpkg.com/vuetify/dist/vuetify.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vue-resource@1.5.0"></script>
+  <script>
+
+  // Add human readable display func to Number objects
+  //https://stackoverflow.com/a/20463021
+    Object.defineProperty(Number.prototype,'fileSize',{value:function(a,b,c,d){
+      return (a=a?[1e3,'k','B']:[1024,'K','iB'],b=Math,c=b.log,
+        d=c(this)/c(a[0])|0,this/b.pow(a[0],d)).toFixed(2)
+        +' '+(d?(a[1]+'MGTPEZY')[--d]+a[2]:'Bytes');
+    },writable:false,enumerable:false});
+
+    Vue.component('downloadcard',{
+      props: ["archives"],
+      template: `
+        <v-card>
+         <v-card-title>
+           <div>
+             <h3>Download All Artifacts</h3>
+             <div>To download all the artifacts relating to this job either
+             download and extract all the archives linked below, or use
+             the following shell snippet: </div>
+             <code>curl {{ this.$root.container_public_url }}/{{ this.$root.archive_base_name }}.txt |while read a; do curl $a |tar xj; done</code>
+           </div>
+         </v-card-title>
+         <v-list>
+          <downloadlink v-for="archive in archives" :key="archive" :archive="archive"></downloadlink>
+        </v-list>
+       </v-card>
+      `
+    })
+
+    Vue.component('downloadlink',{
+      props: ["archive"],
+      computed: {
+        basename: function() {
+          tokens = this.archive.split("/")
+          return tokens[tokens.length -1]
+        }
+      },
+      template: `
+        <v-list-tile>
+          <v-list-tile-action>
+            <v-icon>archive</v-icon>
+          </v-list-tile-action>
+          <v-list-tile-content>
+           <a :href="archive">{{ this.basename }}</a>
+          </v-list-tile-content>
+        </v-list-tile>
+      `
+    })
+
+    Vue.component('filelist', {
+      props: ['files', 'container_public_url', 'dataloaded', 'archive_base_name'],
+      methods: {
+        searchchange: function(event){
+          // This function is called when text is entered or removed
+          // from the search box. There are two separate
+          // models for the file list, a hierachy for browsing folders
+          // and a flat list of files for searching.
+          // When ever text is entered into the search box, we switch
+          // to the flat list model, when the search box is cleared
+          // we go back to the hierachy
+          if (event.length == 0){
+            // no text in search box, reset view to root of the file tree
+            this.localfiles = this.listfrombranch(this.filetree)
+          } else {
+            // some text has been entered, set view to filtered flat list
+            // of files
+            this.localfiles = this.files
+          }
+          // Reset the path. This means that a user who has browsed
+          // the file tree will loose their place when searching
+          // however not clearing the path leads to inconsistent ui
+          // which is worse.
+          this.path=[{path: 'Artifacts', size: 0}]
+        },
+        listfrombranch: function(branch){
+          // The data table requires a flat list to render.
+          // This function takes one node from the file tree
+          // and produces a flat list of files and folders
+          flist = []
+          flist = flist.concat(branch.files)
+          Object.keys(branch.children).forEach(key => {
+            child = branch.children[key]
+            flist.push({
+              type: 'folder',
+              icon: 'folder',
+              size: 0,
+              path: child.path,
+              branch: child,
+            })
+          })
+          if (branch.parent != null){
+            flist.push({
+              type: 'folder',
+              icon: 'folder',
+              path: '..',
+              size: 0,
+              branch: branch
+            })
+          }
+          return flist
+        },
+        // called when an item in the file list is clicked
+        clickhandler: function(item){
+          // if this is a folder, dont follow the link
+          // update the display to show the next folder
+          if('type' in item && item.type == 'folder'){
+            event.preventDefault()
+            if (item.path == '..'){
+              // go up to the parent folder
+              this.localfiles = this.listfrombranch(item.branch.parent)
+              this.path.pop()
+            } else {
+              // go down to a child folder
+              this.localfiles = this.listfrombranch(item.branch)
+              this.path.push(item.branch)
+            }
+          }
+          // If it was a file, do nothing, let the browser
+          // load or download the linked file.
+        },
+        // called when a breadcrumb (path trail) item is clicked
+        breadcrumbclick: function(dir){
+          empty_path = [{path: 'Artifacts', size: 0}]
+          // go back to the root of the tree
+          if(dir.path == "Artifacts"){
+            this.localfiles = this.listfrombranch(this.filetree)
+            this.path = empty_path
+            return;
+          }
+
+          // go to whichver dir was clicked then
+          // rebuild the path array
+          this.localfiles=this.listfrombranch(dir)
+          tpath = []
+          while (dir.parent != null){
+            tpath.push(dir)
+            dir=dir.parent
+          }
+          tpath.reverse()
+          this.path = empty_path.concat(tpath)
+        }
+      },
+      computed: {
+        filetree: function(){
+          tree = {
+            parent: null,
+            path: '',
+            files: [],
+            children: {}
+          }
+          this.files.forEach(f => {
+            path = f.path.split('/').filter(p => p.length > 0)
+            dirs = path.slice(0, -1)
+            file = path[path.length -1]
+            branch = tree
+            dirs.forEach(dirname => {
+              if (!(dirname in branch.children)){
+                branch.children[dirname]={
+                  path: dirname,
+                  children: {},
+                  files: [],
+                  parent: branch
+                }
+              }
+              branch = branch.children[dirname]
+            })
+            branch.files.push({
+              path: f.path,
+              size: f.size
+            })
+          })
+          return tree
+        },
+        cfiles: function(){
+          return this.files
+        }
+      },
+      watch: {
+        files: function(n,o){
+          this.localfiles = this.listfrombranch(this.filetree);
+        }
+      },
+      data: function(){
+        return {
+          path: [{path: 'Artifacts', size: 0}],
+          branch: {},
+          localfiles: [],
+          search: '',
+          rows_per_page_items: [25,100,500,{"text":"All","value":-1}],
+          headers: [
+            {
+              text: "File",
+              value: "path"
+            },
+            {
+              text: "Size",
+              value: "size"
+            }
+          ]
+        }
+      },
+      template: `
+      <v-card>
+       <v-card-title>
+          <div>
+            <h3>Browse Artifacts</h3>
+            Use this table to locate and download individual files.
+            <v-breadcrumbs v-if="this.path.length > 1">
+              <v-icon slot="divider">chevron_right</v-icon>
+               <v-breadcrumbs-item v-for="dir in path" :key="dir.path">
+                  <span @click="breadcrumbclick(dir)">{{dir.path.split('/').slice(-1)[0]}}</span>
+               </v-breadcrumbs-item>
+            </v-breadcrumbs>
+          </div>
+         <v-spacer></v-spacer>
+         <v-text-field
+           v-model="search"
+           v-on:input="searchchange"
+           append-icon="search"
+           label="Search"
+           single-line
+           hide-details
+         ></v-text-field>
+       </v-card-title>
+        <v-data-table
+          :headers="this.headers"
+          :items="this.localfiles"
+          :search="search"
+          :loading="! this.dataloaded"
+          :rows-per-page-items="this.rows_per_page_items"
+          class="elevation-1"
+        >
+          <template slot="items" slot-scope="props">
+            <tr @click="clickhandler(props.item)">
+              <td>
+                <v-icon>{{ props.item.type == 'folder' ? 'folder': 'insert_drive_file'}}</v-icon>
+                <a :href="container_public_url +'/' + archive_base_name +'/'+ props.item.path">
+                  {{ search.length > 0 ? props.item.path : props.item.path.split('/').slice(-1)[0] }}
+                </a>
+              </td>
+              <td>{{ props.item.type == 'folder' ? '' : props.item.size.fileSize(1) }}</td>
+            </tr>
+          </template>
+        </v-data-table>
+      </v-card>
+      `
+    })
+    new Vue({
+      el: '#app',
+      created: function(){
+        this.$http.get("data.json").then(function(response){
+          this.files = response.body.files
+          this.job_name = response.body.job_name
+          this.build_number = response.body.build_number
+          this.archive_base_name = response.body.archive_base_name
+          this.archives = response.body.archives
+          this.container_public_url = response.body.container_public_url
+          this.dataloaded = true
+        })
+      },
+      computed: {
+        build_id: function(){
+          return this.job_name+'/'+this.build_number
+        },
+        items: function(){
+          items = [
+            {
+              icon: 'face',
+              title: 'View this build in Jenkins',
+              url: "https://rpc.jenkins.cit.rackspace.net/job/" + this.build_id
+            },
+            {
+              icon: 'graphic_eq',
+              title: 'Build Summary Dashboard',
+              url: "http://rpc-repo.rackspace.com/rpcgating/buildsummary/"
+            },
+
+          ]
+
+          // pull out a few known report files from the potentially
+          // large list of artifacts and link to them in the
+          // sidebar
+          this.findreport(
+            items,
+            'ara-report/index.html',
+            'dns',
+            'ARA Report'
+          )
+          this.findreport(
+            items,
+            'dstat.html',
+            'trending_up',
+            'DStat Report'
+          )
+          return items
+        },
+        title: function(){
+          return "RE Build Artefacts for "+this.build_id
+        }
+      },
+      methods: {
+        findreport: function(items, pathsuffix, icon, title){
+          files = this.files.filter(f => f.path.endsWith(pathsuffix))
+          if (files.length > 0){
+            items.push({
+              icon: icon,
+              title: title,
+              url: this.container_public_url + "/" + this.archive_base_name +'/' +files[0].path
+            })
+          }
+        }
+      },
+      data: {
+        archives: [],
+        archive_base_name: '',
+        dataloaded: false,
+        container_public_url: '',
+        files: [],
+        job_name: '',
+        build_number: '',
+        clipped: true,
+        drawer: true,
+        fixed: true,
+        miniVariant: false,
+      }
+    })
+  </script>
+</body>
+</html>

--- a/playbooks/templates/artifact/index.html
+++ b/playbooks/templates/artifact/index.html
@@ -42,6 +42,12 @@
               <downloadcard
                 :archives="this.archives"
               ></downloadcard>
+              <faileduploads
+                :failed_uploads="this.failed_uploads"
+              ></faileduploads>
+              <linkwarning
+                :removed_links_count="this.removed_links_count"
+              ></linkwarning>
               <filelist
                 :files="this.files"
                 :container_public_url="this.container_public_url"
@@ -61,6 +67,9 @@
   <script src="https://unpkg.com/vue/dist/vue.js"></script>
   <script src="https://unpkg.com/vuetify/dist/vuetify.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/vue-resource@1.5.0"></script>
+  <!--<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.10/lodash.min.js"></script> -->
+  <!-- lodash was used in an attempt to debounce search events, however it was unsuccessfull
+  as dattables refreshes immediately even if the function to switch models is debounced -->
   <script>
 
   // Add human readable display func to Number objects
@@ -78,10 +87,10 @@
          <v-card-title>
            <div>
              <h3>Download All Artifacts</h3>
-             <div>To download all the artifacts relating to this job either
-             download and extract all the archives linked below, or use
-             the following shell snippet: </div>
-             <code>curl {{ this.$root.container_public_url }}/{{ this.$root.archive_base_name }}.txt |while read a; do curl $a |tar xj; done</code>
+             <div>
+               Use the following link to download an archive of artifacts
+               relating to this job.
+             </div>
            </div>
          </v-card-title>
          <v-list>
@@ -110,6 +119,58 @@
         </v-list-tile>
       `
     })
+
+    Vue.component('linkwarning', {
+      props: ["removed_links_count"],
+      template: `
+        <v-card v-if="removed_links_count > 0">
+         <v-card-title>
+           <div>
+             <h3>Symlinks Removed</h3>
+             <div>
+              {{ removed_links_count }} symlinks have been removed from this
+              artifact set. Please check the <a href="removedlinks.txt">list of removed symlinks</a>
+              if you are missing a file.
+             </div>
+           </div>
+         </v-card-title>
+       </v-card>
+      `
+    })
+
+    Vue.component('faileduploads', {
+      props: ["failed_uploads"],
+      data: function (){
+        return {
+          showfailures: true
+        }
+      },
+      methods: {
+        togglefailures: function(){
+          this.showfailures = ! this.showfailures
+        }
+      },
+      template: `
+        <v-card v-if="failed_uploads.length > 0">
+         <v-card-title>
+           <div>
+             <h3>Some Uploads Failed</h3>
+             <div>
+              {{ failed_uploads.length }} file{{ failed_uploads.length > 1 ? "s" : "" }} failed to upload.
+             </div>
+           </div>
+         </v-card-title>
+         <v-card-actions>
+          <v-btn @click="togglefailures" v-if="showfailures" color="info">Hide Failures</v-btn>
+          <v-btn @click="togglefailures" v-else color="info">Show Failures</v-btn>
+         </v-card-actions>
+         <v-card-text v-if="showfailures">
+          <p v-for="failure in failed_uploads" style="color: red">{{failure}}</p>
+         </v-card-text>
+       </v-card>
+      `
+    })
+
 
     Vue.component('filelist', {
       props: ['files', 'container_public_url', 'dataloaded', 'archive_base_name'],
@@ -279,7 +340,7 @@
          <v-spacer></v-spacer>
          <v-text-field
            v-model="search"
-           v-on:input="searchchange"
+           @input="searchchange"
            append-icon="search"
            label="Search"
            single-line
@@ -319,6 +380,8 @@
           this.archive_base_name = response.body.archive_base_name
           this.archives = response.body.archives
           this.container_public_url = response.body.container_public_url
+          this.removed_links_count = response.body.removed_links_count
+          this.failed_uploads = response.body.failed_uploads
           this.dataloaded = true
         })
       },
@@ -375,6 +438,7 @@
         }
       },
       data: {
+        failed_uploads: [],
         archives: [],
         archive_base_name: '',
         dataloaded: false,

--- a/playbooks/templates/artifact/styles.css
+++ b/playbooks/templates/artifact/styles.css
@@ -1,0 +1,14 @@
+/** CSS Styles */
+code {
+  padding: 20px;
+  margin-top: 10px;
+}
+
+div.card {
+  margin-bottom: 20px;
+}
+
+
+div.list__tile:hover {
+  background-color: #eee;
+}

--- a/playbooks/upload_to_swift.yml
+++ b/playbooks/upload_to_swift.yml
@@ -16,38 +16,33 @@
     - set_fact:
         adir: "{{ artifacts_dir | dirname }}/{{archive_base_name}}"
 
-    - name: Clean up previous attempts
-      shell: rm -f {{ adir | basename }}.txt {{ adir | basename }}.list {{ adir | basename }}-split*
+    # links are unlikely to work when expanded on a different
+    # system so remove them. Create a list of removed links
+    # to give users a clue as to why their file is missing.
+    # Also swift client fails on dangling links.
+    - name: Remove links from artifacts
+      shell: |
+        find {{ adir | basename }} \
+          -type l \
+          -print \
+          -delete \
+          | tee {{ adir | basename }}/removedlinks.txt
       args:
         chdir: "{{ adir |dirname }}"
-        executable: /bin/bash
-        warn: no
+      register: removed_links
 
-    - name: Build full archive file listing
-      shell: find {{ adir | basename }} -type f > {{ adir | basename }}.list
+    # This task runs async while the individual files are being uploaded
+    # then when compression is complete, the resultant archive is uploaded.
+    # 3 Hour Timeout
+    - name: Create archive
+      shell: "tar -c {{ adir | basename }} | gzip --fast > {{archive_base_name}}.tar.gz"
       args:
         chdir: "{{ adir | dirname }}"
-        executable: /bin/bash
-
-    # split on macOS can't cope with --lines
-    - name: Split full archive file listing into chunks
-      command: split -l {{ files_per_archive }} {{ adir | basename }}.list {{ adir | basename }}-split.
-      args:
-        chdir: "{{ adir | dirname }}"
-
-    - name: Register split archive contents files
-      shell: "ls -1 {{ adir | basename }}-split.*"
-      args:
-        chdir: "{{ adir | dirname }}"
-        executable: /bin/bash
-      register: _archive_file_lists
-
-    - name: Create the archives from the split file listings
-      command: "tar -cjf {{ item }}.tar.bz2 -T {{ item }}"
-      args:
-        chdir: "{{ adir | dirname }}"
-        warn: no
-      with_items: "{{ _archive_file_lists.stdout_lines }}"
+      async: 10800
+      poll: 0
+      register: create_archive_async
+      tags:
+        - skip_ansible_lint
 
     - name: Create a public Cloud Files container
       os_object:
@@ -145,13 +140,19 @@
         src: templates/artifact/styles.css
         dest: "{{ adir }}/styles.css"
 
-    - name: Create the archive wget source file
-      copy:
-        content: |
-          {% for archive in _archive_file_lists.stdout_lines %}
-          {{ container_public_url }}/{{ archive }}.tar.bz2
-          {% endfor %}
-        dest: "{{ adir }}/{{ adir | basename }}.txt"
+
+    # os_object does not currently support setting object expiration header field
+    # production retention
+    - name: Upload Artifacts to Cloud Files
+      command: "swift upload --object-threads 100 --ignore-checksum --header 'X-Delete-After:{{ retention }}' {{ container }} {{ adir | basename }}"
+      args:
+        chdir: "{{ adir |dirname }}"
+      environment:
+        OS_AUTH_TOKEN: "{{ auth_token }}"
+        OS_STORAGE_URL: "{{ (object_store['endpoints'] | selectattr('region', 'equalto', region) | first)['publicURL'] }}"
+      failed_when: false
+      register: artifact_upload
+
 
     # this is json data containing metadata and a list of files
     # that will be downloaded by index.html
@@ -164,6 +165,12 @@
             "build_number": "{{ build_number }}",
             "archive_base_name": "{{ archive_base_name }}",
             "container_public_url": "{{ container_public_url}}",
+            "removed_links_count": {{ removed_links.stdout_lines|count }},
+            "failed_uploads": [
+              {% for line in artifact_upload.stderr_lines %}
+                "{{ line }}"{{ "," if not loop.last else "" }}
+              {% endfor %}
+            ],
             "files": [
               {% for file_line in file_list.stdout_lines %}
                 {% set file_list = file_line.split() %}
@@ -176,56 +183,53 @@
               {% endfor %}
             ],
             "archives": [
-              {% for archive in _archive_file_lists.stdout_lines %}
-              "{{ container_public_url }}/{{ archive }}.tar.bz2"{{"," if not loop.last else"" }}
-              {% endfor %}
+              "{{ container_public_url }}/{{ archive_base_name }}.tar.gz"
             ]
           }
         dest: "{{ adir }}/data.json"
 
     # os_object does not currently support setting object expiration header field
-    - name: Upload html index and related files to Cloud Files
-      command: "swift upload {{ container }} index.html styles.css data.json {{ adir | basename }}.txt --header 'X-Delete-After:2592000'"
+    - name: Upload index data (data.json) to CloudFiles
+      command: >-
+        swift upload {{ container }} {{ adir | basename }}/data.json
+        --header 'X-Delete-After: {{ retention }}'
       args:
-        chdir: "{{ adir }}"
+        chdir: "{{ adir | dirname }}"
       environment:
         OS_AUTH_TOKEN: "{{ auth_token }}"
         OS_STORAGE_URL: "{{ (object_store['endpoints'] | selectattr('region', 'equalto', region) | first)['publicURL'] }}"
+      register: upload_data
+      until: upload_data|success
+      retries: 2
+
+    - name: Wait for async archive creation to complete
+      async_status:
+        jid: "{{ create_archive_async.ansible_job_id }}"
+      register: caa
+      until: caa.finished
+      retries: 180
+      delay: 60
 
     # os_object does not currently support setting object expiration header field
-    - name: Upload archive files to Cloud Files
+    - name: Upload archive to CloudFiles
       command: >-
-        swift upload {{ container }} {{ item }}.tar.bz2
-        --header 'X-Delete-After: 7200'
+        swift upload {{ container }} {{ archive_base_name }}.tar.gz
+        --header 'X-Delete-After: {{ retention }}'
       args:
         chdir: "{{ adir | dirname }}"
       environment:
         OS_AUTH_TOKEN: "{{ auth_token }}"
         OS_STORAGE_URL: "{{ (object_store['endpoints'] | selectattr('region', 'equalto', region) | first)['publicURL'] }}"
-      with_items: "{{ _archive_file_lists.stdout_lines }}"
-
-    # The Ansible uri module does not support '--upload-file' at this time.
-    # See:
-    # https://github.com/ansible/ansible/issues/24440
-    # https://github.com/ansible/ansible/pull/33689
-    - name: Upload/extract the archives
-      command: >-
-        curl -i -XPUT
-        -H 'X-Auth-Token: {{ auth_token }}'
-        -H 'X-Delete-After: 7200'
-        {{ object_store_url }}/{{ container }}?extract-archive=tar.bz2
-        -T {{ item }}.tar.bz2
-      args:
-        chdir: "{{ adir | dirname }}"
-        warn: no
-      with_items: "{{ _archive_file_lists.stdout_lines }}"
-      no_log: true
+      register: upload_archive
+      until: upload_archive|success
+      retries: 2
 
     # used by common.archive_artifacts to put the link into the build description
     - name: "Write public url file"
       shell: |
-        echo "{{ container_public_url }}/index.html" > ${WORKSPACE}/artifact_public_url
+        echo "{{ container_public_url }}/{{archive_base_name}}/index.html" > ${WORKSPACE}/artifact_public_url
   vars:
     region: "DFW"
     cloud_name: "public_cloud"
-    files_per_archive: 1000
+    # 30 days
+    retention: 2592000

--- a/playbooks/upload_to_swift.yml
+++ b/playbooks/upload_to_swift.yml
@@ -3,12 +3,51 @@
   connection: local
   gather_facts: False
   tasks:
-    - name: Create archive
-      command: "tar -cjf {{ archive_name }} {{ artifacts_dir | basename }}"
+
+    - set_fact:
+        archive_base_name: "{{job_name}}_{{build_number}}"
+
+    # This is done so that downloaded archives have a useful name
+    - name: Move artifacts dir
+      shell: mv "{{ artifacts_dir | basename }}" "{{ archive_base_name }}"
       args:
         chdir: "{{ artifacts_dir | dirname }}"
-      tags:
-        - skip_ansible_lint
+
+    - set_fact:
+        adir: "{{ artifacts_dir | dirname }}/{{archive_base_name}}"
+
+    - name: Clean up previous attempts
+      shell: rm -f {{ adir | basename }}.txt {{ adir | basename }}.list {{ adir | basename }}-split*
+      args:
+        chdir: "{{ adir |dirname }}"
+        executable: /bin/bash
+        warn: no
+
+    - name: Build full archive file listing
+      shell: find {{ adir | basename }} -type f > {{ adir | basename }}.list
+      args:
+        chdir: "{{ adir | dirname }}"
+        executable: /bin/bash
+
+    # split on macOS can't cope with --lines
+    - name: Split full archive file listing into chunks
+      command: split -l {{ files_per_archive }} {{ adir | basename }}.list {{ adir | basename }}-split.
+      args:
+        chdir: "{{ adir | dirname }}"
+
+    - name: Register split archive contents files
+      shell: "ls -1 {{ adir | basename }}-split.*"
+      args:
+        chdir: "{{ adir | dirname }}"
+        executable: /bin/bash
+      register: _archive_file_lists
+
+    - name: Create the archives from the split file listings
+      command: "tar -cjf {{ item }}.tar.bz2 -T {{ item }}"
+      args:
+        chdir: "{{ adir | dirname }}"
+        warn: no
+      with_items: "{{ _archive_file_lists.stdout_lines }}"
 
     - name: Create a public Cloud Files container
       os_object:
@@ -33,19 +72,25 @@
         object_cdn: "{{ service_catalog | selectattr('type', 'equalto', 'rax:object-cdn') | first }}"
       when: rax_pub_cloud
 
-    # os_object does not currently support setting object expiration header field
-    - name: Upload file to Cloud Files
-      command: "swift upload {{ container }} {{ archive_name }} --header 'X-Delete-After:2592000'"
-      args:
-        chdir: "{{ artifacts_dir | dirname }}"
+    - set_fact:
+        object_cdn_url: "{{ (object_cdn['endpoints'] | selectattr('region', 'equalto', region) | first)['publicURL'] }}/{{ container }}"
+
+    - set_fact:
+        object_store_url: "{{ (object_store['endpoints'] | selectattr('region', 'equalto', region ) | first)['publicURL']}}"
+
+    - name: Enable CDN
+      uri:
+        url: "{{object_cdn_url}}"
+        method: PUT
+        headers:
+          X-AUTH-TOKEN: "{{ auth_token }}"
+          X-Cdn-Enabled: True
+        status_code: "200, 201, 202, 204"
       no_log: true
-      environment:
-        OS_AUTH_TOKEN: "{{ auth_token }}"
-        OS_STORAGE_URL: "{{ (object_store['endpoints'] | selectattr('region', 'equalto', region) | first)['publicURL'] }}"
 
     - name: Get Rackspace CloudFiles CDN URL
       uri:
-        url: "{{ (object_cdn['endpoints'] | selectattr('region', 'equalto', region) | first)['publicURL'] }}/{{ container }}"
+        url: "{{ object_cdn_url }}"
         method: HEAD
         headers:
           X-AUTH-TOKEN: "{{ auth_token }}"
@@ -62,23 +107,125 @@
         container_public_url: "{{ object_store['endpoints'][0]['publicURL'] }}"
       when: not rax_pub_cloud
 
-    - name: Read artifact description file
-      set_fact:
-        artifact_description: "{{ lookup('file', description_file) }}"
-      no_log: True
-      when:
-        - description_file is defined
-        - description_file != None
 
-    - name: Create artifact report location if doesn't exist
-      file:
-        path: "{{ report_dir }}"
-        state: directory
+    # In order for uploaded files to be browsable:
+    # 1. Static hosting must be enabled (this links index.html to requests for container/)
+    # 2. CDN must be enabled (to allow anonymous http access to the container)
+    # 3. An index page must be generated, as this is not done automatically
+    - name: Enable static web hosting
+      uri:
+        url: "{{object_store_url}}"
+        method: POST
+        headers:
+          X-AUTH-TOKEN: "{{ auth_token }}"
+          X-Container-Meta-Web-Index: index.html
+        status_code: 200, 201, 202, 204
+      no_log: true
 
-    - name: Generate HTML report with file URL
-      template:
-        src: swift.html.j2
-        dest: "{{ report_dir }}/index.html"
+    # Do this before generating index.html, styles.css and data.json
+    # So they don't show up on the final page.
+    - name: Generate file list with sizes for index page data
+      shell: |
+        find . \
+          -type f \
+          -mindepth 1 \
+          -exec ls -l {} \; \
+        |sed 's+\./++g'
+      args:
+        chdir: "{{ adir }}"
+      register: file_list
+
+    - name: Copy index.html
+      copy:
+        src: templates/artifact/index.html
+        dest: "{{ adir }}/index.html"
+
+    - name: Copy style.css
+      copy:
+        src: templates/artifact/styles.css
+        dest: "{{ adir }}/styles.css"
+
+    - name: Create the archive wget source file
+      copy:
+        content: |
+          {% for archive in _archive_file_lists.stdout_lines %}
+          {{ container_public_url }}/{{ archive }}.tar.bz2
+          {% endfor %}
+        dest: "{{ adir }}/{{ adir | basename }}.txt"
+
+    # this is json data containing metadata and a list of files
+    # that will be downloaded by index.html
+    # and used to display a list of available artifacts
+    - name: Generate data.json
+      copy:
+        content: |
+          {
+            "job_name": "{{ job_name }}",
+            "build_number": "{{ build_number }}",
+            "archive_base_name": "{{ archive_base_name }}",
+            "container_public_url": "{{ container_public_url}}",
+            "files": [
+              {% for file_line in file_list.stdout_lines %}
+                {% set file_list = file_line.split() %}
+                {% if file_list|length > 3 %}
+                  {
+                    "path": "{{file_list[-1]}}",
+                    "size": {{file_list[4]}}
+                  }{{ "," if not loop.last else "" }}
+                {% endif %}
+              {% endfor %}
+            ],
+            "archives": [
+              {% for archive in _archive_file_lists.stdout_lines %}
+              "{{ container_public_url }}/{{ archive }}.tar.bz2"{{"," if not loop.last else"" }}
+              {% endfor %}
+            ]
+          }
+        dest: "{{ adir }}/data.json"
+
+    # os_object does not currently support setting object expiration header field
+    - name: Upload html index and related files to Cloud Files
+      command: "swift upload {{ container }} index.html styles.css data.json {{ adir | basename }}.txt --header 'X-Delete-After:2592000'"
+      args:
+        chdir: "{{ adir }}"
+      environment:
+        OS_AUTH_TOKEN: "{{ auth_token }}"
+        OS_STORAGE_URL: "{{ (object_store['endpoints'] | selectattr('region', 'equalto', region) | first)['publicURL'] }}"
+
+    # os_object does not currently support setting object expiration header field
+    - name: Upload archive files to Cloud Files
+      command: >-
+        swift upload {{ container }} {{ item }}.tar.bz2
+        --header 'X-Delete-After: 7200'
+      args:
+        chdir: "{{ adir | dirname }}"
+      environment:
+        OS_AUTH_TOKEN: "{{ auth_token }}"
+        OS_STORAGE_URL: "{{ (object_store['endpoints'] | selectattr('region', 'equalto', region) | first)['publicURL'] }}"
+      with_items: "{{ _archive_file_lists.stdout_lines }}"
+
+    # The Ansible uri module does not support '--upload-file' at this time.
+    # See:
+    # https://github.com/ansible/ansible/issues/24440
+    # https://github.com/ansible/ansible/pull/33689
+    - name: Upload/extract the archives
+      command: >-
+        curl -i -XPUT
+        -H 'X-Auth-Token: {{ auth_token }}'
+        -H 'X-Delete-After: 7200'
+        {{ object_store_url }}/{{ container }}?extract-archive=tar.bz2
+        -T {{ item }}.tar.bz2
+      args:
+        chdir: "{{ adir | dirname }}"
+        warn: no
+      with_items: "{{ _archive_file_lists.stdout_lines }}"
+      no_log: true
+
+    # used by common.archive_artifacts to put the link into the build description
+    - name: "Write public url file"
+      shell: |
+        echo "{{ container_public_url }}/index.html" > ${WORKSPACE}/artifact_public_url
   vars:
     region: "DFW"
     cloud_name: "public_cloud"
+    files_per_archive: 1000

--- a/rpc_jobs/unit/artefact_publish.yml
+++ b/rpc_jobs/unit/artefact_publish.yml
@@ -12,30 +12,21 @@
       common.globalWraps(){
         // Do something that creates an artifact
         stage("Build"){
+          // ARA placeholder included to test that an ARA
+          // link is added to the sidebar of the index page
+          // when an ARA report is present.
           sh """
             mkdir -p artifacts
+            mkdir -p artifacts_report
+            mkdir -p artifacts/localhost/host/openstack/log/ara-report
+            echo "<html>ara report placeholder</html>" \
+              > artifacts/localhost/host/openstack/log/ara-report/index.html;
             date > artifacts/datestamp
+            hostname > artifacts/hostname
+            echo "<html>dstat report placeholder</html>" \
+              > /var/log/dstat.html
+            cp -vr /var/log artifacts
           """
         }
-
-        stage("Upload"){
-          pubcloud.uploadToSwift(
-            archive_name: "artifacts_${BUILD_TAG}.tar.bz2",
-            artifacts_dir: "${WORKSPACE}/artifacts",
-            container: "jenkins_logs",
-            path: "${WORKSPACE}/artifacts",
-            report_dir: "${WORKSPACE}/artifacts_report"
-          )
-        }
-
-        stage("Publish"){
-          // link to artifacts from Jenkins UI
-          publishHTML(
-            alwaysLinkToLastBuild: true,
-            keepAll: true,
-            reportFiles: "index.html",
-            reportName: "Build Artifact Links",
-            reportDir: "${WORKSPACE}/artifacts_report"
-          )
-        }
+        common.archive_artifacts()
       }


### PR DESCRIPTION
The first attempt at this failed, as we were using a cloud files
api call which takes an archive and expands it out into a container.
That operation was too slow and unreliable to be useful.

As a recap, the aim is to have artifacts be browsable (and therefore
linkable) but also downloadable in bulk for local analysis.

This commit achieves both aims, by uploading a single archive but
also uploading each file individually. Both of these operations
have potential to take significant amounts of time. Archive creation
has taken 3 hours in the past due to compression. In order to speed
that up, this commit switches from bzip compression to gzip --fast
which can be an order of magnitude faster. Single file upload can
also be slow due to the number of api operations it requires. The
api rate limit is 100r/s so the upload is done with 100 threads.

In my testing, compression and both upload operations for an RPCO
artifact set took 7 minutes. That included 20k files totalling ~450mb.

Issue: [RE-1526](https://rpc-openstack.atlassian.net/browse/RE-1526)