### PR TITLE
RE-1503 Add rpc-gating merge trigger job

### DIFF
--- a/job_dsl/rpc_gating_merge_trigger.groovy
+++ b/job_dsl/rpc_gating_merge_trigger.groovy
@@ -1,0 +1,71 @@
+// Can't use env.FOO = {FOO} to transfer JJB vars to groovy
+// as this file won't be templated by JJB.
+// Alternative is to use parameters with JJB vars as the defaults.
+library "rpc-gating@${RPC_GATING_BRANCH}"
+common.globalWraps(){
+
+  // We do not want to trigger any of these
+  // for rpc-gating forks or branches other
+  // than 'master'. So if this is triggered
+  // by anything else, end now.
+  // TODO(odyssey4me):
+  // Remove once RE-1645 is resolved.
+  if (env.RPC_GATING_BRANCH != "master") {
+    print "Triggered by branch ${RPC_GATING_BRANCH} instead of master. Skipping triggers."
+    currentBuild.result = 'SUCCESS'
+    return
+  }
+
+  // Here we define the jobs to execute when a merge happens.
+  // Some are executed in series, and some parallel. We wait
+  // until they are all complete before completing the pipeline.
+
+  List serialJobs = [
+    'Build-Gating-Venv',
+    'Jenkins-Job-Builder'
+  ]
+
+  List parallelJobs = [
+    'Build-Summary-Docker-Build',
+    'Setup-Grafana',
+    'Setup-Graphite',
+    'Setup-Nodepool',
+    'Setup-StatsD'
+  ]
+
+  List jobParameters = [
+    [
+      $class: 'StringParameterValue',
+      name: 'RPC_GATING_BRANCH',
+      value: env.RPC_GATING_BRANCH
+    ]
+  ]
+
+  for (job in serialJobs) {
+    stage(job) {
+      build(
+        job: job,
+        wait: true,
+        parameters: jobParameters
+      ) // build
+    } // stage
+  } // for
+
+  def parallelBuilds = [:]
+
+  // Cannot do for (job in jobNames), see:
+  // https://jenkins.io/doc/pipeline/examples/#parallel-multiple-nodes
+  for (j in parallelJobs) {
+    def job = j
+    parallelBuilds[job] = {
+      build(
+        job: job,
+        wait: true,
+        parameters: jobParameters
+      ) // build
+    } // parallelBuilds
+  } // for
+
+  parallel parallelBuilds
+
+} // globalWraps

--- a/rpc_jobs/build_summary.yml
+++ b/rpc_jobs/build_summary.yml
@@ -1,23 +1,3 @@
-# Trigger a build summary docker image build when a change
-# is merged to rpc-gating master
-- job:
-    name: "Merge-Trigger-Docker-Build"
-    project-type: freestyle
-    scm:
-      - git:
-          url: https://github.com/rcbops/rpc-gating
-          branches:
-           - master
-    properties:
-      - build-discarder:
-          num-to-keep: 30
-    triggers:
-        - github
-    builders:
-      - trigger-builds:
-        - project:
-            - "Build-Summary-Docker-Build"
-
 # Build and publish the build summary docker image
 - job:
     name: 'Build-Summary-Docker-Build'

--- a/rpc_jobs/jjb_setup.yml
+++ b/rpc_jobs/jjb_setup.yml
@@ -1,28 +1,3 @@
-# This job is specified as `freestyle` as using a pipeline job with github
-# trigger causes the job to be triggered irrespective of which branch was
-# pushed to.  Additionally, the environment variables we were trying to use to
-# determine the branch to pushed to were not being passed into the job by the
-# plugins in question.
-# Also, having a separate merge trigger job ensures that JJB still runs on
-# pushes to master, even if the JJB job is used to test an alternative branch.
-- job:
-    name: "Merge-Trigger-JJB"
-    project-type: freestyle
-    scm:
-      - git:
-          url: https://github.com/rcbops/rpc-gating
-          branches:
-           - master
-    properties:
-      - build-discarder:
-          num-to-keep: 30
-    triggers:
-        - github
-    builders:
-      - trigger-builds:
-        - project:
-            - "Jenkins-Job-Builder"
-
 # Node CentOS to ensure the CIT slave is used. If a pub cloud ubuntu slave is used,
 # the Jenkins API won't be reachable.
 - job:

--- a/rpc_jobs/rpc_gating.yml
+++ b/rpc_jobs/rpc_gating.yml
@@ -1,0 +1,20 @@
+- job:
+    name: "Merge-Trigger-rpc-gating"
+    project-type: pipeline
+    concurrent: false
+    properties:
+      - rpc-gating-github
+      - build-discarder:
+          num-to-keep: 30
+    triggers:
+        - github
+    parameters:
+      - rpc_gating_params
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/rcbops/rpc-gating
+            branches:
+              - "${RPC_GATING_BRANCH}"
+            credentials-id: "github_account_rpc_jenkins_svc"
+      script-path: job_dsl/rpc_gating_merge_trigger.groovy

--- a/rpc_jobs/setup_grafana.yml
+++ b/rpc_jobs/setup_grafana.yml
@@ -1,23 +1,3 @@
-# Merge Trigger job for setup grafana.
-# This used to redeploy whenever there are merges to rpc-gating.
-- job:
-    name: "Merge-Trigger-Grafana"
-    project-type: freestyle
-    scm:
-      - git:
-          url: https://github.com/rcbops/rpc-gating
-          branches:
-           - master
-    properties:
-      - build-discarder:
-          num-to-keep: 30
-    triggers:
-        - github
-    builders:
-      - trigger-builds:
-        - project:
-            - "Setup-Grafana"
-
 - job:
     name: Setup-Grafana
     project-type: pipeline

--- a/rpc_jobs/setup_graphite.yml
+++ b/rpc_jobs/setup_graphite.yml
@@ -1,23 +1,3 @@
-# Merge Trigger job for setup graphite.
-# This used to redeploy whenever there are merges to rpc-gating.
-- job:
-    name: "Merge-Trigger-Graphite"
-    project-type: freestyle
-    scm:
-      - git:
-          url: https://github.com/rcbops/rpc-gating
-          branches:
-           - master
-    properties:
-      - build-discarder:
-          num-to-keep: 30
-    triggers:
-        - github
-    builders:
-      - trigger-builds:
-        - project:
-            - "Setup-Graphite"
-
 - job:
     name: Setup-Graphite
     project-type: pipeline

--- a/rpc_jobs/setup_nodepool.yml
+++ b/rpc_jobs/setup_nodepool.yml
@@ -1,26 +1,3 @@
-# Merge Trigger job for setup nodepool.
-# This used to redeploy whenever there are merges to rpc-gating.
-# This ensures that the nodepool/zk cluster is kept updated and that
-# new images are built when there are changes to dib elements or
-# nodepool config.
-- job:
-    name: "Merge-Trigger-Nodepool"
-    project-type: freestyle
-    scm:
-      - git:
-          url: https://github.com/rcbops/rpc-gating
-          branches:
-           - master
-    properties:
-      - build-discarder:
-          num-to-keep: 30
-    triggers:
-        - github
-    builders:
-      - trigger-builds:
-        - project:
-            - "Setup-Nodepool"
-
 - job:
     name: Setup-Nodepool
     project-type: pipeline

--- a/rpc_jobs/setup_statsd.yml
+++ b/rpc_jobs/setup_statsd.yml
@@ -1,23 +1,3 @@
-# Merge Trigger job for setup statsd.
-# This used to redeploy whenever there are merges to rpc-gating.
-- job:
-    name: "Merge-Trigger-StatsD"
-    project-type: freestyle
-    scm:
-      - git:
-          url: https://github.com/rcbops/rpc-gating
-          branches:
-           - master
-    properties:
-      - build-discarder:
-          num-to-keep: 30
-    triggers:
-        - github
-    builders:
-      - trigger-builds:
-        - project:
-            - "Setup-StatsD"
-
 - job:
     name: Setup-StatsD
     project-type: pipeline

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -9,10 +9,8 @@
     scenario:   "functional"
     action:     "test"
     jira_project_key: "RE"
-    trigger_build: "PM_{repo_name}-{branch}-{image}-{scenario}-{action}"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
-      - 'PM-push-trigger_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
 # This job is specified as `freestyle` as using a pipeline job with github
 # trigger causes the job to be triggered irrespective of which branch was

--- a/rpc_jobs/unit/re_unit_tests.yml
+++ b/rpc_jobs/unit/re_unit_tests.yml
@@ -22,6 +22,25 @@
       if(env.ghprbPullId != null){
         env.RPC_GATING_BRANCH="origin/pr/${env.ghprbPullId}/merge"
       }
+
+      // We execute this here so that when a PR is submitted
+      // all the parallel builds below do not have to do their
+      // own request for the venv to be built. This helps reduce
+      // the load on jenkins and gets the job done faster.
+      stage("Build-Gating-Venv") {
+        build(
+          job: "Build-Gating-Venv",
+          wait: true,
+          parameters: [
+            [
+              $class: 'StringParameterValue',
+              name: 'RPC_GATING_BRANCH',
+              value: env.RPC_GATING_BRANCH
+            ]
+          ]
+        ) // build
+      } // stage
+
       parallel ([
         "With Requested Credentials": {
           build(


### PR DESCRIPTION
In order to properly co-ordinate the execution of merge
trigger jobs when commits are merged into rpc-gating,
we create a single merge trigger job which co-ordinates
the others appropriately.

Please see the individual commits for details of each change.

Tested successfully here:
https://rpc.jenkins.cit.rackspace.net/job/Merge-Trigger-rpc-gating/19

Issue: [RE-1503](https://rpc-openstack.atlassian.net/browse/RE-1503)