### PR TITLE
RE-1550 Add rpc-octavia pike snapshot

### DIFF
--- a/rpc_jobs/rpc_octavia.yml
+++ b/rpc_jobs/rpc_octavia.yml
@@ -116,15 +116,17 @@
     # to Queens we will retire rpc-octavia and use the
     # upstream installer
     branch:
-      - "master"
+      - "master":
+          IMAGE: "rpc-r14.15.0-xenial-swift"
+      - "pike":
+          IMAGE: "rpc-r16.2.2-xenial_no_artifacts-swift"
 
     # Use image for RPC-O install
     image:
       - xenial_snapshot:
-          IMAGE: "rpc-r14.15.0-xenial-swift"
           REGIONS: "DFW"
           FALLBACK_REGIONS: ""
-          FLAVOR: "8"
+          FLAVOR: "7"
           BOOT_TIMEOUT: 1500
 
     # Octavia ignores that setting for now


### PR DESCRIPTION
We also flip the flavor size back to 7, since we've since had a
successful run on this flavor [1].

[1] https://rpc.jenkins.cit.rackspace.net/job/PM_rpc-octavia-master-xenial_snapshot-functional-test/16/

Issue: [RE-1550](https://rpc-openstack.atlassian.net/browse/RE-1550)