### PR TITLE
RE-1536 Remove non-snapshot periodic jobs

### DIFF
--- a/rpc_jobs/rpc_designate.yml
+++ b/rpc_jobs/rpc_designate.yml
@@ -28,36 +28,6 @@
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
  - project:
-    name: "rpc-designate-post-merge"
-
-    repo_name: "rpc-designate"
-    # URL of the rpc-designate repository
-    repo_url: "https://github.com/rcbops/rpc-designate"
-
-    branches:
-      - "master"
-      - "master-rc"
-
-    # Use image for RPC-O install
-    image:
-      - xenial:
-          FLAVOR: "performance2-15"
-          IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
-
-    scenario:
-      - "newton"
-      - "pike"
-      - "queens"
-    action:
-      - "deploy"
-
-    jira_project_key: "RI"
-
-    # Link to the standard post-merge-template
-    jobs:
-      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
-
- - project:
     name: "rpc-designate-post-merge-snapshot"
 
     repo_name: "rpc-designate"


### PR DESCRIPTION
The snapshot periodic jobs are running reliably, so no need to run both
sets any longer.

Issue: [RE-1536](https://rpc-openstack.atlassian.net/browse/RE-1536)