### PR TITLE
RE-1584 Move rpc-openstack newton xenial PR jobs to use nodepool

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -109,13 +109,13 @@
     image:
       - trusty:
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+          FLAVOR: "performance2-15"
       - xenial:
-          IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
+          SLAVE_TYPE: "rpco-14.2-xenial-base"
     scenario:
       - "swift"
     action:
-      - deploy:
-          FLAVOR: "performance2-15"
+      - deploy
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 


### PR DESCRIPTION
With the dependent PR merged, we can start using nodepool nodes
which use an image built by nodepool, instead of relying on the
static image created some time ago which cannot be re-created.

The pike and master branches already use nodepool for PR's.

Depends-On: https://github.com/rcbops/rpc-openstack/pull/3062

This has been tested in https://rpc.jenkins.cit.rackspace.net/job/PM_rpc-openstack-newton-xenial-swift-deploy-testjp/7/

Issue: [RE-1584](https://rpc-openstack.atlassian.net/browse/RE-1584)