### PR TITLE
ASC-655 Add sdqc action

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -201,9 +201,12 @@
       - swift
     action:
       - system
+      - sdqc
       - deploy
     exclude:
       - action: system
+        scenario: ironic
+      - action: sdqc
         scenario: ironic
     # Required by RPC-ASC team to upload test results qTest
     credentials: "rpc_asc_creds"


### PR DESCRIPTION
This commit adds an 'sdqc' action to the
`rpc-openstack-master-mnaio-postmerge` project. The `ironic` scenario is
excluded when this action is used. So, the only job that should be
created by this change is:

    PM_rpc-openstack-master-xenial_mnaio_no_artifacts-swift-sdqc

The purpose of this is to run the deployment and validation of
[openstack-ops](https://github.com/rsoprivatecloud/openstack-ops/) in
isolation from other system test suites. Currently, this is necessary
due to a conflict in the deployment ansible code.

Issue: [ASC-655](https://rpc-openstack.atlassian.net/browse/ASC-655)