### PR TITLE
RE-1610 Move rpc-designate PR jobs to use snapshot builds

### DIFF
--- a/rpc_jobs/rpc_designate.yml
+++ b/rpc_jobs/rpc_designate.yml
@@ -10,14 +10,19 @@
 
     # Use image for RPC-O install
     image:
-      - xenial:
-          FLAVOR: "performance2-15"
-          IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
+      - xenial_snapshot:
+          REGIONS: "DFW"
+          FALLBACK_REGIONS: ""
+          FLAVOR: "7"
+          BOOT_TIMEOUT: 1500
 
     scenario:
-      - "newton"
-      - "pike"
-      - "queens"
+      - newton:
+          IMAGE: "rpc-r14.9.0-xenial-swift"
+      - pike:
+          IMAGE: "rpc-r16.1.0-xenial_no_artifacts-swift"
+      - queens:
+          IMAGE: "rpc-r18.0.0-xenial_no_artifacts-swift"
     action:
       - "deploy"
 
@@ -52,8 +57,7 @@
     action:
       - "deploy"
 
-    # Sending these failures to RE while we stabilise these images
-    jira_project_key: "RE"
+    jira_project_key: "RI"
 
     # Link to the standard post-merge-template
     jobs:


### PR DESCRIPTION
The snapshot-based PM builds have been running successfully for
some time now, and are executed far faster.

This PR switches the PR builds to do the same thing, and switches
the error reporting from RE to RI considering it's now a stable
implementation.

Issue: [RE-1610](https://rpc-openstack.atlassian.net/browse/RE-1610)