### PR TITLE
RE-1466 Correct rpco-14.2-xenial-base flavor name

### DIFF
--- a/nodepool/files/nodepool.yml
+++ b/nodepool/files/nodepool.yml
@@ -26,7 +26,7 @@ labels:
     min-ready: 0
     max-ready-age: 3600
   - name: rpco-14.2-xenial-base
-    min-ready: 0
+    min-ready: 1
     max-ready-age: 3600
 
 providers:
@@ -73,7 +73,7 @@ providers:
             console-log: true
           - name: rpco-14.2-xenial-base
             diskimage: rpco-14.2-xenial-artifacts
-            flavor-name: 7
+            flavor-name: "15GB Standard Instance"
             key-name: jenkins
             console-log: true
       - name: onmetal


### PR DESCRIPTION
The flavor '7' isn't recognised by the shade library,
but using the actual name of the flavor works. This
patch corrects the name so that this base image is
usable, then sets the minimum number of available
nodes to verify that the image nodes start successfully
and are usable for testing.

Issue: [RE-1466](https://rpc-openstack.atlassian.net/browse/RE-1466)