### PR TITLE
RE-1484 Add rpc-openstack release jobs

### DIFF
--- a/rpc_jobs/rpc_maas.yml
+++ b/rpc_jobs/rpc_maas.yml
@@ -84,9 +84,9 @@
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
-# NOTE(mattt): the rpc-maas team would rather run all functional
-#              tests on PR (`check`), rather than `gate`. Leaving these
-#              all commented for now.
+# TODO(mattt): We need to split out existing pre-merge jobs between check and
+#              gate, but this will be done after rpc-maas has been
+#              successfully added to the release pipeline.
 #- project:
 #    name: "rpc-maas-master-xenial-gate"
 #    repo_name: "rpc-maas"

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -1,3 +1,7 @@
+# TODO(mattt): We need to split out existing pre-merge jobs between check and
+#              gate, but this will be done after rpc-openstack has been
+#              successfully added to the release pipeline.
+
 - project:
     name: "rpc-openstack-master-premerge"
     repo_name: "rpc-openstack"
@@ -436,6 +440,65 @@
     credentials: "rpc_asc_creds"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+- project:
+    name: 'rpc-openstack-master-mnaio-release'
+    repo_name: 'rpc-openstack'
+    repo_url: 'https://github.com/rcbops/rpc-openstack'
+    branch: "master-rc"
+    jira_project_key: "RO"
+    image:
+      - xenial_mnaio_no_artifacts:
+          FLAVOR: "onmetal-io2"
+          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+          REGIONS: "IAD"
+          FALLBACK_REGIONS: "DFW"
+    scenario:
+      - swift
+    action:
+      - deploy
+    jobs:
+      - 'RELEASE_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+- project:
+    name: 'rpc-openstack-pike-mnaio-release'
+    repo_name: 'rpc-openstack'
+    repo_url: 'https://github.com/rcbops/rpc-openstack'
+    branch: "pike-rc"
+    jira_project_key: "RO"
+    image:
+      - xenial_mnaio_no_artifacts:
+          FLAVOR: "onmetal-io2"
+          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+          REGIONS: "IAD"
+          FALLBACK_REGIONS: "DFW"
+    scenario:
+      - swift
+    action:
+      - deploy
+    jobs:
+      - 'RELEASE_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+- project:
+    name: "rpc-openstack-newton-mnaio-release"
+    repo_name: "rpc-openstack"
+    repo_url: "https://github.com/rcbops/rpc-openstack"
+    branch: "newton-rc"
+    jira_project_key: "RO"
+    image:
+      - xenial_mnaio_loose_artifacts:
+          FLAVOR: "onmetal-io2"
+          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+          REGIONS: "IAD"
+          FALLBACK_REGIONS: "DFW"
+    scenario:
+      - swift
+    action:
+      - deploy
+    # Required by RPC-ASC team to upload test results qTest
+    credentials: "rpc_asc_creds"
+    jobs:
+      - 'RELEASE_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
 - project:
     name: "rpc-openstack-dependency-update"


### PR DESCRIPTION
This commit adds a pike and newton MNAIO release job for rpc-openstack.
The MNAIO jobs are often referred to to determine the health of a
branch before release, so it makes most sense to run these prior to
releasing.

Additionally, we update a comment in rpc_maas.yml to better reflect our
intention of splitting out check and gate jobs after rpc-maas has been
successfully added to the pipeline. This comment was inadvertently
copied from rpc-ceph and since rpc-maas already has a lint and
functional jobs this should be a straight-forward exercise for us to
do.

Issue: [RE-1484](https://rpc-openstack.atlassian.net/browse/RE-1484)