### PR TITLE
RE-1513 Update rpc_component SHA

### DIFF
--- a/constraints_rpc_component.txt
+++ b/constraints_rpc_component.txt
@@ -1,3 +1,3 @@
 GitPython==2.1.9
-git+https://github.com/rcbops/rpc_component@776c7d7ddc96fd62b503c78c980256906db5a6fd#egg=rpc_component
+git+https://github.com/rcbops/rpc_component@85f152ece9eee3c9cd7d68bd2ecc5982e17400ae#egg=rpc_component
 schema==0.6.7


### PR DESCRIPTION
This change updates rpc_component to the latest version to ensure
rpc-gating works with the new component file format, where release order
is reversed.

Issue: [RE-1513](https://rpc-openstack.atlassian.net/browse/RE-1513)