### PR TITLE
RE-1550 Update rpc-octavia snapshot image

### DIFF
--- a/rpc_jobs/rpc_octavia.yml
+++ b/rpc_jobs/rpc_octavia.yml
@@ -121,10 +121,10 @@
     # Use image for RPC-O install
     image:
       - xenial_snapshot:
-          IMAGE: "rpc-r14.12.0-xenial-swift"
+          IMAGE: "rpc-r14.15.0-xenial-swift"
           REGIONS: "DFW"
           FALLBACK_REGIONS: ""
-          FLAVOR: "7"
+          FLAVOR: "8"
           BOOT_TIMEOUT: 1500
 
     # Octavia ignores that setting for now


### PR DESCRIPTION
The rpc-r14.15.0-xenial-swift image has some necessary fixes in it to
update endpoint IPs after a thaw. This commit bumps the image and also
sets the flavor to a flavor 8 as the 7 causes excessive swapping when
octavia starts spinning up instances.

Issue: [RE-1550](https://rpc-openstack.atlassian.net/browse/RE-1550)