### PR TITLE
RE-1513 Improve gate test guarantees

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -51,7 +51,8 @@ check_groovy(){
          return
        }
   extract_groovy_from_jjb
-  groovy scripts/lint_support_groovy/syntax.groovy \
+  groovy -classpath src \
+    scripts/lint_support_groovy/syntax.groovy \
     scripts/lint_support_groovy/*.groovy \
     pipeline_steps/*.groovy \
     tmp_groovy/*.groovy \

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -549,6 +549,30 @@ void clone_external_repo(String directory, String repo, String ref, String refsp
 }
 
 
+/**
+ * Merge list of pull requests.
+ *
+ * Iterate through the list of pull request IDs and merge each change
+ * on top of the current HEAD. If a merge fails an exception is raised.
+ *
+ * @param directory location of the Git repository
+ * @param pullRequestIDs ordered list of pull request numbers to merge
+ * @return null
+ */
+void merge_pr_chain(String directory='./', List pullRequestIDs=null){
+  println("Attempting to merge the following pull requests onto the base branch: ${pullRequestIDs}.")
+  dir(directory){
+    for (pullRequestID in pullRequestIDs) {
+      println("Merging pull request ${pullRequestID}.")
+      sh """#!/bin/bash -xe
+        git merge origin/pr/${pullRequestID}/head
+      """
+    }
+  }
+  println("Finished merging the pull requests onto the base branch.")
+}
+
+
 void configure_git(){
   print "Configuring Git"
   // credentials store created to ensure that non public repos
@@ -1355,6 +1379,10 @@ void stdJob(String hook_dir, String credentials, String jira_project_key, String
                   env.REPO_URL,
                   env.BRANCH,
                 )
+                if (env.pullRequestChain) {
+                  pullRequestIDs = loadCSV(env.pullRequestChain)
+                  merge_pr_chain("${env.WORKSPACE}/${env.RE_JOB_REPO_NAME}", pullRequestIDs)
+                }
               } else {
                 print("Triggered by PR: ${env.ghprbPullLink}")
                 clone_with_pr_refs(
@@ -1655,4 +1683,14 @@ void createRelease(){
       ],
     ]
   )
+}
+
+
+List loadCSV(String str){
+  str.split(",").collect {it.trim()}
+}
+
+
+String dumpCSV(List l){
+  l.join(",")
 }

--- a/pipeline_steps/gate.groovy
+++ b/pipeline_steps/gate.groovy
@@ -1,0 +1,363 @@
+import org.jenkinsci.plugins.workflow.job.WorkflowJob
+import org.jenkinsci.plugins.workflow.job.WorkflowRun
+import groovy.transform.Field
+
+import com.rackspace.exceptions.REException
+
+
+void testPullRequest(String repoName, Boolean testWithAntecedents, String githubStatusContext){
+    try {
+        if (testWithAntecedents) {
+           testPullRequestWithAntecedents(repoName, githubStatusContext)
+        } else {
+           testPullRequestOnly(repoName)
+        }
+    }catch (REException e){
+        currentBuild.result="FAILURE"
+    }
+}
+
+
+void testPullRequestOnly(String repoName){
+    List jobNames = Hudson.instance.getAllItems(org.jenkinsci.plugins.workflow.job.WorkflowJob)*.fullName
+
+    def parallelBuilds = [:]
+
+    // Cannot do for (job in jobNames), see:
+    // https://jenkins.io/doc/pipeline/examples/#parallel-multiple-nodes
+    for (j in jobNames) {
+        def job = j
+        def m = job =~ /GATE_${repoName}/
+        if (m) {
+            parallelBuilds[job] = {
+                build(
+                    job: job,
+                    wait: true,
+                    parameters: [
+                        [
+                            $class: "StringParameterValue",
+                            name: "RPC_GATING_BRANCH",
+                            value: RPC_GATING_BRANCH,
+                        ],
+                        [
+                            $class: "StringParameterValue",
+                            name: "BRANCH",
+                            value: sha1,
+                        ]
+                    ]
+                )
+            }
+        }
+    }
+
+    parallel parallelBuilds
+
+    build(
+      job: "Merge-Pull-Request",
+      wait: false,
+      parameters: [
+        [
+          $class: "StringParameterValue",
+          name: "RPC_GATING_BRANCH",
+          value: RPC_GATING_BRANCH,
+        ],
+        [
+          $class: "StringParameterValue",
+          name: "pr_repo",
+          value: ghprbGhRepository,
+        ],
+        [
+          $class: "StringParameterValue",
+          name: "pr_number",
+          value: ghprbPullId,
+        ],
+        [
+          $class: "StringParameterValue",
+          name: "commit",
+          value: ghprbActualCommit,
+        ],
+      ]
+    )
+}
+
+
+@Field WorkflowRun triggerBuild = currentBuild.rawBuild
+@Field Result SUCCESS = Result.fromString("SUCCESS")
+/**
+ * Global variable for tracking the status of downstream gate builds
+ * that are managed by testPullRequestWithAntecedents.
+ */
+@Field Map gateBuilds = [:]
+
+
+/**
+ * Test pull request with antecedent builds.
+ *
+ * For any build, an antecedent build is defined as being one:
+ *   - of the same job type
+ *   - triggered by a pull request targeted at the same base branch
+ *   - with a lower build number
+ *   - that is not finished
+ *
+ * If an antecedent build is no longer running, either it was successful
+ * and the code has already merged or it failed and its changes can be
+ * ignored.
+ *
+ * If multiple gate trigger builds are running, to ensure that each
+ * pull request is tested against the HEAD of the branch that will exist
+ * when it merges instead of the one that exists when the builds starts,
+ * this function finds all the active antecedent builds and performs
+ * tests on the assumption that the antecedent builds are all successful
+ * and merge in the order they were started. If an antecedent fails, the
+ * tests are restarted.
+ */
+void testPullRequestWithAntecedents(String repoName, String statusContext){
+    allWorkflowJobs = Hudson.instance.getAllItems(WorkflowJob)
+    gateJobs = (allWorkflowJobs.findAll {it.displayName =~ /GATE_${repoName}-${ghprbTargetBranch}/}).sort(false)
+    println("Discovered the following pull request gate jobs for repo ${repoName}:\n${gateJobs.collect() {it.displayName}.join("\n")}")
+
+    triggerJobName = triggerBuild.getParent().displayName
+    triggerJob = allWorkflowJobs.find {it.displayName == triggerJobName}
+    antecedentTriggerBuilds = []
+    pullRequestIDs = []
+    triggerBuildTargetBranch = triggerBuild.getAction(ParametersAction).getParameter("ghprbTargetBranch").getValue()
+
+    while (true) {
+        updateGateBuilds()
+
+        currentAntecedentTriggerBuilds = triggerJob.getBuilds().findAll {
+            (
+                it.isBuilding() == true
+                && it.getNumber() < triggerBuild.getNumber()
+                && it.getAction(ParametersAction).getParameter("ghprbTargetBranch").getValue() == triggerBuildTargetBranch
+            )
+        }.reverse()
+        if (antecedentTriggerBuilds.size() != currentAntecedentTriggerBuilds.size()) {
+            failedAntecedents = antecedentTriggerBuilds.findAll() {it.getResult() && it.getResult().isWorseThan(SUCCESS)}
+            if (failedAntecedents) {
+                println("Antecedent builds that have completed with failure:\n${failedAntecedents.join("\n")}")
+                println("Terminating existing builds that depend on failed antecedents.")
+                killGateBuilds()
+            }else if (antecedentTriggerBuilds){
+                completed = antecedentTriggerBuilds.findAll() {!(it in currentAntecedentTriggerBuilds)}
+                println("Antecedent builds that have completed with success:\n${completed.join("\n")}")
+            }
+            antecedentTriggerBuilds = currentAntecedentTriggerBuilds
+        } else{
+           failedAntecedents = []
+        }
+
+        if (gateBuilds.isEmpty() || failedAntecedents){
+            if (antecedentTriggerBuilds){
+                println("Active antecedent builds:\n${antecedentTriggerBuilds.join("\n")}")
+            }else {
+                println("No active antecedent builds.")
+            }
+            println("Base branch being tested against: ${ghprbTargetBranch}.")
+            pullRequestIDs = antecedentTriggerBuilds.collect(){getPullRequestID(it)}
+            pullRequestIDs.add(getPullRequestID(triggerBuild))
+            println("Pull requests to merge on top of base branch in tests: ${pullRequestIDs}.")
+        }
+
+        // A failed gate build only causes the trigger build to fail if all antecedents succeed
+        if (antecedentTriggerBuilds.empty) {
+            failedGateBuilds = getFailedGateBuilds()
+            if (failedGateBuilds) {
+                errMsg = "One or more builds failed to reach success:\n${failedGateBuilds.collect() {it.getAbsoluteUrl()}.join("\n")}"
+                println(errMsg)
+                throw new REException(errMsg)
+            }
+        }
+
+        pullRequestIDsParam = common.dumpCSV(pullRequestIDs)
+        def parallelBuilds = [:]
+        for (j in gateJobs) {
+            WorkflowJob job = j
+            if (! (job in gateBuilds)) {
+               gateBuilds[job] = [
+                    "build": null,
+                    "nextNumber": job.getNextBuildNumber(),
+                ]
+                String jobName = job.displayName
+                parallelBuilds[jobName] = {
+                    build(
+                        job: jobName,
+                        wait: false,
+                        parameters: [
+                            [
+                                $class: "StringParameterValue",
+                                name: "RPC_GATING_BRANCH",
+                                value: RPC_GATING_BRANCH,
+                            ],
+                            [
+                                $class: "StringParameterValue",
+                                name: "BRANCH",
+                                value: ghprbTargetBranch,
+                            ],
+                            [
+                                $class: "StringParameterValue",
+                                name: "pullRequestChain",
+                                value: pullRequestIDsParam,
+                            ],
+                        ]
+                    )
+                }
+            }
+        }
+        if (parallelBuilds){
+            parallel parallelBuilds
+        }
+        if (antecedentTriggerBuilds.empty && isGateBuildsSuccess()){
+            break
+        }else {
+            sleep(time: 120, unit: "SECONDS")
+        }
+    }
+
+    (prRepoOrg, prRepoName) = ghprbGhRepository.split("/")
+    /* When a check is required by GitHub, it prevents the pull request being merged if
+       it is not marked as `"success"`. Normally GHPRB would be soley responsible for
+       updating the status context however this would necessitate a separate job to
+       perform the merge. The following section updates the pull request's status
+       context on GitHub if all tests were successful to enable the same build to merge
+       the pull request. GHPRB will the report success again assuming all subsequent
+       steps succeed.
+     */
+    println("Updating pull request status context.")
+    description = "Gate tests passed, merging..."
+    github.create_status(prRepoOrg, prRepoName, ghprbActualCommit, "success", triggerBuild.getAbsoluteUrl(), description, statusContext)
+    github.merge_pr(prRepoOrg, prRepoName, ghprbPullId, ghprbActualCommit)
+}
+
+
+Integer getPullRequestID(build){
+    build.getAction(ParametersAction).getParameter("ghprbPullId").getValue()
+}
+
+
+Boolean isGateBuildsSuccess(){
+    gateBuilds.every {
+        build = getBuild(it)
+        build && ! build.hasntStartedYet() && ! build.isBuilding() && build.getResult() && build.getResult().equals(SUCCESS)
+    }
+}
+
+
+List getFailedGateBuilds(){
+    gateBuilds.findAll() {
+        build = getBuild(it)
+        (
+            build
+            && build.getResult()
+            && build.getResult().isWorseThan(SUCCESS)
+        )
+    }.collect {getBuild(it)}
+}
+
+
+WorkflowRun getBuild(build){
+    build.value["build"]
+}
+
+
+Integer getNextNumber(build){
+    build.value["nextNumber"]
+}
+
+
+WorkflowJob getJob(build){
+    build.key
+}
+
+
+WorkflowRun findBuild(WorkflowJob job, Integer oldestNumber){
+    build = null
+    potentialBuild = job.getLastBuild()
+    while(potentialBuild.getNumber() >= oldestNumber){
+        potentialBuildCause = potentialBuild.getCauses()[0]
+        if (potentialBuildCause instanceof Cause.UpstreamCause){
+            if (potentialBuildCause.getUpstreamBuild() == triggerBuild.getNumber()){
+                build = potentialBuild
+                break
+            }
+        }
+        potentialBuild = potentialBuild.getPreviousBuild()
+    }
+    return build
+}
+
+
+void updateGateBuilds(){
+    buildCount = gateBuilds.findAll {getBuild(it)}.size()
+    missingBuilds = false
+    gateBuilds.clone().each { gateBuild ->
+        build = getBuild(gateBuild)
+        if (! build){
+            job = getJob(gateBuild)
+            if (findQueueItem(job)){
+                return
+            }
+            startedBuild = findBuild(job, getNextNumber(gateBuild))
+            if (startedBuild){
+              gateBuilds[job]["build"] = startedBuild
+              println("New gate test build: ${startedBuild} ${startedBuild.getAbsoluteUrl()}")
+            } else {
+                println("Requested build of job ${job.displayName} cannot be found, preparing for new request.")
+                gateBuilds.remove(job)
+                missingBuilds = true
+            }
+        }
+    }
+    updatedBuildCount = gateBuilds.findAll {getBuild(it)}.size()
+    if ((! missingBuilds) && gateBuilds.size() == updatedBuildCount && updatedBuildCount > buildCount){
+        buildURLs = gateBuilds.findAll {getBuild(it)}.collect {getBuild(it).getAbsoluteUrl()}
+        println("All gate tests started:\n${buildURLs.join("\n")}")
+    }
+}
+
+
+Queue.WaitingItem findQueueItem(WorkflowJob job){
+    item = null
+    queue = Queue.getInstance()
+    for (queueItem in queue.getItems()){
+        if (queueItem instanceof Queue.WaitingItem){
+            qica = queueItem.getAction(CauseAction)
+            qiuc = (qica.findCause(Cause.UpstreamCause))
+            if (qiuc.getUpstreamBuild() == triggerBuild.getNumber() && queueItem.task == job){
+                item = queueItem
+                break
+            }
+        }
+    }
+    return item
+}
+
+
+void killGateBuilds(){
+    queue = Queue.getInstance()
+    gateBuilds.each { gateBuild ->
+        build = getBuild(gateBuild)
+        if (! build){
+            job = getJob(gateBuild)
+            queueItem = findQueueItem(job)
+            if (queueItem){
+                println("Terminating queued downstream test ${queueItem}")
+                queue.cancel(queueItem)
+            }
+            build = findBuild(job, getNextNumber(gateBuild))
+        }
+        if (build){
+            println("Terminating downstream test ${build}")
+            listener = build.asFlowExecutionOwner().getListener()
+            listener.hyperlink(
+                triggerBuild.getAbsoluteUrl(),
+                "Terminated by upstream build due to failure in antecedent test.\n"
+            )
+            build.doKill()
+        }
+    }
+    gateBuilds = [:]
+}
+
+
+return this;

--- a/pipeline_steps/github.groovy
+++ b/pipeline_steps/github.groovy
@@ -100,4 +100,37 @@ def merge_pr(
 }
 
 
+def create_status(
+    String org,
+    String repo,
+    String commit,
+    String state,
+    String targetURL,
+    String description,
+    String context
+    ){
+  withCredentials([
+    string(
+      credentialsId: 'rpc-jenkins-svc-github-pat',
+      variable: 'pat'
+    )
+  ]){
+    sh """#!/bin/bash -xe
+      cd ${env.WORKSPACE}
+      set +x; . .venv/bin/activate; set -x
+      python rpc-gating/scripts/ghutils.py\
+        --org '$org'\
+        --repo '$repo'\
+        --pat '$pat'\
+        create_status\
+        --commit '$commit'\
+        --state '$state'\
+        --target_url '$targetURL'\
+        --description '$description'\
+        --context '$context'
+    """
+  }
+}
+
+
 return this;

--- a/rpc_jobs/standard_job_gate.yml
+++ b/rpc_jobs/standard_job_gate.yml
@@ -2,6 +2,8 @@
     name: 'Component-Gate-Trigger_{repo_name}'
     project-type: pipeline
     concurrent: true
+    test_with_antecedents: true
+    status_context: "CIT/gate"
     triggers:
       - github-pull-request:
           org-list:
@@ -10,7 +12,7 @@
           trigger-phrase: '(re)?check_component_gate'
           only-trigger-phrase: true
           auth-id: "github_account_rpc_jenkins_svc"
-          status-context: 'CIT/gate'
+          status-context: "{status_context}"
           cancel-builds-on-update: true
     properties:
       - github:
@@ -21,66 +23,10 @@
       - rpc_gating_params
     dsl: |
       library "rpc-gating@${{RPC_GATING_BRANCH}}"
+
       common.globalWraps(){{
-        List jobNames = Hudson.instance.getAllItems(org.jenkinsci.plugins.workflow.job.WorkflowJob)*.fullName
-
-        def parallelBuilds = [:]
-
-        // Cannot do for (job in jobNames), see:
-        // https://jenkins.io/doc/pipeline/examples/#parallel-multiple-nodes
-        for (j in jobNames) {{
-          def job = j
-          def m = job =~ /GATE_{repo_name}/
-          if (m) {{
-            parallelBuilds[job] = {{
-              build(
-                job: job,
-                wait: true,
-                parameters: [
-                  [
-                    $class: "StringParameterValue",
-                    name: "RPC_GATING_BRANCH",
-                    value: RPC_GATING_BRANCH,
-                  ],
-                  [
-                    $class: "StringParameterValue",
-                    name: "BRANCH",
-                    value: sha1,
-                  ]
-                ]
-              )
-            }} // parallelBuilds
-          }} // if
-        }} // for
-
-        parallel parallelBuilds
-
-        build(
-          job: "Merge-Pull-Request",
-          wait: false,
-          parameters: [
-            [
-              $class: "StringParameterValue",
-              name: "RPC_GATING_BRANCH",
-              value: RPC_GATING_BRANCH,
-            ],
-            [
-              $class: "StringParameterValue",
-              name: "pr_repo",
-              value: ghprbGhRepository,
-            ],
-            [
-              $class: "StringParameterValue",
-              name: "pr_number",
-              value: ghprbPullId,
-            ],
-            [
-              $class: "StringParameterValue",
-              name: "commit",
-              value: ghprbActualCommit,
-            ],
-          ]
-        )
+          testWithAntecedents = "{test_with_antecedents}".toBoolean()
+          gate.testPullRequest("{repo_name}", testWithAntecedents, "{status_context}")
       }} // globalWraps
 
 - job-template:
@@ -136,6 +82,11 @@
             pull request match the regex the build will exit without running the test scripts.
             This is used to skip tests that are not relevant to a change, for example testing a
             deployment when only changing documentation. By default no builds are skipped.
+      - string:
+          name: pullRequestChain
+          default: ""
+          description: |
+            A comma separated list of pull requsts IDs to enable the testing of a chain of pull requests.
 
     dsl: |
       library "rpc-gating@${{RPC_GATING_BRANCH}}"

--- a/scripts/ghutils.py
+++ b/scripts/ghutils.py
@@ -119,6 +119,32 @@ def add_issue_url_to_pr(repo, pull_request_number, issue_key):
 @cli.command()
 @click.pass_obj
 @click.option(
+    '--commit',
+    required=True,
+)
+@click.option(
+    '--state',
+    required=True,
+)
+@click.option(
+    '--target_url',
+    required=True,
+)
+@click.option(
+    '--description',
+    required=True,
+)
+@click.option(
+    '--context',
+    required=True,
+)
+def create_status(repo, commit, state, target_url, description, context):
+    repo.create_status(commit, state, target_url, description, context)
+
+
+@cli.command()
+@click.pass_obj
+@click.option(
     '--pull-request-number',
     help="Pull request to update",
     required=True,

--- a/scripts/lint_support_groovy/queue.groovy
+++ b/scripts/lint_support_groovy/queue.groovy
@@ -1,0 +1,6 @@
+//Dummy cause class for lint jobs
+package Queue
+
+public class WaitingItem {
+
+}

--- a/scripts/lint_support_groovy/result.groovy
+++ b/scripts/lint_support_groovy/result.groovy
@@ -1,0 +1,4 @@
+//Dummy cause class for lint jobs
+public class Result {
+
+}

--- a/scripts/lint_support_groovy/workflowjob.groovy
+++ b/scripts/lint_support_groovy/workflowjob.groovy
@@ -1,0 +1,10 @@
+//Dummy cause class for lint jobs
+package org.jenkinsci.plugins.workflow.job
+
+public class WorkflowJob {
+
+}
+
+public class WorkflowRun {
+
+}

--- a/src/com/rackspace/exceptions/REException.groovy
+++ b/src/com/rackspace/exceptions/REException.groovy
@@ -1,0 +1,7 @@
+package com.rackspace.exceptions
+import groovy.transform.InheritConstructors
+
+
+@InheritConstructors
+class REException extends Exception {
+}


### PR DESCRIPTION
Without this change, any Component-Gate-Trigger_ job tests a pull
request against the target branch using the merge branch supplied by
GitHub but does not account for any changes that merge while those tests
are running.

This change ensures that a pull request is tested with any other pull
requests that are also going through the gate. To achieve this a build
looks for any builds that were started before it and includes their pull
requests in its own tests. If any of those builds fails, the tests on
dependent builds are terminated with a link to the upstream build and
new ones are started.

This change should provide a stronger guarantee as to the state of the
repository however if tests are unstable or pull requests are approved
that are broken, the time to merge a working pull request may increase.

This functionality can be disabled by setting `test_with_antecedents:
false` in a project.

Component-Gate-Trigger_ jobs that use this functionality no longer
depend on Merge-Pull-Request. This was done to simplify the tracking of
pull requests and the success of the tests. To enable merging to still
work, Component-Gate-Trigger_ will now update the status context for
"CIT/gate" so that the GitHub required status does not block the build
from merging the pull request.

REException class added to help reduce the noise in the build console
log. The new exception type is used to allow an exception to be raised
to exit the build without the stack trace appearing in the log.

The following test builds show what happens under various situations:
https://rpc.jenkins.cit.rackspace.net/job/Component-Gate-Trigger_rpc-product-1-gh/273
https://rpc.jenkins.cit.rackspace.net/job/Component-Gate-Trigger_rpc-product-1-gh/274
https://rpc.jenkins.cit.rackspace.net/job/Component-Gate-Trigger_rpc-product-1-gh/275

Issue: [RE-1513](https://rpc-openstack.atlassian.net/browse/RE-1513)