### PR TITLE
ASC-662 Remove most leapfrog system jobs

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -147,13 +147,7 @@
       - "r12.2.2_to_newton_leap"
       - "r12.1.2_to_newton_leap"
       - "kilo_to_newton_leap"
-      - "mitaka_to_newton_leap_system"
       - "liberty_to_newton_leap_system"
-      - "r12.2.8_to_newton_leap_system"
-      - "r12.2.5_to_newton_leap_system"
-      - "r12.2.2_to_newton_leap_system"
-      - "r12.1.2_to_newton_leap_system"
-      - "kilo_to_newton_leap_system"
     jira_project_key: "RLM"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
@@ -180,11 +174,6 @@
       - "r12.1.2_to_r14.current_leap"
       - "kilo_to_r14.current_leap"
       - "liberty_to_r14.current_leap_system"
-      - "r12.2.8_to_r14.current_leap_system"
-      - "r12.2.5_to_r14.current_leap_system"
-      - "r12.2.2_to_r14.current_leap_system"
-      - "r12.1.2_to_r14.current_leap_system"
-      - "kilo_to_r14.current_leap_system"
     jira_project_key: "RLM"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'


### PR DESCRIPTION
This commit removes all but the following leapfrog system jobs.

* PM_rpc-upgrades-master-trusty_mnaio-swift-liberty_to_r14.current_leap_system
* PM_rpc-upgrades-master-trusty_mnaio-swift-liberty_to_newton_leap_system

At the time of this commit, all of the leapfrog system jobs were
consistently failing. The jobs would either fail during deployment or
the system tests would fail. In order to reduce the noise and not waste
infrastructure resources all but the above jobs are being deleted.

The above jobs should be enough for us to be able to resolve the root
cause of the failures. Once they are passing the jobs deleted in this PR
will be added back in a more controlled manner.

JIRA: ASC-662

Issue: [ASC-662](https://rpc-openstack.atlassian.net/browse/ASC-662)