### PR TITLE
RE-1606 Check skip_pattern in gate jobs

### DIFF
--- a/rpc_jobs/dummy_pipeline.yml
+++ b/rpc_jobs/dummy_pipeline.yml
@@ -27,6 +27,10 @@
     branches:
       - 'master'
 
+    skip_pattern: |
+      \.md$
+      | \.rst$
+
     image:
       - container:
           SLAVE_TYPE: "container"
@@ -60,6 +64,10 @@
     repo_url: "https://github.com/mattt416/rpc-product-1"
 
     branch: "master"
+
+    skip_pattern: |
+      \.md$
+      | \.rst$
 
     image:
       - "xenial":

--- a/rpc_jobs/rpc_maas.yml
+++ b/rpc_jobs/rpc_maas.yml
@@ -11,7 +11,8 @@
       | ^releasenotes/
       | ^doc/
       | ^gating/generate_release_notes/
-      | ^gating/post_merge_test/
+      | ^gating/periodic/
+      | ^gating/release/
     image:
       - "xenial"
     scenario:
@@ -46,7 +47,8 @@
       | ^releasenotes/
       | ^doc/
       | ^gating/generate_release_notes/
-      | ^gating/post_merge_test/
+      | ^gating/periodic/
+      | ^gating/release/
     image:
       - trusty:
           SLAVE_TYPE: "nodepool-ubuntu-trusty-g1-8"
@@ -92,6 +94,14 @@
 #    repo_name: "rpc-maas"
 #    repo_url: "https://github.com/rcbops/rpc-maas"
 #    branch: "master"
+#    skip_pattern: |
+#      \.md$
+#      | \.rst$
+#      | ^releasenotes/
+#      | ^doc/
+#      | ^gating/generate_release_notes/
+#      | ^gating/periodic/
+#      | ^gating/release/
 #    image:
 #      - "xenial":
 #          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
@@ -110,6 +120,14 @@
 #    repo_name: "rpc-maas"
 #    repo_url: "https://github.com/rcbops/rpc-maas"
 #    branch: "master"
+#    skip_pattern: |
+#      \.md$
+#      | \.rst$
+#      | ^releasenotes/
+#      | ^doc/
+#      | ^gating/generate_release_notes/
+#      | ^gating/periodic/
+#      | ^gating/release/
 #    image:
 #      - "trusty":
 #          SLAVE_TYPE: "nodepool-ubuntu-trusty-g1-8"


### PR DESCRIPTION
Currently, the gate jobs do not check if the commit is only changing
files in the skip_list. This means we may end up running lengthy gate
jobs which don't need to be run. This commit updates
pipeline/gate.groovy to only run gate jobs if isSkippable() is false.

Additionally, we update rpc-maas' skip_list replacing
gating/post_merge_test with gating/periodic, and add gating/release to
the existing skip_pattern. We also duplicate this skip_pattern to the
commented gate jobs in rpc_maas.yml.

Lastly, for testing, we update dummy_pipeline.yml to add a skip_pattern
to rpc-product-1's check and gate jobs.

Issue: [RE-1606](https://rpc-openstack.atlassian.net/browse/RE-1606)