### PR TITLE
RE-1590 Move rpc-upgrades AIO PR's to nodepool

### DIFF
--- a/nodepool/files/elements/rpco-artifacts-ubuntu-minimal/root.d/75-ubuntu-minimal-baseinstall
+++ b/nodepool/files/elements/rpco-artifacts-ubuntu-minimal/root.d/75-ubuntu-minimal-baseinstall
@@ -14,6 +14,14 @@ sudo bash -c "cat << EOF >${TARGET_ROOT}/etc/apt/sources.list
 deb ${DIB_DISTRIBUTION_MIRROR} ${DIB_RELEASE} ${DIB_DEBIAN_COMPONENTS//,/ }
 EOF"
 
+# Add a backup of a default set of sources
+sudo bash -c "cat << EOF >${TARGET_ROOT}/etc/apt/sources.list.original
+deb ${DIB_DISTRIBUTION_MIRROR} ${DIB_RELEASE} ${DIB_DEBIAN_COMPONENTS//,/ }
+deb ${DIB_DISTRIBUTION_MIRROR} ${DIB_RELEASE}-updates ${DIB_DEBIAN_COMPONENTS//,/ }
+deb ${DIB_DISTRIBUTION_MIRROR} ${DIB_RELEASE}-backports ${DIB_DEBIAN_COMPONENTS//,/ }
+deb ${DIB_DISTRIBUTION_MIRROR} ${DIB_RELEASE}-security ${DIB_DEBIAN_COMPONENTS//,/ }
+EOF"
+
 # Make sure that the sources.list.d directory exists
 # (it was removed by the debootstrap element)
 sudo bash -c "mkdir ${TARGET_ROOT}/etc/apt/sources.list.d"

--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -12,8 +12,7 @@
       | ^gating/generate_release_notes/
     image:
       - trusty_aio:
-          FLAVOR: "performance2-15"
-          IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+          SLAVE_TYPE: "nodepool-rpco-14.2-trusty-base"
     scenario:
       - "swift"
     action:


### PR DESCRIPTION
We can now use nodepool nodes instead of relying on the
static image created some time ago which cannot be
re-created. This broadens the regions available to the
test execution and provides quicker access to the nodes.

Also, the tests which make use of the artifacted image expect
a backup of the default apt sources to be in place to allow
switching from artifacted to non-artifacted setups. Instead of
the tests having to assume or derive the correct default sources
we include a copy in the image instead.

Do NOT merge until https://github.com/rcbops/rpc-upgrades/pull/186 is merged.

Issue: [RE-1590](https://rpc-openstack.atlassian.net/browse/RE-1590)