### PR TITLE
RE-1546 Use html download attribute

### DIFF
--- a/playbooks/templates/artifact/index.html
+++ b/playbooks/templates/artifact/index.html
@@ -114,7 +114,7 @@
             <v-icon>archive</v-icon>
           </v-list-tile-action>
           <v-list-tile-content>
-           <a :href="archive">{{ this.basename }}</a>
+           <a :href="archive" download>{{ this.basename }}</a>
           </v-list-tile-content>
         </v-list-tile>
       `


### PR DESCRIPTION
Chrome fails to download the archive, instead it logs a content
type warning to the console. This commit fixes the issue by
adding the html5 download attribute to instruct the browser to
download rather than display the linked file.

Issue: [RE-1546](https://rpc-openstack.atlassian.net/browse/RE-1546)