### PR TITLE
RE-1585 Move rpc-o newton trusty PR jobs to use nodepool

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -108,8 +108,7 @@
       | ^gating/update_dependencies/
     image:
       - trusty:
-          IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
-          FLAVOR: "performance2-15"
+          SLAVE_TYPE: "nodepool-rpco-14.2-trusty-base"
       - xenial:
           SLAVE_TYPE: "nodepool-rpco-14.2-xenial-base"
     scenario:


### PR DESCRIPTION
We can now use nodepool nodes instead of relying on the
static image created some time ago which cannot be
re-created.

This has been tested here: https://rpc.jenkins.cit.rackspace.net/job/PM_rpc-openstack-newton-trusty-swift-deploy-testjp/11

Issue: [RE-1585](https://rpc-openstack.atlassian.net/browse/RE-1585)