### PR TITLE
RE-1626 Fix jira issue creation for upload fails

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -344,12 +344,16 @@ def archive_artifacts(Map args = [:]){
       // prevent failures in RE code eg (artifact archival) from causing
       // the build result to be set to failure.
       // try-catch placed here because this function is used in multiple places.
-      print "Error while archiving artifacts, swallowing this exception to prevent "\
-            +"archive errors from failing the build: ${e}"
-      common.create_jira_issue("RE",
-                               "Artifact Archival Failure: ${env.BUILD_TAG}",
-                               "[${env.BUILD_TAG}|${env.BUILD_URL}]",
-                               ["jenkins", "artifact_archive_fail"])
+      try {
+        print "Error while archiving artifacts, swallowing this exception to prevent "\
+              +"archive errors from failing the build: ${e}"
+        create_jira_issue("RE",
+                          "Artifact Archival Failure: ${env.BUILD_TAG}",
+                          "[${env.BUILD_TAG}|${env.BUILD_URL}]",
+                          ["jenkins", "artifact_archive_fail"])
+      } catch (f){
+        print "Failed to create Jira Issue :( ${f}"
+      }
     }// try
   } // stage
 }


### PR DESCRIPTION
The common. prefix can't be used to call functions from within
common. This commit removes the prefix and also adds an inner
try/catch to stop any other issues like this leaking out to the
build result.

Issue: [RE-1626](https://rpc-openstack.atlassian.net/browse/RE-1626)