### PR TITLE
ASC-635 Create ASC experimental job

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -464,3 +464,24 @@
 
     jobs:
       - 'Component-Gate-Trigger_{repo_name}'
+
+- project:
+    name: "experimental-asc-rpc-openstack-master-mnaio-postmerge"
+    repo_name: "rpc-openstack"
+    repo_url: "https://github.com/rcbops/rpc-openstack"
+    branch:
+      - "master"
+    CRON: "@monthly"
+    jira_project_key: ""
+    image:
+      - staging_asc_xenial_mnaio_no_artifacts:
+          FLAVOR: "onmetal-io2"
+          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+          REGIONS: "IAD"
+          FALLBACK_REGIONS: "DFW"
+    scenario:
+      - swift
+    action:
+      - system
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'


### PR DESCRIPTION
This commit creates a discrete postmerge MNAIO job labeled as
`experimental_asc`. The purpose of this is to enable experimental test
execution on CI MNAIO infrastructure without impacting the production CI
jobs.

Issue: [ASC-635](https://rpc-openstack.atlassian.net/browse/ASC-635)