### PR TITLE
RE-1297 Remove `re` ref from status context

### DIFF
--- a/rpc_jobs/unit/re_unit_tests.yml
+++ b/rpc_jobs/unit/re_unit_tests.yml
@@ -7,10 +7,10 @@
           org-list:
             - rcbops
           github-hooks: true
-          trigger-phrase: '.*recheck_all.*|.*recheck_unit_?tests.*'
+          trigger-phrase: '.*recheck_all.*|.*recheck_unit_tests.*'
           only-trigger-phrase: false
           auth-id: "github_account_rpc_jenkins_svc"
-          status-context: 'CIT/re_unit_tests'
+          status-context: 'CIT/unit_tests'
           cancel-builds-on-update: true
     properties:
       - rpc-gating-github


### PR DESCRIPTION
Currently the status context and trigger phrase doesn't match. Instead
of adding `re` to the trigger phrase, we just remove it from the status
context since we don't use this prefix anywhere else.

Once this merges, we'll need to update the repo settings to make this
test required (since it's going to appear as a new test).

Additionally, we remove an unnecessary `?` in the trigger phrase. This
was left over when we removed the `cit` reference from the trigger
phrase in 36f717f5.

Issue: [RE-1297](https://rpc-openstack.atlassian.net/browse/RE-1297)