### PR TITLE
Change Jira key from K8S to RE

### DIFF
--- a/rpc_jobs/rpc_octavia.yml
+++ b/rpc_jobs/rpc_octavia.yml
@@ -27,7 +27,7 @@
     action:
       - "test"
 
-    jira_project_key: "K8S"
+    jira_project_key: "RI"
 
     # Link to the standard pre-merge-template
     jobs:
@@ -62,7 +62,7 @@
     action:
       - "test"
 
-    jira_project_key: "K8S"
+    jira_project_key: "RI"
 
     # Link to the standard pre-merge-template
     jobs:
@@ -96,7 +96,7 @@
     action:
       - "test"
 
-    jira_project_key: "K8S"
+    jira_project_key: "RI"
 
     # Add repo creds to post merge jobs so artefacts can be uploaded
     credentials: "rpc_repo"
@@ -135,7 +135,7 @@
     action:
       - "test"
 
-    jira_project_key: "K8S"
+    jira_project_key: "RI"
 
     # Add repo creds to post merge jobs so artefacts can be uploaded
     credentials: "rpc_repo"


### PR DESCRIPTION
With Octavia becoming officially supported in RPC-O we should report
CI failures to the RE queue instead of K8S