### PR TITLE
REO-265 Sync Git submodules before updating

### DIFF
--- a/rpc_jobs/phobos.yml
+++ b/rpc_jobs/phobos.yml
@@ -138,6 +138,7 @@
                   sudo git reset --hard
                   sudo git checkout "${env.RPC_BRANCH}"
                   sudo git reset --hard origin/${env.RPC_BRANCH} || sudo git reset --hard ${env.RPC_BRANCH}
+                  sudo git submodule sync
                   sudo git submodule update --init
                 """
               }


### PR DESCRIPTION
Execute `git submodule sync` before executing `git submodule update
--init` to account for a possible change in a submodule's "url".

https://rpc-openstack.atlassian.net/browse/REO-265

Issue: [REO-265](https://rpc-openstack.atlassian.net/browse/REO-265)