### PR TITLE
RLM-1498 Drops 14.2.0 leap testing

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -112,7 +112,6 @@
       - "r12.2.2_to_r14.current_leap"
       - "r12.1.2_to_r14.current_leap"
       - "kilo_to_r14.current_leap"
-      - "kilo_to_r14.2.0_leap"
       - "r11.0.0_to_r14.current_leap"
       - "r11.0.1_to_r14.current_leap"
       - "r11.0.4_to_r14.current_leap"


### PR DESCRIPTION
Drops 14.2.0 leap testing

Issue: [RLM-1498](https://rpc-openstack.atlassian.net/browse/RLM-1498)