### PR TITLE
RE-1548 Quote env.RE_JOB_TRIGGER_DETAIL on PULL

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1295,7 +1295,7 @@ void setTriggerVars(){
       env.RE_JOB_TRIGGER_DETAIL = root_cause.getShortDescription()
   } else if (root_cause instanceof org.jenkinsci.plugins.ghprb.GhprbCause){
       env.RE_JOB_TRIGGER="PULL"
-      env.RE_JOB_TRIGGER_DETAIL = "${root_cause.title}/${root_cause.pullID}"
+      env.RE_JOB_TRIGGER_DETAIL = "\"${root_cause.title}/${root_cause.pullID}\""
   } else {
       env.RE_JOB_TRIGGER="OTHER"
   }


### PR DESCRIPTION
When RE_JOB_TRIGGER is PULL, we need to quote the RE_JOB_TRIGGER_DETAIL
env var as it contains spaces and is breaking the rpc-o's MNAIO tooling
when run on the MNAIO RELEASE job.

Issue: [RE-1548](https://rpc-openstack.atlassian.net/browse/RE-1548)