### PR TITLE
RO-4182 Job Failure Analysis

### DIFF
--- a/gating/common/run_lint.sh
+++ b/gating/common/run_lint.sh
@@ -8,4 +8,4 @@ pip install -c constraints.txt -r requirements.txt
 pip install -c constraints.txt -r test-requirements.txt
 
 export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
-RPC_GATING_LINT_USE_VENV=no ./lint.sh
+./lint.sh

--- a/influx-reports/influx.py
+++ b/influx-reports/influx.py
@@ -219,7 +219,9 @@ def get_downtime(client, build, start, end):
 
 
 def return_time(client, query, delta_seconds=0):
-    """ From an InfluxDB query, fetch
+    """Get first point as time object.
+
+    From an InfluxDB query, fetch
     the first point time, and return a
     python time object. Shift it from
     a few seconds (delta_seconds) if necessary.
@@ -263,8 +265,7 @@ def add_time(client, build, stages, started, leapfiledir, completefiledir):
 
 
 def get_build_data(
-    client, build, leapfrog=False, leapfiledir=None, completefiledir=None
-        ):
+        client, build, leapfrog=False, leapfiledir=None, completefiledir=None):
     if leapfrog:
         # This is the first marker file created and so approximately the start
         start_time = get_mtime("clone.complete", leapfiledir, completefiledir)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,8 @@ python-swiftclient
 python-subunit
 pytz
 PyYAML
-rackspace_monitoring
-rackspace_monitoring_cli
+rackspace-monitoring
+rackspace-monitoring-cli
 rackspaceauth
 shade
 six

--- a/scripts/build_summary/build.py
+++ b/scripts/build_summary/build.py
@@ -20,6 +20,7 @@ class Build(object):
     Represents one RPC-AIO build. Contains functionality for intepreting
     the build.xml, injected_vars and log files.
     """
+
     builds = {}
 
     def __init__(self, build_folder, job_name, build_num):
@@ -32,8 +33,8 @@ class Build(object):
         self.result = self.tree.find('./result').text
         # jenkins uses miliseconds not seconds
         self.timestamp = datetime.datetime.fromtimestamp(
-            float(self.tree.find('startTime').text)/1000)
-        self.duration = float(self.tree.find('duration').text)/1000
+            float(self.tree.find('startTime').text) / 1000)
+        self.duration = float(self.tree.find('duration').text) / 1000
         self.build_folder = build_folder
         self.job_name = job_name
         self.build_num = build_num
@@ -88,7 +89,7 @@ class Build(object):
 
     def get_stage(self):
         for candidate in ['PM', 'PR']:
-            if self.job_name.startswith(candidate+"_"):
+            if self.job_name.startswith(candidate + "_"):
                 return candidate
         else:
             raise Exception("Job stage unknown: {}".format(self.job_name))
@@ -232,7 +233,7 @@ class Build(object):
                     lines = f.readlines()
             except IOError:
                 try:
-                    with gzip.open(log_file+".gz", 'rt') as f:
+                    with gzip.open(log_file + ".gz", 'rt') as f:
                         lines = f.readlines()
                 except IOError:
                     return []

--- a/scripts/build_summary/build_summary_gh.py
+++ b/scripts/build_summary/build_summary_gh.py
@@ -2,13 +2,14 @@
 
 # Stdlib import
 import datetime
+import dateutil.parser
 import functools
 import gc
 import json
 import os
 import re
-import sys
 import traceback
+import uuid
 
 # 3rd Party imports
 import click
@@ -55,11 +56,16 @@ def _datetime(dt):
     return str(dt)
 
 
+@to_serializable.register(uuid.UUID)
+def _uuid(uuid):
+    return str(uuid)
+
+
 def serialise(obj):
-    return json.dumps(obj, default=to_serializable).replace("'", "\'")
+    return json.dumps(obj, default=to_serializable)
 
 
-@click.command(help='args are paths to jenkins build.xml files')
+@click.command(help='arg is a jenkins jobs dir')
 @click.argument('jobsdir')
 @click.option('--newerthan', default=0,
               help='Build IDs older than this will not be shown')
@@ -72,17 +78,17 @@ def summary(jobsdir, newerthan, jsonfile):
     age_limit = (datetime.datetime.now()
                  - datetime.timedelta(days=RETENTION_DAYS))
 
-    data = dict(builds=[])
+    data = dict(builds={})
     # read data from json input file
     if os.path.exists(jsonfile):
         try:
             with open(jsonfile, 'r') as f:
                 data = json.load(f)
         except Exception as e:
-            sys.stderr.write(
+            print(
                 "Failed to read json file: {jsonfile}"
                 .format(jsonfile=jsonfile))
-            traceback.print_exc(file=sys.stderr)
+            traceback.print_exc()
 
     # Current production data.json has some extremely long failure detail
     # fields. This commit includes a change to failure.py to ensure
@@ -90,25 +96,44 @@ def summary(jobsdir, newerthan, jsonfile):
     # on disk, we load and truncate the fields here.
     # At the end of this run, the data file will be rewritten with
     # truncated values, so this fix code will only be needed once.
-    for b in data['builds']:
-        for f in b['failures']:
-            f['detail'] = f['detail'][:1000]
+    if "failures" in data:
+        for id, failure in data['failures'].items():
+                failure['detail'] = failure['detail'][:1000]
 
     # create set of build ids so we don't scan builds
     # we already have summary information about
-    build_dict = {"{jn}_{bn}".format(jn=b['job_name'], bn=b['build_num']):
-                  b for b in data['builds']}
+    if "builds" in data:
+        build_dict = {"{jn}_{bn}".format(jn=b['job_name'], bn=b['build_num']):
+                      b for b in data['builds'].values()}
+    else:
+        build_dict = {}
+
+    # These dicts store builds and failures read in from
+    # the input json file that will also be written
+    # to the output json file.
+    cached_builds = {}
+    cached_failures = {}
 
     # walk the supplied dir, scan new builds
-    for count, build in enumerate(["{}/build.xml".format(root)
-                                  for root, dirs, files
-                                  in os.walk(jobsdir)
-                                  if "build.xml" in files
-                                  and ("PM_" in root or "PR_" in root)]):
+    parse_failures = 0
+    build_files = list(enumerate(["{}/build.xml".format(root)
+                       for root, dirs, files
+                       in os.walk(jobsdir)
+                       if "build.xml" in files
+                       and ("PM_" in root or "PR_" in root)]))
+    for count, build in build_files:
         path_groups_match = re.search(
-            ('^(?P<build_folder>.*/(?P<job_name>[^/]+)/'
-             'builds/(?P<build_num>[0-9]+))/'), build)
+                ('^(?P<build_folder>.*/(?P<job_name>[^/]+)/'
+                 'builds/(?P<build_num>[0-9]+))/'), build)
         if path_groups_match:
+            if (count % 100 == 0):
+                gc.collect()
+                total = len(build_files)
+                print("{}/{} ({:.2f} %)".format(
+                    count,
+                    total,
+                    float(count/total) * 100
+                ))
             path_groups = path_groups_match.groupdict()
             job_name = path_groups['job_name']
             build_num = path_groups['build_num']
@@ -117,7 +142,27 @@ def summary(jobsdir, newerthan, jsonfile):
                 build_num=build_num
             )
             if key in build_dict:
-                continue
+                try:
+                    # build already cached, don't need to rescan
+                    # But we do need to ensure that the cached data is age
+                    # checked and added to a dict of cached items to be
+                    # written out at the end.
+                    b = build_dict[key]
+                    if dateutil.parser.parse(b["timestamp"]) > age_limit:
+                        cached_builds[b["id"]] = build_dict[key]
+                        # ensure all referenced failures are also stored
+                        for failure_id in b["failures"]:
+                            print("f", end="")
+                            f = data["failures"][failure_id]
+                            cached_failures[f["id"]] = f
+                    print("c", end="")
+                    continue
+                except Exception as e:
+                    # failed to process cache, read the build log
+                    # as if it wasn't cached.
+                    # ! = cache read failure
+                    print("cache failure: " + str(e))
+                    print("!", end="")
             try:
                 build = Build(
                     build_folder=path_groups['build_folder'],
@@ -129,44 +174,99 @@ def summary(jobsdir, newerthan, jsonfile):
                         build.log_lines = build.read_logs()
                         Failure.scan_build(build)
                         build.log_lines = []
-                        if (count % 25 == 0):
-                            gc.collect()
                     build_dict[key] = build
-                    sys.stderr.write(".")
-                    # sys.stderr.write("OK: {key}\n".format(key=key))
+                    # . = build read ok
+                    print(".", end="")
+                    # print("OK: {key}\n".format(key=key))
                 else:
-                    sys.stderr.write("_")
-                    # sys.stderr.write("Old Build: {key}\n" .format(key=key))
+                    # o = old
+                    print("o", end="")
+                    # print("Old Build: {key}\n" .format(key=key))
             except lxml.etree.XMLSyntaxError as e:
-                sys.stderr.write("\nFAIL: {key} {e}\n".format(key=key, e=e))
+                print("\nFAIL: {key} {e}\n".format(key=key, e=e))
+                parse_failures += 1
             except Exception as e:
-                sys.stderr.write("\nFAIL: {key} {e}\n".format(key=key, e=e))
+                parse_failures += 1
+                print("\nFAIL: {key} {e}\n".format(key=key, e=e))
                 if ("can't parse internal" not in str(e)):
-                    traceback.print_exc(file=sys.stderr)
+                    traceback.print_exc()
+
+    print("\nbuilds: {} failures: {}".format(len(build_dict.keys()),
+                                             parse_failures))
 
     # dump data out to json file
     # remove builds older than RETENTION_DAYS
     # ensure we only dump data newer than RETENTION_DAYS
 
     with open(jsonfile, "w") as f:
-        f.write(serialise(dict(
-            builds=build_dict.values(),
+
+        cache_dict = dict(
+            builds={id: build for id, build in Build.builds.items()
+                    if build.timestamp > age_limit},
+            failures={id: f for id, f in Failure.failures.items()
+                      if f.build.timestamp > age_limit},
             timestamp=datetime.datetime.now(),
             retention_days=RETENTION_DAYS
-        )))
+        )
+        # debug statements for combining previously cached
+        # builds and failures with builds and failures
+        # detected on this run
+        print("\nNew Builds: {lcdb}"
+              "\nNew Failures: {lcdf}"
+              "\nBuilds carried forward: {lcb}"
+              "\nFailures carried forward: {lcf}"
+              .format(lcdb=len(cache_dict["builds"]),
+                      lcdf=len(cache_dict["failures"]),
+                      lcb=len(cached_builds),
+                      lcf=len(cached_failures)))
 
-    #
-    # Pickle build objs newer than RETENTION_DAYS to the cache file, so those
-    # logs don't need to be reprocessed on the next run.
-    # cache_dict = {}
-    # for key, build in buildobjs.items():
-    #     if build.timestamp > age_limit:
-    #         cache_dict[key] = build
-    #         # don't cache log_lines as the cache size would get unmanagably
-    #         # large
-    #         build.log_lines = []
-    # with open(cache, 'wb') as f:
-    #     pickle.dump(cache_dict, f, pickle.HIGHEST_PROTOCOL)
+        cache_dict["builds"].update(cached_builds)
+        cache_dict["failures"].update(cached_failures)
+
+        # convert objects to dicts for storage, this would be done
+        # by serialise() but its easier to do the integrity
+        # check when all the values are of the same type.
+        for id, build in cache_dict["builds"].items():
+            if type(build) is not dict:
+                cache_dict["builds"][id] = build.get_serialisation_dict()
+        for id, failure in cache_dict["failures"].items():
+            if type(failure) is not dict:
+                cache_dict["failures"][id] = failure.get_serialisation_dict()
+
+        def build_integrity_fail(id):
+            print("Integrity fail for build: {}".format(id))
+            del cache_dict["builds"][id]
+
+        def failure_integrity_fail(id):
+            print("Integrity fail for failure: {}".format(id))
+            del cache_dict["failures"][id]
+
+        # integrity check
+        # its important the data set is consistent as the
+        # UI assumes consistency. Its better to remove a few
+        # inconsistent items than have the whole UI die.
+        for id, build in cache_dict["builds"].copy().items():
+            try:
+                if build["id"] != id:
+                    build_integrity_fail(id)
+                for failure in build["failures"]:
+                    if failure not in cache_dict["failures"]:
+                        build_integrity_fail(id)
+                        break
+            except Exception as e:
+                    print("Build integrity exception: "+str(e))
+                    build_integrity_fail(id)
+
+        for id, failure in cache_dict["failures"].copy().items():
+            try:
+                if (failure["id"] != id
+                        or failure["build"] not in cache_dict["builds"]):
+                    failure_integrity_fail(id)
+            except Exception:
+                    failure_integrity_fail(id)
+
+        cache_string = serialise(cache_dict)
+        f.write(cache_string)
 
 
 if __name__ == '__main__':

--- a/scripts/build_summary/build_summary_gh.py
+++ b/scripts/build_summary/build_summary_gh.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 # Stdlib import
 import datetime
@@ -123,8 +124,8 @@ def summary(jobsdir, newerthan, jsonfile):
                        and ("PM_" in root or "PR_" in root)]))
     for count, build in build_files:
         path_groups_match = re.search(
-                ('^(?P<build_folder>.*/(?P<job_name>[^/]+)/'
-                 'builds/(?P<build_num>[0-9]+))/'), build)
+            ('^(?P<build_folder>.*/(?P<job_name>[^/]+)/'
+             'builds/(?P<build_num>[0-9]+))/'), build)
         if path_groups_match:
             if (count % 100 == 0):
                 gc.collect()
@@ -132,7 +133,7 @@ def summary(jobsdir, newerthan, jsonfile):
                 print("{}/{} ({:.2f} %)".format(
                     count,
                     total,
-                    float(count/total) * 100
+                    float(count / total) * 100
                 ))
             path_groups = path_groups_match.groupdict()
             job_name = path_groups['job_name']
@@ -254,7 +255,7 @@ def summary(jobsdir, newerthan, jsonfile):
                         build_integrity_fail(id)
                         break
             except Exception as e:
-                    print("Build integrity exception: "+str(e))
+                    print("Build integrity exception: " + str(e))
                     build_integrity_fail(id)
 
         for id, failure in cache_dict["failures"].copy().items():

--- a/scripts/build_summary/components.js
+++ b/scripts/build_summary/components.js
@@ -1,0 +1,901 @@
+titleCard = Vue.component("titleCard",{
+  props: {
+    "title":{},
+    "link": {default: ''}
+  },
+  template: `
+    <v-card>
+      <v-card-title primary-title v-if="title.length > 0">
+        <h3 v-if="this.link == ''">{{this.title}}</h3>
+        <a v-else :href="this.link"><h3>{{this.title}}</h3></a>
+      </v-card-title>
+      <v-card-text>
+        <slot></slot>
+      </v-card-text>
+    </v-card>
+  `
+})
+
+trendGraph = Vue.component("trendGraph",{
+  props: ["title", "chart"],
+  template: `
+    <v-card>
+      <v-card-title primary-title v-if="title.length > 0">
+        <h3>{{this.title}}</h3>
+      </v-card-title>
+      <v-card-text>
+        <canvas height="50px" class="chart"></canvas>
+      </v-card-text>
+    </v-card>
+  `,
+  methods: {
+    draw: function(){
+      var ctx = this.$el.querySelector(".chart").getContext('2d')
+      var chart = new Chart(ctx, this.chart)
+    }
+  },
+  mounted: function(){ this.draw() },
+})
+
+// durationScatter = Vue.component("durationScatter",{
+//     props: {
+//       builds: {},
+//       title: {}
+//     },
+//     computed: {
+//       chart: function(){
+//         return {
+//           type: 'scatter',
+//           data: {
+//             labels: this.$root.labels,
+//             datasets: this.datasets,
+//           },
+//           options: this.$root.stackedOptions
+//         }
+//       },
+//       datasets: function(){
+//         var failuresByCategory = this.$root.failuresByCategory(this.builds)
+//         var colours = this.$root.colours(failuresByCategory.length + 1)
+//         var ds = failuresByCategory.reduce((a,c,i)=>{
+//           a.push({
+//             label: c[1],
+//             // ensure success is always green
+//             //backgroundColor: c == "Success" ? colours[0] : colours[(i+1)%(colours.length-1)],
+//             backgroundColor: colours[i],
+//             data: this.$root.histogram(
+//               c[2].map(f => f.build),
+//               this.$root.retention_days,
+//               1
+//             )
+//           }); return a
+//         },[])
+//         return ds.filter(this.dsFilter)
+//       },
+//     },
+//     template: `
+//       <trendGraph
+//         :title="this.title"
+//         :chart="this.chart"
+//       ></trendGraph>
+//     `
+// })
+
+failureTypesTrend = Vue.component("failureTypesTrend",{
+  props: {
+    "builds":{},
+    "title": {},
+    "topN": {default: 5},
+    "dsFilter": {
+      default: function(){
+        return function(item){
+          return true
+        }
+      }
+    }
+  },
+  template: `
+    <trendGraph
+      :title="this.title"
+      :chart="this.chart">
+    </trendGraph>
+  `,
+  computed: {
+    chart: function(){
+      return {
+        type: 'bar',
+        data: {
+          labels: this.$root.labels,
+          datasets: this.datasets,
+        },
+        options: this.$root.stackedOptions
+      }
+    },
+    topFailureTypes: function(){
+      return this.$root.failuresByType(this.builds)
+        .slice(0,this.topN)
+        .map(l => [l[0], l[1], l[2].map(f => f.build)])
+      },
+    datasets: function(){
+      var colours = this.$root.colours(this.topFailureTypes.length + 1)
+      var ds = this.topFailureTypes.reduce((a,c,i)=>{
+        a.push({
+          label: c[1],
+          // ensure success is always green
+          //backgroundColor: c[1] == "Success" ? colours[0] : colours[(i+1)%(colours.length-1)],
+          backgroundColor: colours[i],
+          data: this.$root.histogram(
+            c[2],
+            this.$root.retention_days,
+            1
+          )
+        }); return a
+      },[])
+      var filtered = ds.filter(this.dsFilter)
+      return filtered
+    },
+  }
+
+})
+failureCategoriesTrend = Vue.component("failureCategoriesTrend",{
+  props: {
+    "builds": {},
+    "title": {},
+    "dsFilter": {
+      default: function(){
+        return function(item){
+          return true
+        }
+      }
+    }
+  },
+  template: `
+    <trendGraph
+      :title="this.title"
+      :chart="this.chart"></trendGraph>
+  `,
+  computed: {
+    chart: function(){
+      return {
+        type: 'line',
+        data: {
+          labels: this.$root.labels,
+          datasets: this.datasets,
+        },
+        options: this.$root.stackedOptions
+      }
+    },
+    datasets: function(){
+      var failuresByCategory = this.$root.failuresByCategory(this.builds)
+      var colours = this.$root.colours(failuresByCategory.length + 1)
+      var ds = failuresByCategory.reduce((a,c,i)=>{
+        a.push({
+          label: c[1],
+          // ensure success is always green
+          //backgroundColor: c == "Success" ? colours[0] : colours[(i+1)%(colours.length-1)],
+          backgroundColor: colours[i],
+          data: this.$root.histogram(
+            c[2].map(f => f.build),
+            this.$root.retention_days,
+            1
+          )
+        }); return a
+      },[])
+      return ds.filter(this.dsFilter)
+    },
+  }
+})
+
+repoTable = Vue.component("repoTable",{
+  data: function(){
+    d = {search: ''}
+    d.headers=[{text:"Repository", value: "name"},
+               {text: "Number of Builds", value:"numBuilds"},
+               {text: "Failure %", value: "failPercent"},
+               {text: "Most Failing Job", value: "mostFailingJob"},
+               {text: "Most Failing Branch", value: "mostFailingBranch"},
+               {text: "Top Failure Type", value: "topFailureType"}]
+    d.pagination = {
+      sortBy: 'failPercent',
+      descending: true
+    }
+    d.rowsperpage = [5,15,25,50,100,{text:"All",value:-1}]
+    d.items = []
+    Object.values(this.$root.repos).forEach(r => {
+      var builds = r[2]
+      var ro = {name: r[1],
+                numBuilds: builds.length,
+                mostFailingJob: ' ',
+                mostFailingBranch: ' ',
+                topFailureType: ' ',
+                failPercent: 0}
+      var buildFailures = builds.filter(b => b.result != "SUCCESS")
+      var failCount = buildFailures.length
+      ro.failPercent = ((failCount/ro.numBuilds)*100).toFixed(0)
+      mostFailingJob = buildFailures.countBy("job_name")[0]
+      ro.mostFailingJob = mostFailingJob[1]
+      ro.mostFailingJobCount = mostFailingJob[0]
+      mostFailingBranch = buildFailures.countBy("branch")[0]
+      ro.mostFailingBranch = mostFailingBranch[1]
+      ro.mostFailingBranchCount = mostFailingBranch[0]
+      topFailureType = this.$root.failuresByType(builds)[0]
+      ro.topFailureType = topFailureType[1]
+      ro.topFailureTypeCount = topFailureType[0]
+      d.items.push(ro)
+    })
+    return d
+  },
+  template: `
+    <div>
+      <v-card>
+        <v-card-title primary-title>
+          <h3>Repository Overview</h3>
+          <v-spacer></v-spacer>
+          <v-text-field
+            v-model="search"
+            append-icon="search"
+            label="Search"
+            single-line
+            hide-details></v-text-field>
+        </v-card-title>
+        <v-card-text>
+          <v-data-table
+            :headers="headers"
+            :items="items"
+            :pagination.sync=pagination
+            :rows-per-page-items="rowsperpage"
+            :search="search">
+            <template slot="items" slot-scope="props">
+              <td><router-link :to="'/repo/'+props.item.name">{{props.item.name}}</router-link></td>
+              <td>{{props.item.numBuilds}}</td>
+              <td :style="'background-color:'+$root.failColour(props.item.failPercent/100)+';'">{{props.item.failPercent}}</td>
+              <td>
+                <router-link :to="'/job/'+props.item.mostFailingJob">{{props.item.mostFailingJob}}</router-link>
+                ({{props.item.mostFailingJobCount}})
+              </td>
+              <td>{{props.item.mostFailingBranch}} ({{props.item.mostFailingBranchCount}})</td>
+              <td><router-link :to="'/ftype/'+props.item.topFailureType">{{props.item.topFailureType}}</router-link> ({{props.item.topFailureTypeCount}})</td>
+            </template>
+          </v-data-table>
+        </v-card-text>
+      </v-card>
+    </div>
+  `
+})
+resultTrendGraph = Vue.component("resultTrendGraph", {
+  props: ["builds", "title"],
+  computed: {
+    success: function(){
+      return this.$root.histogram(
+        this.builds.filter(b => b.result == "SUCCESS"), this.$root.retention_days, 1)
+    },
+    failurepr: function(){
+      return this.$root.histogram(
+        this.builds.filter(b => b.result != "SUCCESS" && b.stage == "PR"), this.$root.retention_days, 1)
+    },
+    failurepm: function(){
+      return this.$root.histogram(
+        this.builds.filter(b => b.result != "SUCCESS" && b.stage == "PM"), this.$root.retention_days, 1)
+    },
+    chart: function(){
+      return {
+        type: 'bar',
+        data: {
+          labels: this.$root.labels,
+          datasets: [
+            {
+              label: "Periodic Failures",
+              backgroundColor: 'rgba(237, 134, 134, 0.39)',
+              data: this.failurepm
+            },
+            {
+              label: "PR Failures",
+              backgroundColor: 'rgba(237, 186, 134, 0.39)',
+              data: this.failurepr
+            },
+            {
+              label: "Success",
+              backgroundColor: 'rgba(134, 237, 134, 0.39)',
+              data: this.success
+            }
+          ]
+        },
+        options: this.$root.stackedOptions,
+      }
+    }
+  },
+  template: `
+    <trendGraph
+      :title="this.title"
+      :chart="this.chart">
+    </trendGraph>
+  `
+})
+
+trendGraphs = Vue.component("trendGraphs",{
+  props: ["builds"],
+  template: `
+    <v-tabs>
+      <v-tab>Builds by Result</v-tab>
+      <v-tab>Failures by Category</v-tab>
+      <v-tab>Top 5 Failure Types</v-tab>
+      <v-tab-item>
+        <resultTrendGraph
+          title=""
+          :builds="this.builds"></resultTrendGraph>
+      </v-tab-item>
+      <v-tab-item>
+        <failureCategoriesTrend
+          title=""
+          :builds="this.builds"></failureCategoriesTrend>
+      </v-tab-item>
+      <v-tab-item>
+        <failureTypesTrend
+          title=""
+          :builds="this.builds">
+        </failureTypesTrend>
+      </v-tab-item>
+
+    </v-tabs>
+  `
+})
+
+buildTable = Vue.component("buildTable",{
+  props: ['buildsOrFilter', 'title'],
+  computed: {
+    builds: function(){
+      if (typeof this.buildsOrFilter == 'function'){
+        // its a filter funciton, use it to filter builds
+        return Object.values(this.$root.builds).filter(b => filterfunc(b))
+      } else {
+        // its already a list of builds, return it
+        return this.buildsOrFilter
+      }
+    },
+    items: function(){
+      // pull all useful text out of a build object
+      // this is used with methods/filter to search
+      // as the default search won't look into
+      // nested structures
+      return this.builds.reduce((a,c)=> {
+        c.searchText= [
+          c.result,
+          c.timestamp,
+          c.branch,
+          ...c.build_hierachy.map(b => b.name),
+          ...c.build_hierachy.map(b => b.build_num),
+          ...c.failures.map(f => f.category),
+          ...c.failures.map(f => f.description),
+          ...c.failures.map(f => f.detail),
+          ...c.failures.map(f => f.type),
+        ].join(" ").toLowerCase()
+        a.push(c)
+        return a
+      },[])
+    }
+  },
+  methods: {
+    filter: function(items, search, filter){
+      return items.filter(i =>
+        i.searchText.indexOf(search.toLowerCase())>=0)
+    }
+  },
+  data: function(){
+      return {
+        headers: [
+          {text: "Result", value: "result"},
+          {text: "Date", value: "timestamp"},
+          {text: "Branch", value: "branch"},
+          {text: "Job Tree", value: "build_hierachy", sortable: false},
+          {text: "Failures", value: "failures", sortable: false}
+        ],
+        search: '',
+        rowsperpage: [5,15,25,50,{text: "All", value: -1}],
+        pagination: {
+          sortBy: 'timestamp',
+          descending: true
+        }
+      }
+  },
+  template: `
+    <v-card>
+      <v-card-title primary-title>
+        <h3>{{title}}</h3>
+        <v-spacer></v-spacer>
+        <v-text-field
+          v-model="search"
+          append-icon="search"
+          label="Search"
+          single-line
+          hide-details></v-text-field>
+      </v-card-title>
+      <v-card-text>
+        <v-data-table
+          :headers="headers"
+          :items="items"
+          :rows-per-page-items="rowsperpage"
+          :search="search"
+          :custom-filter="filter"
+          :pagination.sync="pagination">
+          <template slot="items" slot-scope="props">
+            <tr :style="props.item.result == 'SUCCESS' ? '' : 'background-color: rgba(237, 134, 134, 0.39);'">
+              <td>
+                <p>
+                {{props.item.result}}</p>
+              </td>
+              <td>
+                <dateCell :date="props.item.timestamp"></dateCell>
+              </td>
+              <td>
+                {{props.item.branch}}
+              </td>
+              <td>
+                <!-- job tree
+                  Suppress link when url is # (usually for cron trigger)
+                  special case jobs so that links within build summary
+                  are used for the job name and a link to jenkins is
+                  used for the build number.
+                -->
+                <ul>
+                  <li :key="parent.url" v-for="parent in props.item.build_hierachy">
+                    <span v-if="parent.url != '#'">
+                      <router-link
+                        v-if="parent.url.includes('/job/')"
+                        :to="'/job/'+parent.name">
+                          {{parent.name}}
+                      </router-link>
+                      <a v-else :href="parent.url">{{parent.name}}</a>
+                      <a :href="parent.url">{{parent.build_num}}</a>
+                    </span>
+                    <span v-else>{{parent.name}} {{parent.build_num}}</span>
+                  </li>
+                </ul>
+              </td>
+              <td>
+                <!-- failures -->
+                <ul>
+                  <li :key="failure.id" v-for="failure in props.item.failures">
+                    <router-link :to="'/ftype/'+failure.type">{{failure.type}}</router-link>
+                    {{failure.detail}}
+                    <router-link :to="'/fcat/'+failure.category">{{failure.category}}</router-link>
+                  </li>
+                </ul>
+              </td>
+            </tr>
+          </template>
+        </v-data-table>
+      </v-card-text>
+    </v-card>
+  `
+})
+
+
+
+jobTable = Vue.component("jobTable",{
+  props: {
+    'builds':{},
+    'title':{},
+    'sort': {
+      default: function(){
+        return {
+          sortBy: 'failPercent',
+          descending: true
+        }
+      }
+    },
+    'showFailurePercent':{
+      default: true
+    },
+    'showTopFailureType':{
+      default: true
+    }
+  },
+  computed: {
+    // builds: function(){
+    //   return this.$root.repos[this.repo.name].jobs
+    // },
+    items: function(){
+      return this.builds.countBy("job_name").reduce((a,c) => {
+      //return Object.values(this.jobs).reduce((a,c) => {
+        var builds = c[2]
+        var name = c[1]
+        var numBuilds = builds.length
+        var numFailedBuilds = builds.filter(b => b.result != "SUCCESS").length
+        var oldestNewest = this.$root.oldestNewestBuilds(builds)
+        a.push({
+          jobName: name,
+          numBuilds: numBuilds,
+          oldest: this.$root.dfmt(oldestNewest.oldest.timestamp),
+          newest: this.$root.dfmt(oldestNewest.newest.timestamp),
+          failPercent: ((numFailedBuilds/numBuilds)*100).toFixed(0),
+          topFailureType: this.$root.failuresByType(builds)[0][1]
+        })
+        return a
+      }, [])
+    }
+  },
+  data: function(){
+      var d =  {
+        headers: [
+          {text: "Job", value: "jobName"},
+          {text: "Number of Builds", value: "numBuilds"},
+          {text: "Oldest Build", value: "oldest"},
+          {text: "Newest Build", value: "newest"}
+        ],
+        search: '',
+        rowsperpage: [5,10,25,50,{text: "All", value: -1}],
+        pagination: this.sort,
+      }
+    if(this.showFailurePercent){
+      d.headers.push({text: "Failure %", value: "failPercent"})
+    }
+    if(this.showTopFailureType){
+      d.headers.push({text: "Top Failure Type", value: "topFailureType"})
+    }
+    return d
+  },
+  template: `
+    <v-card>
+      <v-card-title primary-title>
+        <h3>{{title}}</h3>
+        <v-spacer></v-spacer>
+        <v-text-field
+          v-model="search"
+          append-icon="search"
+          label="Search"
+          single-line
+          hide-details></v-text-field>
+      </v-card-title>
+      <v-card-text>
+        <v-data-table
+          :headers="headers"
+          :items="items"
+          :rows-per-page-items="rowsperpage"
+          :search="search"
+          :pagination.sync="pagination">
+          <template slot="items" slot-scope="props">
+              <td>
+                <router-link :to="'/job/'+props.item.jobName">{{props.item.jobName}}</router-link>
+              </td>
+              <td>
+                {{props.item.numBuilds}}
+              </td>
+              <td>
+                <dateCell :date="props.item.oldest"></dateCell>
+              </td>
+              <td>
+                <dateCell :date="props.item.newest"></dateCell>
+              </td>
+              <td v-if="showFailurePercent" :style="'background-color:'+$root.failColour(props.item.failPercent/100)+';'">
+                {{props.item.failPercent}}
+              </td>
+              <td v-if="showTopFailureType">
+                <router-link :to="'/ftype/'+props.item.topFailureType">
+                  {{props.item.topFailureType}}
+                </router-link>
+              </td>
+          </template>
+        </v-data-table>
+      </v-card-text>
+    </v-card>
+  `
+})
+
+failureTables = Vue.component("failureTables",{
+  props: {
+    "builds": {},
+    "showTopJobs": {
+        default: true
+    }
+  },
+  template: `
+    <v-tabs>
+      <v-tab>Failures by Type</v-tab>
+      <v-tab>Failures by Category</v-tab>
+      <v-tab-item>
+        <failureTable
+          :builds="this.builds"
+          title=""
+          :showTopJobs="this.showTopJobs">
+        </failureTable>
+      </v-tab-item>
+      <v-tab-item>
+        <failureCategoryTable
+          :builds="this.builds"
+          title=""
+          :showTopJobs="this.showTopJobs">
+        </failureCategoryTable>
+      </v-tab-item>
+    </v-tabs>
+  `
+})
+
+failureCategoryTable = Vue.component("failureCategoryTable", {
+  props: {
+    builds: {},
+    title: {},
+    numTopJobs: {
+      default: 3
+    },
+    showTopJobs: {
+      default: true
+    },
+    numTopTypes: {
+      default: 3
+    }
+  },
+  computed: {
+    items: function(){
+      // count all the builds passed in, used for % calculation
+      var totalBuilds = Object.values(this.builds).length
+      // builds by failure type
+      var failuresByCategory = this.$root.failuresByCategory(Object.values(this.builds))
+      return failuresByCategory.reduce((a,c) => {
+        // list of builds for this type
+        var category = c[1]
+        var categoryBuilds = c[2].map(f => f.build)
+        var categoryFailures = c[2]
+        var oldestNewest = this.$root.oldestNewestBuilds(categoryBuilds)
+        a.push({
+          failureCategory: category,
+          // in order to find out which category this failure is associated with
+          // first get all the failure objects, then find one of the same
+          // Category, then read its category.
+          failureCategory: categoryFailures[0].category,
+          failureOccurences: categoryBuilds.length,
+          failurePercent: ((categoryBuilds.length/totalBuilds)*100).toFixed(0),
+          oldest: oldestNewest.oldest.timestamp,
+          newest: oldestNewest.newest.timestamp,
+          topJobs: categoryBuilds.countBy("job_name").slice(0,this.numTopJobs),
+          topFailureTypes: this.$root.failuresByType(categoryBuilds).slice(0,this.numTopTypes)
+        })
+        return a
+      }, [])
+    }
+  },
+  data: function(){
+      var d = {
+        headers: [
+          {text: "Category", value: "failureCategory"},
+          {text: "Occurences", value: "failureOccurences"},
+          {text: "Percentage of Builds", value: "failurePercent"},
+          {text: "Oldest Occurence", value: "oldest"},
+          {text: "Newest Occurence", value: "newest"},
+          {text: "Top Failure Types", value: "topFailureTypes"},
+        ],
+        search: '',
+        rowsperpage: [5,10,25,50,{text: "All", value: -1}],
+        pagination: {
+          sortBy: 'failureOccurences',
+          descending: true
+        },
+      }
+      if (this.showTopJobs){
+        d.headers.push({text: "Top Jobs", value: "topJobs"})
+      }
+      return d
+  },
+  template: `
+    <v-card>
+      <v-card-title primary-title>
+        <h3>{{title}}</h3>
+        <v-spacer></v-spacer>
+        <v-text-field
+          v-model="search"
+          append-icon="search"
+          label="Search"
+          single-line
+          hide-details></v-text-field>
+      </v-card-title>
+      <v-card-text>
+        <v-data-table
+          :headers="headers"
+          :items="items"
+          :rows-per-page-items="rowsperpage"
+          :search="search"
+          :pagination.sync="pagination">
+          <template slot="items" slot-scope="props">
+              <td>
+                  <router-link :to="'/fcat/'+props.item.failureCategory">{{props.item.failureCategory}}</router-link>
+              </td>
+              <td>
+                {{props.item.failureOccurences}}
+              </td>
+              <td :style="'background-color:'+$root.failColour(props.item.failurePercent/100)+';'">
+                {{props.item.failurePercent}}
+              </td>
+              <td>
+                <dateCell :date="props.item.oldest"></dateCell>
+              </td>
+              <td>
+                <dateCell :date="props.item.newest"></dateCell>
+              </td>
+              <td>
+                <ul>
+                  <li v-for="type in props.item.topFailureTypes" :key="type[1]">
+                    <router-link :to="'/ftype/'+type[1]">{{type[1]}}</router-link> ({{type[0]}})
+                  </li>
+                </ul>
+              </td>
+              <td v-if="showTopJobs">
+                <ul>
+                  <li v-for="job in props.item.topJobs" :key="job[1]">
+                    <router-link :to="'/job/'+job[1]">{{job[1]}}</router-link> ({{job[0]}})
+                  </li>
+                </ul>
+              </td>
+          </template>
+        </v-data-table>
+      </v-card-text>
+    </v-card>
+  `
+})
+failureTable = Vue.component("failureTable",{
+  props: {
+    'builds':{},
+    'title':{},
+    'numTopJobs': {
+      default: 3
+    },
+    'showTopJobs': {
+      default: true
+    },
+    'showCategory': {
+      default: false
+    }
+  },
+  computed: {
+    items: function(){
+      // count all the builds passed in, used for % calculation
+      var totalBuilds = Object.values(this.builds).length
+      // builds by failure type
+      var failuresByType = this.$root.failuresByType(Object.values(this.builds))
+      return failuresByType.reduce((a,c) => {
+        // list of builds for this type
+        var type = c[1]
+        var typeBuilds = c[2].map(f => f.build)
+        var typeFailures = c[2]
+        var oldestNewest = this.$root.oldestNewestBuilds(typeBuilds)
+        a.push({
+          failureType: type,
+          // in order to find out which category this failure is associated with
+          // first get all the failure objects, then find one of the same
+          // type, then read its category.
+          failureCategory: typeFailures[0].category,
+          failureOccurences: typeBuilds.length,
+          failurePercent: ((typeBuilds.length/totalBuilds)*100).toFixed(0),
+          oldest: oldestNewest.oldest.timestamp,
+          newest: oldestNewest.newest.timestamp,
+          topJobs: typeBuilds.countBy("job_name").slice(0,this.numTopJobs),
+        })
+        return a
+      }, [])
+    }
+  },
+  data: function(){
+      var d = {
+        headers: [
+          {text: "Type", value: "failureType"},
+          {text: "Occurences", value: "failureOccurences"},
+          {text: "Percentage of Builds", value: "failurePercent"},
+          {text: "Oldest Occurence", value: "oldest"},
+          {text: "Newest Occurence", value: "newest"},
+        ],
+        search: '',
+        rowsperpage: [5,10,25,50,{text: "All", value: -1}],
+        pagination: {
+          sortBy: 'failureOccurences',
+          descending: true
+        },
+      }
+      if (this.showTopJobs){
+        d.headers.push({text: "Top Jobs", value: "topJobs"})
+      }
+      if(this.showCategory){
+        // insert category header at index 1
+        d.headers = [d.headers[0],
+                     {text: "Category", value: "failureCategory"},
+                     ...d.headers.slice(1)]
+      }
+      return d
+  },
+  template: `
+    <v-card>
+      <v-card-title primary-title>
+        <h3>{{title}}</h3>
+        <v-spacer></v-spacer>
+        <v-text-field
+          v-model="search"
+          append-icon="search"
+          label="Search"
+          single-line
+          hide-details></v-text-field>
+      </v-card-title>
+      <v-card-text>
+        <v-data-table
+          :headers="headers"
+          :items="items"
+          :rows-per-page-items="rowsperpage"
+          :search="search"
+          :pagination.sync="pagination">
+          <template slot="items" slot-scope="props">
+              <td>
+                <v-tooltip bottom>
+                  <router-link slot="activator" :to="'/ftype/'+props.item.failureType">{{props.item.failureType}}</router-link>
+                  <span>Category: {{props.item.failureCategory}}</span>
+                </v-tooltip>
+              </td>
+              <td v-if="showCategory">
+                <router-link :to="'/fcat/'+props.item.failureCategory">{{props.item.failureCategory}}</router-link>
+              </td>
+              <td>
+                {{props.item.failureOccurences}}
+              </td>
+              <td :style="'background-color:'+$root.failColour(props.item.failurePercent/100)+';'">
+                {{props.item.failurePercent}}
+              </td>
+              <td>
+                <dateCell :date="props.item.oldest"></dateCell>
+              </td>
+              <td>
+                <dateCell :date="props.item.newest"></dateCell>
+              </td>
+              <td v-if="showTopJobs">
+                <ul>
+                  <li v-for="job in props.item.topJobs" :key="job[1]">
+                    <router-link :to="'/job/'+job[1]">{{job[1]}}</router-link> ({{job[0]}})
+                  </li>
+                </ul>
+              </td>
+          </template>
+        </v-data-table>
+      </v-card-text>
+    </v-card>
+  `
+})
+
+dateCell = Vue.component("dateCell",{
+  props: ["date"],
+  computed: {
+    _date: function(){
+      var d = new Date(this.date)
+      return d
+    }
+  },
+  template: `
+    <v-tooltip bottom>
+      <span slot="activator">{{$root.dfmt(date)}}</span>
+      <span>{{_date.toRelativeString()}} 🕰 {{_date.toLocaleDateString()}} {{_date.toLocaleTimeString()}} </span>
+    </v-tooltip>
+  `
+})
+
+toolbarmenu = Vue.component("toolbarmenu",{
+  props: {
+    title: {},
+    counteditems: {}, // takes result from builds.countBy()
+    urlbase: {},
+  },
+  computed: {
+    items: function(){
+      return this.counteditems.reduce((a,c) => {
+        a.push({
+          title: c[1],
+          url: '/'+this.urlbase+'/'+c[1]
+        })
+        return a
+      },[])
+    }
+  },
+  template: `
+    <v-menu v-if="this.$root.dataloaded">
+      <v-btn flat slot="activator">{{title}}</v-btn>
+      <v-list>
+        <v-list-tile v-for="item in items" :key="item.url">
+          <v-list-tile-title>
+            <router-link :to="item.url">{{item.title}}</router-link>
+          </v-list-tile-title>
+        </v-list-tile>
+      </v-list>
+    </v-menu>
+  `
+})

--- a/scripts/build_summary/constraints.txt
+++ b/scripts/build_summary/constraints.txt
@@ -1,4 +1,5 @@
 click==6.7
+python-dateutil==2.6.0
 humanize==0.5.1
 Jinja2==2.10
 lxml==4.2.1

--- a/scripts/build_summary/failure.py
+++ b/scripts/build_summary/failure.py
@@ -172,7 +172,7 @@ class AptFailure(Failure):
             if match:
                 self.matches = True
                 self.detail = "Apt Fetch Fail: {fail}".format(
-                                 fail=match.string)
+                    fail=match.string)
                 break
 
 
@@ -242,7 +242,7 @@ class SlaveOfflineFailure(Failure):
                 self.matches = True
                 self.detail = ('Slave Died / Agent went offline'
                                ' during the build: {previous_task}'.format(
-                                    previous_task=previous_task))
+                                   previous_task=previous_task))
                 break
 
 
@@ -274,7 +274,7 @@ class PipFailure(Failure):
                 if not self.failure_ignored(i):
                     self.matches = True
                     self.detail = "Can't find pip package: {fail}".format(
-                                     fail=match.group(1))
+                                  fail=match.group(1))
                 break
 
 
@@ -344,7 +344,7 @@ class BuildTimeoutFailure(Failure):
                 previous_task = self.get_previous_task(i)
                 self.matches = True
                 self.detail = 'Build Timeout: {previous_task}'.format(
-                        previous_task=previous_task)
+                    previous_task=previous_task)
                 break
 
 

--- a/scripts/build_summary/failure.py
+++ b/scripts/build_summary/failure.py
@@ -1,38 +1,19 @@
 from abc import ABC, abstractmethod
 import datetime
 import re
-import sys
+import uuid
 
 
 class Failure(ABC):
     description = "Failure Base Class"
-    uuid_re = re.compile("([0-9a-zA-Z]+-){4}[0-9a-zA-Z]+")
-    ip_re = re.compile("([0-9]+\.){3}[0-9]+")
-    colour_code_re = re.compile('(\[8mha:.*)?\[0m')
-    maas_tx_id_re = re.compile('\S*k1k.me\S*')
-    maas_entity_uri_re = re.compile(
-        '/\d+/entities(/[^/]*)?|/\d+/agent_tokens')
-    maas_httpd_tx_id_re = re.compile("'httpdTxnId': '[^']*'")
-    ansible_tmp_re = re.compile('ansible-tmp-[^/]*')
-    node_name_re = re.compile(
-        '(nodepool-[a-zA-Z_0-9]+-[0-9]+)|([a-z]+-[0-9]+-[a-z0-9]+)')
-    normalisers = [
-        (uuid_re, '**UUID**'),
-        (ip_re, '**IPv4**'),
-        (colour_code_re, ''),
-        (maas_tx_id_re, '**TX_ID**'),
-        (maas_entity_uri_re, '**Entity**'),
-        (maas_httpd_tx_id_re,
-            '**HTTP_TX_ID**'),
-        (ansible_tmp_re, 'ansible-tmp-**Removed**'),
-        (node_name_re, '**node-name**')
-    ]
-    failures = []
+    failures = {}
 
     def __init__(self, build):
+        self.id = str(uuid.uuid4())
         self.matches = False
         self.detail = "No detail provided"
         self.build = build
+        Failure.failures[self.id] = self
 
     def get_serialisation_dict(self):
         return {
@@ -42,14 +23,10 @@ class Failure(ABC):
             # baloon
             "detail": self.detail[:1000],
             "description": self.description,
-            "build": self.build.get_serialisation_dict_without_failure_ref(),
-            "category": self.category
+            "build": self.build.id,
+            "category": self.category,
+            "id": self.id
         }
-
-    def get_serialisation_dict_without_build_ref(self):
-        sd = self.get_serialisation_dict()
-        del sd['build']
-        return sd
 
     @classmethod
     def scan_build(cls, build):
@@ -57,7 +34,7 @@ class Failure(ABC):
         if (build.junit is not None):
             cls.scan_junit(build)
         if not build.failures:
-            build.failures.append(UnknownFailure(build))
+            build.failures.append(UnknownFailure(build).id)
 
     @classmethod
     def scan_junit(cls, build):
@@ -101,7 +78,7 @@ class Failure(ABC):
             elif("tempest" in class_name or "tempest" in test_name):
                 f.category = "C8 Tempest"
 
-            build.failures.append(f)
+            build.failures.append(f.id)
 
     @classmethod
     def scan_logs(cls, build):
@@ -113,17 +90,17 @@ class Failure(ABC):
             filter_end_time = datetime.datetime.now()
             if (filter_end_time - filter_start_time >
                     datetime.timedelta(seconds=1)):
-                sys.stderr.write("Slow filter: {d} on build {b}"
-                                 .format(d=subtype.description,
-                                         b=build))
+                print("Slow filter: {d} on build {b}"
+                      .format(d=subtype.description,
+                              b=build))
             if failure.matches:
-                build.failures.append(failure)
-                Failure.failures.append(failure)
+                build.failures.append(failure.id)
+                Failure.failures[failure.id] = failure
         job_end_time = datetime.datetime.now()
         if job_end_time - job_start_time > datetime.timedelta(seconds=5):
-            sys.stderr.write("Slow Build: build {b}"
-                             .format(d=subtype.description,
-                                     b=build))
+            print("Slow Build: build {b}"
+                  .format(d=subtype.description,
+                          b=build))
 
     def get_previous_task(self, line, order=-1, get_line_num=False):
         previous_task_re = re.compile(
@@ -189,13 +166,13 @@ class AptFailure(Failure):
 
     def scan(self):
         match_re = re.compile(
-            ".: Failed to fetch (\s*from\s*)?([^\s]*)( Hash Sum mismatch)?")
+            "Failed to fetch (\s*from\s*)?([^\s]*)( Hash Sum mismatch)?")
         for line in self.build.log_lines:
             match = match_re.search(line)
             if match:
                 self.matches = True
                 self.detail = "Apt Fetch Fail: {fail}".format(
-                                 fail=match.group(1))
+                                 fail=match.string)
                 break
 
 

--- a/scripts/build_summary/index.html
+++ b/scripts/build_summary/index.html
@@ -1,432 +1,177 @@
 <!DOCTYPE html>
-<html lang="en">
-
+<html>
 <head>
-  <style>
-    html,
-    body {
-      height: 100%;
-      width: 100%;
-      padding: 0;
-      margin: 0;
-      white-space: normal;
-    }
-
-    div.container-fluid {
-      width: 100%;
-    }
-
-    div.result-table {
-      margin: auto;
-      width: 95%;
-    }
-
-    div.spark_group {
-      width: 126px;
-    }
-  </style>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui">
-  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
-
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>RE Build Summary</title>
-
-  <!-- jquery -->
-  <script src="https://code.jquery.com/jquery-3.3.1.min.js" crossorigin="anonymous"></script>
-
-  <!-- Jquery Data tables -->
-  <link rel="stylesheet" type="text/css" href="http://cdn.datatables.net/1.10.16/css/jquery.dataTables.css">
-  <script type="text/javascript" charset="utf8" src="http://cdn.datatables.net/1.10.16/js/jquery.dataTables.js"></script>
-
-  <!-- Jquery Sparklines -->
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery-sparklines/2.1.2/jquery.sparkline.js"></script>
-
-  <!-- popper, required by bootstrap -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
-
-  <!-- bootstrap -->
-  <!--<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css" integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB" crossorigin="anonymous"> -->
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootswatch/4.1.1/cerulean/bootstrap.min.css" crossorigin="anonymous">
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.1.1/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
-
-  <!-- Vue JS -->
-  <script src="https://cdn.jsdelivr.net/npm/vue"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.16/vue.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/vue-resource@1.5.0"></script>
-  <link href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons' rel="stylesheet">
-  <!--<link href="https://unpkg.com/vuetify/dist/vuetify.min.css" rel="stylesheet">-->
-  <!--<script src="https://unpkg.com/vuetify/dist/vuetify.js"></script>-->
-  <!--<script src="https://unpkg.com/vue-router/dist/vue-router.js"></script> -->
+  <link href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons' rel="stylesheet" type="text/css"></link>
+  <link href="https://unpkg.com/vuetify@1.0.19/dist/vuetify.min.css" rel="stylesheet" type="text/css"></link>
+  <link href="styles.css" rel="stylesheet" type="text/css"></link>
 </head>
 
 <body>
+  <script src="https://unpkg.com/vue@2.5.16/dist/vue.js"></script>
+  <script src="https://unpkg.com/vuetify@1.0.19/dist/vuetify.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vue-resource@1.5.0"></script>
+  <script src="https://unpkg.com/vue-router@3.0.1/dist/vue-router.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.10/lodash.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.4.0/Chart.min.js"></script>
+  <script src="components.js"></script>
+  <script src="views.js"></script>
+
   <div id="app">
-    <div class="container-fluid">
-      <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-3">
-        <a class="navbar-brand" href="#">[[title]]</a>
-        <div class="collapse navbar-collapse">
-          <ul class="navbar-nav mr-auto">
-            <li class="nav-item mx-2"><a class="text-secondary" href="https://rpc.jenkins.cit.rackspace.net">Jenkins</a></li>
-            <li class="nav-item mx-2"><a class="text-secondary" href="https://github.com/pulls?q=is%3Aopen+is%3Apr+archived%3Afalse+user%3Arcbops+sort%3Aupdated-desc">PRs</a></li>
-          </ul>
-        </div>
-      </nav>
-      <buildtrends v-bind:builds="builds" v-bind:branches="branches"></buildtrends>
-      <failurelist v-bind:failures="failures" type="category"></failurelist>
-      <recentresults v-bind:builds="builds"></recentresults>
-    </div>
-    <h4> Generated: [[page_timestamp]]</h4>
+    <v-app>
+      <v-toolbar fixed app :clipped-left="clipped">
+        <v-btn flat to="/">RE Build Summary</v-btn>
+        <v-spacer></v-spacer>
+        <toolbarmenu
+          title="Repositories"
+          :counteditems="this.$root.repos"
+          urlbase="repo">
+        </toolbarmenu>
+        <toolbarmenu
+          title="Failure Types"
+          :counteditems="this.$root.failuresByType(Object.values(this.$root.builds))"
+          urlbase="ftype">
+        </toolbarmenu>
+        <toolbarmenu
+          title="Failure Categories"
+          :counteditems="this.$root.failuresByCategory(Object.values(this.$root.builds))"
+          urlbase="fcat">
+        </toolbarmenu>
+      </v-toolbar>
+      <main>
+        <v-content>
+          <v-container fluid>
+            <router-view v-if="$root.dataloaded"></router-view>
+            <h1 v-else>Loading all of the JSON... please wait</h1>
+          </v-container>
+        </v-content>
+      </main>
+      <v-footer>
+        <span>&copy; Rackspace 2018. Source Data Timestamp: {{this.timestamp}}</span>
+      </v-footer>
+    </v-app>
   </div>
+
   <script>
-    function draw_spark() {
-      $('.spark').sparkline('html', {
-        type: 'line',
-        minSpotColor: false,
-        maxSpotColor: 'red',
-        spotColor: false,
-        width: '125px',
-        height: '25px'
-      });
+
+  // Extensions to the array type to make data manipulation easier
+  // group a list by a property
+  Array.prototype.groupBy = function(prop) {
+    return this.reduce(function(groups, item) {
+      const val = item[prop]
+      groups[val] = groups[val] || []
+      groups[val].push(item)
+      return groups
+    }, {})
+  }
+
+  // group a list by property, count and sort
+  // returns [[count, key, items], ...]
+  Array.prototype.countBy = function(prop){
+    var count = Object.entries(this.groupBy(prop))
+      .map(t => [t[1].length, t[0], t[1]])
+      .sort((a,b) => a[0] < b[0] ? 1 : -1)
+    if (count.length == 0){
+      return [0,"",[]]
     }
+    return count
+  }
 
-    function bar_spark(selector, colour) {
-      $(selector).each(function() {
-        $(this).sparkline('html', {
-          type: 'bar',
-          barColor: colour,
-          width: '125px',
-          height: '30px',
-          chartRangeMax: $(this).data('max'),
-          chartRangeMin: $(this).data('min'),
-        });
-      })
-    }
-
-    function draw_spark_bar() {
-      bar_spark('.spark_shist', 'green');
-      bar_spark('.spark_fhist', 'red');
-    }
-
-    Vue.component("buildhistorygraph", {
-      props: ["builds", "repo", "branch"],
-      delimiters: ['[[', ']]'],
-      computed: {
-        fbuilds: function() {
-          _fbuilds = this.builds.filter(build => build.repo == this.repo && build.branch == this.branch);
-          return _fbuilds;
-        },
-        spark_success: function() {
-          return this.$root.histogram(
-            this.fbuilds.filter(build => build.result == "SUCCESS"),
-            this.$root.retention_days,
-            1)
-        },
-        spark_failure: function() {
-          return this.$root.histogram(
-            this.fbuilds.filter(build => build.result != "SUCCESS"),
-            this.$root.retention_days, -1)
-        },
-        absmax: function() {
-          values = this.spark_success.concat(this.spark_failure)
-          absvalues = (values).map(v => Math.abs(v))
-          // ... is equivalent to * in python
-          return Math.max(...absvalues);
-        }
-      },
-      methods: {},
-      template: `
-    <td>
-      <div class="spark_group">
-        <span class="spark_shist" v-bind:values="spark_success.join(',')" data-min="0" data-max="absmax"></span>
-        <span class="spark_fhist" v-bind:values="spark_failure.join(',')" data-min="absmax * -1" data-max="0"></span>
-      </div>
-    </td>
-  `
-    })
-
-    Vue.component('buildtrends', {
-      props: ["builds", "branches"],
-      delimiters: ['[[', ']]'],
-      computed: {
-        fbuilds: function() {
-          return this.$root.builds.filter(b => b.stage == "PM")
-        },
-        repos: function() {
-          repos = new Set();
-          this.fbuilds.forEach(function(build) {
-            repos.add(build.repo)
-          });
-          return Array.from(repos);
-        }
-      },
-      updated: function() {
-        $('#summary').DataTable({
-          "ordering": false,
-          "paging": false,
-          "searching": false,
-          "info": false,
-          "drawCallback": draw_spark_bar
-        })
-      },
-      template: `
-    <div class="buildtrends">
-      <div class="result-table" id="periodic">
-      <h3> Periodic Build Trends </h3>
-      <p> Note: [[this.$root.retention_days]] days, one column per day, green/positive are successfull jobs
-      red/negative are failed (or aborted) jobs. Most recent on the right.</p>
-        <table id="summary" class="table">
-          <thead>
-            <tr>
-              <th></th><!-- repo headings col !-->
-              <th v-for="branch in branches" :key="branch">
-                [[branch]]
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="repo in repos" :key="repo">
-              <th>[[repo]]</th>
-              <buildhistorygraph v-for="branch in branches" :key="branch" v-bind:branch="branch" v-bind:repo="repo" v-bind:builds="builds"> </buildhistorygraph>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-`
-    })
-
-    Vue.component("failurelist", {
-      data: function() {
-        return {
-          category_failures: {}
-        }
-      },
-      props: ["failures", "type"],
-      delimiters: ['[[', ']]'],
-      updated: function() {
-        $('#failures').DataTable({
-          "order": [
-            [6, "desc"]
-          ],
-          "columnDefs": [{
-              "targets": [4, 6],
-              "visible": false
-            },
-            {
-              "targets": [2],
-              "width": "100px",
-            }
-          ],
-          "drawCallback": draw_spark
-        });
-      },
-      computed: {
-        categories: function() {
-          categories = new Set();
-          this.failures.forEach(function(fail) {
-            categories.add(fail.category);
-          })
-          return Array.from(categories)
-        }
-      },
-      methods: {
-        for_category: function(category) {
-          if (!(category in this.category_failures)) {
-            ff = this.failures.filter(f => f.category == category)
-            this.category_failures.category = ff
-          }
-          return this.category_failures.category
-        },
-        rowclass: function(failures, warning, danger) {
-          num = failures.length
-          if (num > danger) {
-            return "table-danger";
-          } else if (num > warning) {
-            return "table-warning"
-          } else {
-            return ""
-          }
-        }
-      },
-      template: `
-    <div class="result-table" id="failcount">
-    <h3 v-if="type=='category'">Failures by Category</h3>
-    <h3 v-else>Failures</h3>
-    <table id="failures" class="table">
-      <thead>
-        <tr>
-          <th>Count</th>
-          <th>Failure <span v-if="type=='category'">Category</span></th>
-          <th>Trend</th>
-          <th>Oldest</th>
-          <th>Oldest Job ID</th>
-          <th>Newest</th>
-          <th>Newest Job Timestamp For Sorting</th>
-        </tr>
-      </thead>
-      <tbody v-if="type=='category'">
-        <failurerow v-for="category in categories" :key="category" :category="category" :failures="for_category(category)" :rowclass="rowclass(for_category(category), 30, 50)" :name="category"></failurerow>
-      </tbody>
-    </table>
-    </div>
-  `
-    })
-
-    Vue.component("failurerow", {
-      props: ["failures", "rowclass", "name"],
-      delimiters: ["[[", "]]"],
-      computed: {
-        filtered_builds: function() {
-          var c_builds = this.failures.map(f => f.build)
-          return c_builds
-        },
-        filtered_date_sorted_builds: function() {
-          return this.$root.date_sorted_builds(this.filtered_builds)
-        },
-        newest_build: function() {
-          return this.filtered_date_sorted_builds[this.filtered_date_sorted_builds.length - 1]
-        },
-        oldest_build: function() {
-          return this.filtered_date_sorted_builds[0]
-        },
-      },
-      template: `
-  <tr v-bind:class="rowclass">
-    <td>[[failures.length]]</td>
-    <td>[[name]]</td>
-    <td><span class="spark" v-bind:values="this.$root.histogram(filtered_builds, this.$root.retention_days, 1)"></span></td>
-    <td><buildlink v-bind:build="oldest_build"/></td> <!--oldest-->
-    <td>[[oldest_build.build_num]]</td>
-    <td><buildlink v-bind:build="newest_build"/></td> <!--newest-->
-    <td>[[newest_build.timestamp]]</td>
-  </tr>
-  `
-
-    })
-
-    Vue.component("buildlink", {
-      props: ["build"],
-      delimiters: ["[[", "]]"],
-      template: `
-    <a v-bind:href="this.$root.jenkins_url+'/job/'+buildid(build)">[[this.$root.dfmt(build.timestamp)]]</a>
-  `
-    })
-
-    Vue.component("recentresults", {
-      delimiters: ["[[", "]]"],
-      props: ["builds"],
-      updated: function() {
-        $('#jobs').DataTable({
-          "order": [
-            [0, "desc"]
-          ],
-          "pageLength": 50,
-          "columnDefs": [{
-            "targets": [0],
-            "visible": false
-          }]
-        });
-      },
-      template: `
-    <div id="recent-builds" class="result-table">
-      <h3>Recent Results</h3>
-       <table id="jobs" class="table">
-         <thead>
-           <tr>
-             <th>Date for Sorting</th>
-             <th>Date / Result</th>
-             <th>Branch</th>
-             <th>Job Tree</th>
-             <th>Failures</th>
-           </tr>
-         </thead>
-         <tbody>
-          <buildrow v-for="build in builds" :key="buildid(build)" v-bind:build="build"></buildrow>
-         </tbody>
-       </table>
-    </div>
-  `
-    })
-
-    Vue.component("buildrow", {
-      props: ["build"],
-      delimiters: ["[[", "]]"],
-      methods: {
-        wrappable: function(s) {
-          var mid = s.replace(/\./g, ". ")
-          return mid.replace(/_/g, "_ ")
-        }
-      },
-      computed: {
-        rowclass: function() {
-          if (this.build.result == "SUCCESS") {
-            return "table-success"
-          } else {
-            return "table-danger"
-          }
-        },
-        jurl: function() {
-          return this.$root.jenkins_url
-        }
-      },
-      template: `
-    <tr v-bind:class="rowclass">
-      <td>[[build.timestamp]]</td>
-      <td>[[this.$root.dfmt(build.timestamp)]] [[build.result]]</td>
-      <td>[[build.branch]]</td>
-      <td>
-        <ul>
-          <li v-for="item in build.build_hierachy">
-            <a v-bind:href="item.url">[[item.name]] [[item.build_num]]</a>
-          </li>
-        </ul>
-      </td>
-      <td>
-        <ul>
-          <li v-for="fail in build.failures" class="failure">
-            <a v-bind:href="jurl+'/job/'+buildid(build)">[[wrappable(fail.category + " " + fail.type + " " + " " + fail.detail)]]</a>
-          </li>
-        </ul>
-      </td>
-    </tr>
-  `
-    })
-
-    // mixin properties are added to all components
-    Vue.mixin({
-      methods: {
-        buildid: function(build) {
-          return `${build.job_name}/${build.build_num}`
-        }
+  // Recursively flatten a list
+  Array.prototype.flatten = function(){
+    return this.reduce((a,c) => {
+      if (Array.isArray(c)){
+        c = c.flatten()
+        return [...a, ...c]
+      } else {
+        return [...a, c]
       }
-    })
+    },[])
+  }
+
+  // Add relative powers to the date class
+  Date.prototype.toRelativeString = function(){
+    var diff = (((new Date()).getTime() - this.getTime()) / 1000),
+      day_diff = Math.floor(diff / 86400);
+
+    if (isNaN(day_diff) || day_diff < 0) return;
+
+    var relativeString =
+      day_diff == 0 && (
+        diff < 60 && "just now"
+        || diff < 120 && "1 minute ago"
+        || diff < 3600 && Math.floor(diff / 60) + " minutes ago"
+        || diff < 7200 && "1 hour ago"
+        || diff < 86400 && Math.floor(diff / 3600) + " hours ago"
+      )
+        || day_diff == 1 && "Yesterday"
+        || day_diff < 7 && day_diff + " days ago"
+        || Math.ceil(day_diff / 7) + " weeks ago"
+    return relativeString
+  }
+
+    const routes = [
+      { path: '/', component: homeView},
+      { path: '/repo/:repoName', component: repoDetailView, props: true },
+      { path: '/job/:jobName', component: jobView, props: true },
+      { path: '/ftype/:type', component: failureTypeView, props: true},
+      { path: '/fcat/:category', component: failureCategoryView, props: true },
+    ]
+
+    const router = new VueRouter({ routes })
 
     var vm = new Vue({
+      router,
       el: '#app',
-      data: {
-        builds: [],
-        page_timestamp: "loading...",
-        retention_days: 0,
-        jenkins_url: "https://rpc.jenkins.cit.rackspace.net",
-        branches: ["master", "pike", "newton"],
-        title: "Loading..."
-      },
-      beforeCreate: function() {
-        this.$http.get("data.json").then(function(response) {
-          this.builds = response.body.builds
-          this.page_timestamp = response.body.timestamp
+      created: function(){
+        this.$http.get("data.json").then(function(response){
+          this.builds_raw = response.body.builds
+          this.failures_raw = response.body.failures
+          this.timestamp = response.body.timestamp
           this.retention_days = response.body.retention_days
-          this.title = "RE Build Summary"
+          this.dataloaded = true
+          console.log("data loaded")
         })
       },
-      // computed properties are cached
       computed: {
-        failures: function() {
-          var f = this.builds
-                    .map(b => b.failures)
-                    .reduce((a, c) => a.concat(c), [])
-          return f
+        // change the json ID refs into actual links
+        builds: function(){
+          Object.values(this.builds_raw).forEach(b => {
+            // convert failure ids to failure objects
+            b.failures = b.failures.map(id => this.failures_raw[id])
+            // convert build ids in failure objects to build objects
+            b.failures.forEach(f => f.build = this.$root.builds_raw[f.build])
+          })
+          // this method actually mutates the builds_raw dict,
+          // but making use of the 'builds' computed var will cause
+          // the mutation to happen via this function.
+          return this.builds_raw
+        },
+        failures: function(){
+          this.failures_raw.forEach(f => {
+            f.build = this.builds_raw[f.build]
+          })
+          return this.failures_raw
+        },
+        jobs: function(){
+          return Object.values(this.builds).countBy("job_name")
+        },
+        repos: function(){
+          var r = Object.values(this.builds).countBy("repo")
+          return r
+        },
+        labels: function(){
+          now = new Date()
+          return [...Array(this.retention_days).keys()].map(
+            (i) => {
+              var daysAgo = this.retention_days-i
+              var dayInMillis = 86400000
+              return new Date(now-dayInMillis * daysAgo).toLocaleDateString()
+            }
+          )
         }
       },
       methods: {
@@ -444,20 +189,104 @@
           })
           return histogram
         },
-        date_sorted_builds: function(builds) {
+        dateSortedBuilds: function(builds) {
           var sorted = builds.sort(function(a, b) {
             return new Date(a.timestamp) - new Date(b.timestamp)
           })
           return sorted;
         },
+        oldestNewestBuilds: function(builds){
+          var dsb = this.dateSortedBuilds(builds)
+          return {oldest: dsb[0],
+                  newest: dsb.slice(-1)[0]}
+        },
         dfmt: function(date_string) {
           d = new Date(date_string)
-          return `${d.toLocaleDateString()} ${d.toLocaleTimeString()}`
+          //return `${d.toLocaleDateString()} ${d.toLocaleTimeString()}`
+          return d.toISOString()
+        },
+        colours: function(numRequired){
+          // Generate colours for chart series in hsla() format
+          // Green is put in first so it can be used for success
+          // other colours are as far from green as possible,
+          // equally spread. These are assumed to be for
+          // various types of failure
+          var colours = []
+          // hue 0-359, green (used for success is 120)
+          var greenHue = 120
+          var maxHue = 359
+          var arc = (maxHue+1.0)/(numRequired+0.0)
+          // push green in first
+          colours.push('hsla('+greenHue+', 80%, 60%, 0.39)')
+          // then add as many other colours as required.
+          for(i=1; i<=numRequired-1; i++){
+            var hue = ((greenHue + (i*arc)) % maxHue).toFixed(0)
+            colours.push('hsla('+hue+', 80%, 60%, 0.39)')
+          }
+          return colours
+        },
+        failColour: function(percent){
+          // generate a colour between white and red
+          // suitable for use as a background for black text
+          // based on an in put percent (Value between 0 and 1)
+          var lumMax = 100
+          var lumMin = 62
+          var lumRange = lumMax-lumMin
+          var lum = lumMax - (percent * lumRange)
+          var c = 'hsl(5, 100%, '+lum+'%)'
+          return c
+        },
+        failuresByCategory: function(builds){
+            return builds.map(b => b.failures)
+              .flatten()
+              .countBy("category")
+        },
+        // returns [[count, type, failures], ...]
+        failuresByType: function(builds){
+            // get failed builds by type
+            var fbt = builds
+              .map(b => b.failures) // get failures from each build
+              .flatten()
+              .countBy("type")
+            return fbt
         }
       },
-      delimiters: ['[[', ']]']
+      data: {
+        ghBase: "https://github.com/rcbops/",
+        jenkinsBase: "https://rpc.jenkins.cit.rackspace.net/job/",
+        timestamp:  "",
+        retention_days: 0,
+        builds_raw: [],
+        failures_raw: [],
+        test: 'testvalue',
+        items: [],
+        failed_uploads: [],
+        archives: [],
+        archive_base_name: '',
+        dataloaded: false,
+        container_public_url: '',
+        files: [],
+        job_name: '',
+        build_number: '',
+        clipped: true,
+        drawer: true,
+        fixed: true,
+        miniVariant: false,
+        stackedOptions: {
+          tooltips: {
+              mode: 'x',
+          },
+          scales: {
+             xAxes: [{
+                 stacked: true
+             }],
+             yAxes: [{
+                 stacked: true
+             }]
+           }
+        }
+      }
     })
   </script>
 </body>
-
 </html>

--- a/scripts/build_summary/requirements.txt
+++ b/scripts/build_summary/requirements.txt
@@ -2,3 +2,4 @@ click
 humanize
 Jinja2
 lxml
+python-dateutil

--- a/scripts/build_summary/styles.css
+++ b/scripts/build_summary/styles.css
@@ -1,0 +1,5 @@
+/** CSS Styles */
+
+div.card {
+  margin-bottom: 20px;
+}

--- a/scripts/build_summary/views.js
+++ b/scripts/build_summary/views.js
@@ -1,0 +1,189 @@
+homeView = Vue.component("homeView",{
+  template: `
+    <div>
+      <titleCard title="All Builds"></titlecard>
+      <trendGraphs
+        :builds="Object.values(this.$root.builds)"
+      ></trendGraphs>
+      <failureTables :builds="Object.values(this.$root.builds)">
+      </failureTables>
+      <repoTable></repoTable>
+      <buildTable
+        :buildsOrFilter="Object.values(this.$root.builds)"
+        title="Recent Builds From All Jobs">
+      </buildTable>
+    </div>
+  `
+})
+
+repoDetailView = Vue.component("repoview", {
+  props: ["repoName"],
+  computed: {
+    builds: function(){
+      return this.$root.repos.filter(l => l[1]==this.repoName)[0][2]
+    }
+  },
+  template: `
+    <div>
+      <titleCard
+        :title="'Repository: ' + repoName"
+      >
+        <a :href="this.$root.ghBase+repoName">View this repository on Github</a><v-icon>launch</v-icon>
+      </titleCard>
+      <trendGraphs
+        :builds="this.builds"
+      ></trendGraphs>
+      <!-- failure types pie -->
+      <!-- failure categories pie -->
+      <jobTable
+        :builds="this.builds"
+        title="Jobs"></jobTable>
+      <failureTables
+        :builds="this.builds">
+      </failureTables>
+      <buildTable
+        title="Build Results"
+        :buildsOrFilter="this.builds"
+      ></buildTable>
+    </div>
+  `
+})
+
+jobView = Vue.component("jobView", {
+  props: ["jobName"],
+  computed: {
+    builds: function(){
+      return Object.values(this.$root.builds).filter(b => b.job_name == this.jobName)
+    }
+  },
+  template: `
+    <div>
+      <titleCard
+        :title="'Job: ' +jobName"
+      >
+      <a :href="this.$root.jenkinsBase+jobName">View job in in Jenkins</a><v-icon>launch</v-icon>
+      </titleCard>
+      <trendGraphs
+        :builds="this.builds"
+      ></trendGraphs>
+      <failureTables
+        :builds="this.builds"
+        :showTopJobs="false">
+      </failureTables>
+      <buildTable
+        title="Build Results"
+        :buildsOrFilter="this.builds"
+      ></buildTable>
+    </div>
+  `
+})
+
+failureTypeView = Vue.component("failureTypeView",{
+  props: {
+    type: {},
+  },
+  data: function(){
+    return {
+      sort: {
+        sortBy: 'numBuilds',
+        descending: true
+      }
+    }
+  },
+  computed: {
+      failures: function(){
+        return this.$root.failuresByType(Object.values(this.$root.builds))
+          .filter(l=> l[1]==this.type)[0][2]
+      },
+      builds: function(){
+        return this.failures.map(f => f.build)
+      },
+      category: function(){
+        return this.failures[0].category
+      }
+  },
+  methods: {
+    dsFilter: function(ds){
+      var type = this.type
+      return ds.label==type
+    }
+  },
+  template: `
+    <div>
+      <titleCard
+        :title="'Failure Type: '+this.type"
+      >
+      Failure Category: <router-link :to="'/fcat/'+category">{{this.category}}</router-link>
+      </titleCard>
+      <failureTypesTrend
+        title=""
+        :builds="this.builds"
+        :dsFilter="this.dsFilter">
+      </failureTypesTrend>
+      <jobTable
+        title="Jobs"
+        :builds="this.builds"
+        :sort="this.sort"
+        :showFailurePercent="false"
+        :showTopFailureType="false">
+      </jobTable>
+      <buildTable
+        :buildsOrFilter="this.builds"
+        title="Builds"
+      ></buildTable>
+    </div>
+  `
+})
+
+failureCategoryView = Vue.component("failureCategoryView",{
+  props: {
+    category: {},
+  },
+  data: function(){
+    return {
+      sort: {
+        sortBy: 'numBuilds',
+        descending: true
+      }
+    }
+  },
+  computed: {
+      failures: function(){
+        return this.$root.failuresByCategory(Object.values(this.$root.builds))
+          .filter(l=> l[1]==this.category)[0][2]
+      },
+      builds: function(){
+        return this.failures.map(f => f.build)
+      },
+  },
+  methods: {
+    dsFilter: function(ds){
+      var category = this.category
+      return ds.label==category
+    }
+  },
+  template: `
+    <div>
+      <titleCard
+        :title="'Failure Category: '+this.category"
+      >
+      </titleCard>
+      <failureCategoriesTrend
+        title=""
+        :builds="this.builds"
+        :dsFilter="this.dsFilter">
+      </failureCategoriesTrend>
+      <jobTable
+        title="Jobs"
+        :builds="this.builds"
+        :sort="this.sort"
+        :showFailurePercent="false"
+        :showTopFailureCategory="false">
+      </jobTable>
+      <buildTable
+        :buildsOrFilter="this.builds"
+        title="Builds"
+      ></buildTable>
+    </div>
+  `
+})

--- a/scripts/create_cloud_image.py
+++ b/scripts/create_cloud_image.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 import argparse
 from time import sleep
+from six import xrange
 
 import openstack.connection
 
@@ -33,15 +34,14 @@ def find_new_image(conn, current_ids, name):
                 print("Found new image matching {}".format(name))
                 return image
             else:
-                print ("Skipping {name}/{id} as it predates the "
-                       "required image."
-                       .format(name=name, id=image.id))
+                print("Skipping {name}/{id} as it predates the "
+                      "required image."
+                      .format(name=name, id=image.id))
     raise Exception("Image {i} not found.".format(i=name))
 
 
 def main():
     """Run the main application."""
-
     # Setup argument parsing
     parser = argparse.ArgumentParser(
         description='Basic cloud CLI utilities',
@@ -130,7 +130,7 @@ def main():
         print("Deleting Image: {n}/{id}".format(n=image.name, id=image.id))
         conn.image.delete_image(image)
 
-    print ("Image Creation Complete.")
+    print("Image Creation Complete.")
 
 
 if __name__ == "__main__":

--- a/scripts/ghutils.py
+++ b/scripts/ghutils.py
@@ -226,9 +226,9 @@ def get_webhooks(ctx, url_match):
         for hook in repo.iter_hooks():
             for k, v in hook.config.items():
                 if (url_match and url_match_re.search(v)) or not url_match:
-                    print "{org}.{repo}.{name}.{k}: {v}".format(
-                        org=org.login, repo=repo.name,
-                        name=hook.name, k=k, v=v)
+                    print("{org}.{repo}.{name}.{k}: {v}".format(
+                          org=org.login, repo=repo.name,
+                          name=hook.name, k=k, v=v))
 
 
 @cli.command()
@@ -272,8 +272,7 @@ def update_rc_branch(ctx, mainline, rc):
             logger.debug("Branch {branch} has protection enabled,"
                          " config: {bp_config}".format(
                              branch=rc,
-                             bp_config=branch_protection_response.json()
-                             ))
+                             bp_config=branch_protection_response.json()))
             branch_protection_enabled = True
             # disable branch protection
             r = branch_api_request(repo, rc, 'DELETE')
@@ -464,9 +463,9 @@ def create_pr(repo, source_branch, target_branch, title, body):
                               base=target_branch,
                               head=source_branch,
                               body=body)
-    print "{org}/{repo}#{num}".format(org=repo.owner,
+    print("{org}/{repo}#{num}".format(org=repo.owner,
                                       repo=repo.name,
-                                      num=pr.number)
+                                      num=pr.number))
 
 
 if __name__ == "__main__":

--- a/scripts/jenkins_node.py
+++ b/scripts/jenkins_node.py
@@ -1,5 +1,4 @@
-"""
-Copyright 2017 Rackspace
+"""Copyright 2017 Rackspace.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scripts/jirautils.py
+++ b/scripts/jirautils.py
@@ -63,10 +63,11 @@ def _get_or_create_issue(project, status, labels, description, summary):
     elif len(issues) > 1:
         issue = issues[0]
         LOGGER.debug("Query: {q} Returned >1 issues: {il}. "
-                     "Will use the oldest issue {i}".format(
-                        q=query,
-                        il=",".join(i.key for i in issues),
-                        i=issue))
+                     "Will use the oldest issue {i}"
+                     .format(
+                         q=query,
+                         il=",".join(i.key for i in issues),
+                         i=issue))
     else:
         issue = _create_issue(
             summary=summary,
@@ -325,31 +326,31 @@ def findfailuredupes(squash, query):
             job = match.group(1)
             jobs[job].append(issue)
         else:
-            print "non matching summary: {}".format(issue.fields.summary)
+            print("non matching summary: {}".format(issue.fields.summary))
     duplicates = {job: sorted(issues, key=lambda x: int(x.id))
                   for job, issues in jobs.items()
                   if len(issues) > 1}
     if duplicates:
-        print "Duplicates:"
+        print("Duplicates:")
         for job, issues in duplicates.items():
-            print "{job} --> {issues}".format(
-                job=job, issues=", ".join(i.key for i in issues))
+            print("{job} --> {issues}".format(
+                job=job, issues=", ".join(i.key for i in issues)))
         if squash:
-            print "Squashing duplicates"
+            print("Squashing duplicates")
             for job, issues in duplicates.items():
                 master_issue = issues.pop(0)
-                print "{job} / {master}".format(job=job, master=master_issue)
+                print("{job} / {master}".format(job=job, master=master_issue))
                 for duplicate_issue in issues:
                     # Add comment to master issue
-                    print ("  Adding Comment to master issue: {}"
-                           .format(master_issue.key))
+                    print("  Adding Comment to master issue: {}"
+                          .format(master_issue.key))
                     authed_jira.add_comment(
                         master_issue.key,
                         "Issue {d} closed as a duplicate of this issue".format(
                             d=duplicate_issue.key))
                     # Add comment to duplicate issue
-                    print ("  Adding Comment to duplicate issue: {}"
-                           .format(duplicate_issue.key))
+                    print("  Adding Comment to duplicate issue: {}"
+                          .format(duplicate_issue.key))
                     authed_jira.add_comment(
                         duplicate_issue.key,
                         "Closing as duplicate of {m}".format(
@@ -357,8 +358,8 @@ def findfailuredupes(squash, query):
                     transition = find_done_transition(authed_jira,
                                                       duplicate_issue)
                     # Close duplicate issue
-                    print "  Transitioning: {k} --> {t}".format(
-                        k=duplicate_issue.key, t=transition['name'])
+                    print("  Transitioning: {k} --> {t}".format(
+                        k=duplicate_issue.key, t=transition['name']))
                     authed_jira.transition_issue(
                         duplicate_issue,
                         transition['id'])
@@ -371,11 +372,11 @@ def findfailuredupes(squash, query):
                             }
                 )
 
-            print "Squash Complete"
+            print("Squash Complete")
         else:
-            print "Squash disabled, leaving duplicates"
+            print("Squash disabled, leaving duplicates")
     else:
-        print "No Duplicates Found"
+        print("No Duplicates Found")
 
 
 if __name__ == "__main__":

--- a/scripts/lint_jjb.py
+++ b/scripts/lint_jjb.py
@@ -160,7 +160,7 @@ def check_retention(job, in_file):
             return_value = 1
         except ValueError as e:
             return_value = 1
-            print e
+            print(e)
         else:
             return_value = 0
             break

--- a/scripts/maasutils.py
+++ b/scripts/maasutils.py
@@ -29,7 +29,7 @@ def get_token_url(raxmon):
 @click.option("--token", 'webhook_token', required=True)
 @click.pass_context
 def set_webhook_token(ctx, webhook_token):
-    """Sets the token that is included in MaaS webhook notifications
+    """Set the token that is included in MaaS webhook notifications.
 
     This is one method of verifying that receieved requests are
     from MaaS. This is per account.

--- a/scripts/notifications.py
+++ b/scripts/notifications.py
@@ -9,11 +9,13 @@ logger = logging.getLogger("notifications")
 
 
 def try_context(ctx_obj, var, var_name, context_attr):
-    """Try and get a value from context, otherwise use value supplied
-       as an arg/option. If neither are supplied, bail.
+    """Try and get a value from context.
 
-       The idea is to prevent the user from having to supply the same
-       option twice when executing multiple commands.
+    Try and get a value from context, otherwise use value supplied
+    as an arg/option. If neither are supplied, bail.
+
+    The idea is to prevent the user from having to supply the same
+    option twice when executing multiple commands.
          var: the value supplied as an option
          var_name: Name of the option
          context_attr: attribute to attempt to read from the context object.
@@ -100,7 +102,7 @@ def cli(debug):
     help="Body of release announcement message."
          " May be omitted if create_release is used.")
 def mail(to, subject, body):
-    """Send mail via local MTA"""
+    """Send mail via local MTA."""
     data = generate_message_data(subject=subject, body=body)
     msg = MIMEText(data["body"])
     msg["From"] = data["from"]

--- a/scripts/periodic_cleanup.py
+++ b/scripts/periodic_cleanup.py
@@ -28,13 +28,13 @@ INDENT_STR = 2 * " "
 
 
 def _indp(message, **kwargs):
-    """ Indent Print """
-    print("{indent}{message}".format(
-            indent=INDENT_STR * INDENT,
-            message=message
-        ),
-        **kwargs
-    )
+    """Indent Print."""
+    print("{indent}{message}"
+          .format(
+              indent=INDENT_STR * INDENT,
+              message=message
+          ),
+          **kwargs)
 
 
 def log(f):
@@ -51,8 +51,8 @@ def log(f):
         delta = end - start
         INDENT -= 1
         _indp("Completed: {function} ({delta}s)".format(
-                function=f.func_name,
-                delta=delta.seconds))
+              function=f.func_name,
+              delta=delta.seconds))
         return result
     return wrapper
 
@@ -230,13 +230,13 @@ class Cleanup:
             _indp("Agent token: {}".format(label), end=" ")
 
             if not re.match(self.protected_prefix, hostname):
-                print ("[not protected]", end=" ")
+                print("[not protected]", end=" ")
             else:
                 print()
                 continue
 
             if hostname not in self.server_names:
-                print ("[not related to active instance]", end=" ")
+                print("[not related to active instance]", end=" ")
             else:
                 print()
                 continue

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -177,9 +177,9 @@ def usage():
         print("<br>{}:<br>".format(name))
         help_lines = command.get_help(click.get_current_context()).split('\n')
         for line in help_lines:
-            if (not (line.startswith("Usage:") or line.startswith("Options:"))
-                    and line):
-                print "{}<br>".format(line)
+            if (not (line.startswith("Usage:") or (
+                    line.startswith("Options:")) and line)):
+                print("{}<br>".format(line))
 
 
 ghutils.cli.add_command(generate_release_notes)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,8 @@
 ansible
 click
+croniter
 jenkins-job-builder
 flake8
 tox
 nose
+jmespath


### PR DESCRIPTION
This commit rewrites the build summary interface so that
* Failures can be viewed by category
* Individual repos/jobs/failures/failure categories can be inspected
* Items within the ui can be linked from outside
* Dynamic graphs/tables with tabs so that the
  most relevant data can be shown without overwhelming the page.

This commit builds on the previous commit that shifted to vuejs
but kept the ui largely similar to the old jquery one.
This embraces vue, and its component structure.

Demo build: http://rpc-repo.rackspace.com/rpcgating/buildsummarybeta/index.html#/

Note that further work is required in RE-1655.

Issue: [RO-4182](https://rpc-openstack.atlassian.net/browse/RO-4182)