### PR TITLE
ASC-665 Externalize RE_JOB_BRANCH for asc staging

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -533,51 +533,23 @@
     jobs:
       - 'Component-Gate-Trigger_{repo_name}'
 
-- job:
-    name: "ASC-staging-rpc-openstack-master-xenial-mnaio-no-artifacts-swift-system"
+- project:
+    name: "experimental-asc-rpc-openstack-master-mnaio-postmerge"
+    repo_name: "rpc-openstack"
+    repo_url: "https://github.com/rcbops/rpc-openstack"
+    branch:
+      - "master"
+    CRON: "@monthly"
     jira_project_key: ""
-    project-type: pipeline
-    concurrent: true
-    properties:
-      - build-discarder:
-          num-to-keep: 14
-      - github:
-          url: "https://github.com/rcbops/rpc-openstack"
-      - inject:
-          properties-content: |
-            STAGES="Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
-            BOOT_TIMEOUT=900
-            RE_JOB_NAME=ASC-Staging
-            RE_JOB_IMAGE=staging_asc_xenial_mnaio_no_artifacts
-            RE_JOB_SCENARIO=swift
-            RE_JOB_ACTION=system
-            RE_JOB_FLAVOR=onmetal-io2
-            RE_JOB_REPO_NAME=rpc-openstack
-    parameters:
-      - string:
-          name: RE_JOB_BRANCH
-          default: dev
-          description: Branch of rpc-openstack-system-tests to use
-      - rpc_gating_params
-      - instance_params:
-          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+    image:
+      - staging_asc_xenial_mnaio_no_artifacts:
           FLAVOR: "onmetal-io2"
+          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
           REGIONS: "IAD"
           FALLBACK_REGIONS: "DFW"
-      - string:
-          name: REPO_URL
-          default: "https://github.com/rcbops/rpc-openstack"
-          description: Url of the repo under test
-      - string:
-          name: BRANCH
-          default: "master"
-          description: Branch of the repo under test
-      - standard_job_params:
-          SLAVE_TYPE: "instance"
-          SLAVE_CONTAINER_DOCKERFILE_REPO: "RE"
-          SLAVE_CONTAINER_DOCKERFILE_PATH: "./Dockerfile.standard_job"
-          SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS: "BASE_IMAGE=ubuntu:16.04"
-
-    dsl: |
-      library "rpc-gating@${RPC_GATING_BRANCH}"
-      common.stdJob("periodic,post_merge_test", "", "", "")
+    scenario:
+      - swift
+    action:
+      - system
+    jobs:
+      - 'SYS_{repo_name}-{branch}-{image}-{scenario}-{action}'

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -533,23 +533,51 @@
     jobs:
       - 'Component-Gate-Trigger_{repo_name}'
 
-- project:
-    name: "experimental-asc-rpc-openstack-master-mnaio-postmerge"
-    repo_name: "rpc-openstack"
-    repo_url: "https://github.com/rcbops/rpc-openstack"
-    branch:
-      - "master"
-    CRON: "@monthly"
+- job:
+    name: "ASC-staging-rpc-openstack-master-xenial-mnaio-no-artifacts-swift-system"
     jira_project_key: ""
-    image:
-      - staging_asc_xenial_mnaio_no_artifacts:
-          FLAVOR: "onmetal-io2"
+    project-type: pipeline
+    concurrent: true
+    properties:
+      - build-discarder:
+          num-to-keep: 14
+      - github:
+          url: "https://github.com/rcbops/rpc-openstack"
+      - inject:
+          properties-content: |
+            STAGES="Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
+            BOOT_TIMEOUT=900
+            RE_JOB_NAME=ASC-Staging
+            RE_JOB_IMAGE=staging_asc_xenial_mnaio_no_artifacts
+            RE_JOB_SCENARIO=swift
+            RE_JOB_ACTION=system
+            RE_JOB_FLAVOR=onmetal-io2
+            RE_JOB_REPO_NAME=rpc-openstack
+    parameters:
+      - string:
+          name: RE_JOB_BRANCH
+          default: dev
+          description: Branch of rpc-openstack-system-tests to use
+      - rpc_gating_params
+      - instance_params:
           IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+          FLAVOR: "onmetal-io2"
           REGIONS: "IAD"
           FALLBACK_REGIONS: "DFW"
-    scenario:
-      - swift
-    action:
-      - system
-    jobs:
-      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+      - string:
+          name: REPO_URL
+          default: "https://github.com/rcbops/rpc-openstack"
+          description: Url of the repo under test
+      - string:
+          name: BRANCH
+          default: "master"
+          description: Branch of the repo under test
+      - standard_job_params:
+          SLAVE_TYPE: "instance"
+          SLAVE_CONTAINER_DOCKERFILE_REPO: "RE"
+          SLAVE_CONTAINER_DOCKERFILE_PATH: "./Dockerfile.standard_job"
+          SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS: "BASE_IMAGE=ubuntu:16.04"
+
+    dsl: |
+      library "rpc-gating@${RPC_GATING_BRANCH}"
+      common.stdJob("periodic,post_merge_test", "", "", "")

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -38,7 +38,7 @@
             REGIONS=DFW
             FALLBACK_REGIONS=
 
-- job-template:
+- job-template: &default_pm_gating_template
     name: 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
     branch: "master"
     jira_project_key: ""
@@ -90,3 +90,31 @@
     dsl: |
       library "rpc-gating@${{RPC_GATING_BRANCH}}"
       common.stdJob("periodic,post_merge_test", "{credentials}", "{jira_project_key}", "{wrappers}")
+
+- job-template:
+    <<: *default_pm_gating_template
+    name: 'SYS_{repo_name}-{branch}-{image}-{scenario}-{action}'
+    parameters:
+      - string:
+          name: SYS_TEST_BRANCH
+          default: "{branch}"
+          description: Url of the system test branch
+      - rpc_gating_params
+      - instance_params:
+          IMAGE: "{IMAGE}"
+          FLAVOR: "{FLAVOR}"
+          REGIONS: "{REGIONS}"
+          FALLBACK_REGIONS: "{FALLBACK_REGIONS}"
+      - string:
+          name: REPO_URL
+          default: "{repo_url}"
+          description: Url of the repo under test
+      - string:
+          name: BRANCH
+          default: "{branch}"
+          description: Branch of the repo under test
+      - standard_job_params:
+          SLAVE_TYPE: "{SLAVE_TYPE}"
+          SLAVE_CONTAINER_DOCKERFILE_REPO: "{SLAVE_CONTAINER_DOCKERFILE_REPO}"
+          SLAVE_CONTAINER_DOCKERFILE_PATH: "{SLAVE_CONTAINER_DOCKERFILE_PATH}"
+          SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS: "{SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS}"


### PR DESCRIPTION
This commit converts the asc staging job from a jjb project into a jjb
job in order to create the RE_JOB_BRANCH as an available parameter to be
set when a build is started. The RE_JOB_BRANCH is used internally by
the gating scripts to determine the branch of
`rpc-openstack-system-tests` to be checked out. Making this available as
a settable variable will allow topic branches of the testing repo to be
specified when triggering the job.

Issue: [ASC-665](https://rpc-openstack.atlassian.net/browse/ASC-665)