### PR TITLE
REO-268: Don't timer-trigger rpc-eng-ops noclean job

### DIFF
--- a/rpc_jobs/rpc_eng_ops.yml
+++ b/rpc_jobs/rpc_eng_ops.yml
@@ -9,7 +9,8 @@
     scenario: "embedded"
     action:
       - "deploy"
-      - "deploynoclean"
+      - "deploynoclean":
+          CRON: "# don't trigger based on timer"
     jira_project_key: "REO"
     # includes id_rsa_cloud10_jenkins_file
     # which is the private key that corresponds to the 'jenkins'


### PR DESCRIPTION
Don't automatically run a job that doesn't clean up after itself
because there's not enough resources (ie Ironic nodes in Phobos) for
that, but don't delete the job so that it can be ran manually to debug
the self-cleaning-and-automatic version.

https://rpc-openstack.atlassian.net/browse/REO-268

Issue: [REO-268](https://rpc-openstack.atlassian.net/browse/REO-268)