### PR TITLE
RE-1545 Fix enable static website

### DIFF
--- a/playbooks/upload_to_swift.yml
+++ b/playbooks/upload_to_swift.yml
@@ -109,11 +109,12 @@
     # 3. An index page must be generated, as this is not done automatically
     - name: Enable static web hosting
       uri:
-        url: "{{object_store_url}}"
+        url: "{{object_store_url}}/{{container}}"
         method: POST
         headers:
           X-AUTH-TOKEN: "{{ auth_token }}"
           X-Container-Meta-Web-Index: index.html
+          X-Container-Meta-Web-Listings: True
         status_code: 200, 201, 202, 204
       no_log: true
 


### PR DESCRIPTION
The ARA report links to foo/ and expects foo/index.html to be returned.
That wasn't working, despite the rackspace docs saying:

  The page you set for X-Container-Meta-Web-Index becomes the index page
  for every subdirectory in your website.

Testing showed that this does work, but that upload_to_swift wasn't
enabling the static website correctly. The problem was that the
container name should have been appended to the object store url
used for enabling the static website.

This commit fixes this above problem and also enables file listing
so that a user can browse files/folders directly as well as using
the generated index.html.

Issue: [RE-1545](https://rpc-openstack.atlassian.net/browse/RE-1545)