### PR TITLE
RE-1584 Correct nodepool node name for RPC-O newton xenial nodes

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -111,7 +111,7 @@
           IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
           FLAVOR: "performance2-15"
       - xenial:
-          SLAVE_TYPE: "rpco-14.2-xenial-base"
+          SLAVE_TYPE: "nodepool-rpco-14.2-xenial-base"
     scenario:
       - "swift"
     action:


### PR DESCRIPTION
Unfortunately the 'nodepool-' prefix was left off the node name.

Issue: [RE-1584](https://rpc-openstack.atlassian.net/browse/RE-1584)