### PR TITLE
Revert "RE-1596 Restore get_rpc_repo_creds function"

### DIFF
--- a/pipeline_steps/artifact_build.groovy
+++ b/pipeline_steps/artifact_build.groovy
@@ -1,33 +1,3 @@
-
-def get_rpc_repo_creds(){
-  return [
-    string(
-      credentialsId: "RPC_REPO_IP",
-      variable: "REPO_HOST"
-    ),
-    string(
-      credentialsId: "RPC_REPO_SSH_USERNAME_TEXT",
-      variable: "REPO_USER"
-    ),
-    file(
-      credentialsId: "RPC_REPO_SSH_USER_PRIVATE_KEY_FILE",
-      variable: "REPO_USER_KEY"
-    ),
-    file(
-      credentialsId: "RPC_REPO_SSH_HOST_PUBLIC_KEY_FILE",
-      variable: "REPO_HOST_PUBKEY"
-    ),
-    file(
-      credentialsId: "RPC_REPO_GPG_SECRET_KEY_FILE",
-      variable: "GPG_PRIVATE"
-    ),
-    file(
-      credentialsId: "RPC_REPO_GPG_PUBLIC_KEY_FILE",
-      variable: "GPG_PUBLIC"
-    )
-  ]
-}
-
 def apt() {
   common.use_node('ArtifactBuilder2') {
     common.withRequestedCredentials("rpc_repo") {

--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -6,7 +6,7 @@
         - git:
             url: https://github.com/rcbops/rpc-gating
             branches:
-              - "${{RPC_GATING_BRANCH}}"
+              - "${RPC_GATING_BRANCH}"
             credentials-id: "github_account_rpc_jenkins_svc"
       script-path: job_dsl/rpc_artifact_build.groovy
     concurrent: true


### PR DESCRIPTION
This reverts commit b677b6d673261d0b96a755fa19e40869ba52583c.

This function is no longer needed. The commit was only included
in order to allow testing to pass prior to the PR merging.

Issue: [RE-1596](https://rpc-openstack.atlassian.net/browse/RE-1596)