### PR TITLE
RE-1535 Fix release when no previous version

### DIFF
--- a/rpc_jobs/standard_job_release.yml
+++ b/rpc_jobs/standard_job_release.yml
@@ -78,13 +78,18 @@
           println "=== predecessor component CLI standard out ==="
           println pred_component_text
 
-          pred_component = readYaml text: pred_component_text
+          if (pred_component_text == ""){
+            pred_version = ""
+          }else{
+            pred_component = readYaml text: pred_component_text
+            pred_version = pred_component["release"]["version"]
+          }
         }
 
         ORG=component["repo_url"].split("/")[3]
         REPO=component["name"]
         VERSION=component["release"]["version"]
-        PREVIOUS_VERSION=pred_component["release"]["version"]
+        PREVIOUS_VERSION=pred_version
         RELEASE_NOTES_FILE="${WORKSPACE}/artifacts/release_notes"
         MAINLINE=component["release"]["series"]
         RC_BRANCH="${MAINLINE}-rc"


### PR DESCRIPTION
If the first version of a component is being released the previous
version argument, used for generating release notes, gets set to an
empty string. It is left the component to determine how to use that
information.

Issue: [RE-1535](https://rpc-openstack.atlassian.net/browse/RE-1535)