### PR TITLE
Add retries and conditionals to cloudfiles upload

### DIFF
--- a/playbooks/upload_to_swift.yml
+++ b/playbooks/upload_to_swift.yml
@@ -2,21 +2,26 @@
 - hosts: localhost
   connection: local
   gather_facts: False
+  vars:
+    region: "DFW"
+    cloud_name: "public_cloud"
+    # 30 days
+    retention: 2592000
   tasks:
+    - name: Set the archive base name
+      set_fact:
+        archive_base_name: "{{ job_name }}_{{ build_number }}"
 
-    - set_fact:
-        archive_base_name: "{{job_name}}_{{build_number}}"
-
-    # This is done so that downloaded archives have a useful name
-    - name: Move artifacts dir
+    - name: Move artifacts dir so that downloaded archives have a useful name
       shell: mv "{{ artifacts_dir | basename }}" "{{ archive_base_name }}"
       args:
         chdir: "{{ artifacts_dir | dirname }}"
 
-    - set_fact:
+    - name: Set the archive directory
+      set_fact:
         adir: "{{ artifacts_dir | dirname }}/{{archive_base_name}}"
 
-    # links are unlikely to work when expanded on a different
+    # Links are unlikely to work when expanded on a different
     # system so remove them. Create a list of removed links
     # to give users a clue as to why their file is missing.
     # Also swift client fails on dangling links.
@@ -34,7 +39,7 @@
     # This task runs async while the individual files are being uploaded
     # then when compression is complete, the resultant archive is uploaded.
     # 3 Hour Timeout
-    - name: Create archive
+    - name: Create archive asynchronously
       shell: "tar -c {{ adir | basename }} | gzip --fast > {{archive_base_name}}.tar.gz"
       args:
         chdir: "{{ adir | dirname }}"
@@ -44,79 +49,81 @@
       tags:
         - skip_ansible_lint
 
-    - name: Create a public Cloud Files container
+    - name: Create a Cloud Files container
       os_object:
         container: "{{ container }}"
         container_access: "public"
         region_name: "{{ region }}"
         cloud: "{{ cloud_name }}"
+      register: _create_container
+      until: _create_container | success
+      retries: 5
+      delay: 10
 
     - name: Authenticate to the cloud and retrieve the service catalog
       os_auth:
         cloud: "{{ cloud_name }}"
         region_name: "{{ region }}"
       no_log: true
+      register: _auth
+      until: (_auth | success) and (auth_token is defined) and (service_catalog is defined)
+      retries: 5
+      delay: 10
 
-    - set_fact:
+    - name: Extract object-store service catalog
+      set_fact:
         object_store: "{{ service_catalog | selectattr('type', 'equalto', 'object-store') | first }}"
 
-    - set_fact:
-        rax_pub_cloud: "{{ 'clouddrive.com' in object_store['endpoints'][0]['publicURL'] }}"
-
-    - set_fact:
-        object_cdn: "{{ service_catalog | selectattr('type', 'equalto', 'rax:object-cdn') | first }}"
-      when: rax_pub_cloud
-
-    - set_fact:
-        object_cdn_url: "{{ (object_cdn['endpoints'] | selectattr('region', 'equalto', region) | first)['publicURL'] }}/{{ container }}"
-
-    - set_fact:
+    - name: Determine the object-store service endpoint URL for the region
+      set_fact:
         object_store_url: "{{ (object_store['endpoints'] | selectattr('region', 'equalto', region ) | first)['publicURL']}}"
 
-    - name: Enable CDN
+    - name: Extract object-cdn service catalog
+      set_fact:
+        object_cdn: "{{ service_catalog | selectattr('type', 'equalto', 'rax:object-cdn') | first }}"
+
+    - name: Determine the object-cdn service endpoint URL for the region
+      set_fact:
+        object_cdn_url: "{{ (object_cdn['endpoints'] | selectattr('region', 'equalto', region) | first)['publicURL'] }}/{{ container }}"
+
+    - name: Enable CDN for the Cloud Files container
       uri:
-        url: "{{object_cdn_url}}"
+        url: "{{ object_cdn_url }}"
         method: PUT
         headers:
           X-AUTH-TOKEN: "{{ auth_token }}"
           X-Cdn-Enabled: True
-        status_code: "200, 201, 202, 204"
-      no_log: true
+        # 201 (Created): The container was CDN-enabled as requested.
+        # 202 (Accepted): The container was already CDN-enabled.
+        # 204 (No Content): The container was CDN-enabled as requested, but has no content.
+        status_code: "201, 202, 204"
+      register: _enable_cdn
+      until: (_enable_cdn | success) and ('x_cdn_ssl_uri' in _enable_cdn)
+      retries: 5
+      delay: 10
 
-    - name: Get Rackspace CloudFiles CDN URL
-      uri:
-        url: "{{ object_cdn_url }}"
-        method: HEAD
-        headers:
-          X-AUTH-TOKEN: "{{ auth_token }}"
-        status_code: 204
-      no_log: true
-      register: object_cdn_data
-      when: rax_pub_cloud
-
-    - set_fact:
-        container_public_url: "{{ object_cdn_data['x_cdn_ssl_uri'] }}"
-      when: rax_pub_cloud
-
-    - set_fact:
-        container_public_url: "{{ object_store['endpoints'][0]['publicURL'] }}"
-      when: not rax_pub_cloud
-
+    - name: Set fact for the user-accessible CDN URL for the container
+      set_fact:
+        container_public_url: "{{ _enable_cdn['x_cdn_ssl_uri'] }}"
 
     # In order for uploaded files to be browsable:
     # 1. Static hosting must be enabled (this links index.html to requests for container/)
     # 2. CDN must be enabled (to allow anonymous http access to the container)
-    # 3. An index page must be generated, as this is not done automatically
+    # 3. An index page must be generated and/or web listings enabled.
     - name: Enable static web hosting
       uri:
-        url: "{{object_store_url}}/{{container}}"
+        url: "{{ object_store_url }}/{{ container }}"
         method: POST
         headers:
           X-AUTH-TOKEN: "{{ auth_token }}"
           X-Container-Meta-Web-Index: index.html
           X-Container-Meta-Web-Listings: True
-        status_code: 200, 201, 202, 204
-      no_log: true
+        # 204 (No Content): The container was enabled as requested.
+        status_code: 204
+      register: _enable_static_hosting
+      until: _enable_static_hosting | success
+      retries: 5
+      delay: 10
 
     # Do this before generating index.html, styles.css and data.json
     # So they don't show up on the final page.
@@ -141,19 +148,27 @@
         src: templates/artifact/styles.css
         dest: "{{ adir }}/styles.css"
 
-
-    # os_object does not currently support setting object expiration header field
-    # production retention
+    # The ansible os_object module does not currently support setting
+    # the object expiration header field, nor does it do threaded uploads
+    # (which make this much faster), so we use the swift client instead.
+    # Checksum validation is also disabled to improve upload speed.
     - name: Upload Artifacts to Cloud Files
-      command: "swift upload --object-threads 100 --ignore-checksum --header 'X-Delete-After:{{ retention }}' {{ container }} {{ adir | basename }}"
+      command: >-
+        swift upload {{ container }} {{ adir | basename }}
+        --object-threads 100
+        --ignore-checksum
+        --header 'X-Delete-After:{{ retention }}'
       args:
         chdir: "{{ adir |dirname }}"
       environment:
         OS_AUTH_TOKEN: "{{ auth_token }}"
         OS_STORAGE_URL: "{{ (object_store['endpoints'] | selectattr('region', 'equalto', region) | first)['publicURL'] }}"
+      # TODO(odyssey4me):
+      # Consider removing '--ignore-checksum' and adding '--skip-identical'
+      # and/or '--changed', then removing the 'failed_when' below and adding
+      # retry/until to improve the chances of success.
       failed_when: false
       register: artifact_upload
-
 
     # this is json data containing metadata and a list of files
     # that will be downloaded by index.html
@@ -189,8 +204,10 @@
           }
         dest: "{{ adir }}/data.json"
 
-    # os_object does not currently support setting object expiration header field
-    - name: Upload index data (data.json) to CloudFiles
+    # The ansible os_object module does not currently support setting
+    # the object expiration header field, nor does it do threaded uploads
+    # (which make this much faster), so we use the swift client instead.
+    - name: Upload index data (data.json) to Cloud Files
       command: >-
         swift upload {{ container }} {{ adir | basename }}/data.json
         --header 'X-Delete-After: {{ retention }}'
@@ -200,8 +217,9 @@
         OS_AUTH_TOKEN: "{{ auth_token }}"
         OS_STORAGE_URL: "{{ (object_store['endpoints'] | selectattr('region', 'equalto', region) | first)['publicURL'] }}"
       register: upload_data
-      until: upload_data|success
-      retries: 2
+      until: upload_data | success
+      retries: 5
+      delay: 10
 
     - name: Wait for async archive creation to complete
       async_status:
@@ -211,8 +229,10 @@
       retries: 180
       delay: 60
 
-    # os_object does not currently support setting object expiration header field
-    - name: Upload archive to CloudFiles
+    # The ansible os_object module does not currently support setting
+    # the object expiration header field, nor does it do threaded uploads
+    # (which make this much faster), so we use the swift client instead.
+    - name: Upload archive to Cloud Files
       command: >-
         swift upload {{ container }} {{ archive_base_name }}.tar.gz
         --header 'X-Delete-After: {{ retention }}'
@@ -222,15 +242,12 @@
         OS_AUTH_TOKEN: "{{ auth_token }}"
         OS_STORAGE_URL: "{{ (object_store['endpoints'] | selectattr('region', 'equalto', region) | first)['publicURL'] }}"
       register: upload_archive
-      until: upload_archive|success
-      retries: 2
+      until: upload_archive | success
+      retries: 5
+      delay: 10
 
-    # used by common.archive_artifacts to put the link into the build description
+    # This is used by common.archive_artifacts to put the link into the
+    # build description.
     - name: "Write public url file"
       shell: |
         echo "{{ container_public_url }}/{{archive_base_name}}/index.html" > ${WORKSPACE}/artifact_public_url
-  vars:
-    region: "DFW"
-    cloud_name: "public_cloud"
-    # 30 days
-    retention: 2592000


### PR DESCRIPTION
In order to improve the chances of the job artifact uploads
succeeding, all operations now have retries added, and more
specific conditions for success.

The rax_pub_cloud fact setting, related conditionals and tasks
for the 'not rax_pub_cloud' case are removed as that is an
unused and untested code path.

The 'Get Rackspace CloudFiles CDN URL' task is removed. The
previous task returns the data required, so this removes an
extra API call and point of failure.

The URI tasks have tightened response codes, with comments
for what each code means. This prevents failures leaking
through and makes it easier to understand what they are.

The URI tasks have 'no_log: True' removed, as they do not
expose any sensitive information unless the playbook is
run with '-vvv' which is not the case here.

As a matter of style and easier debugging, the following is
also done:

1. The vars are moved to the top of the playbook to make them
   more obvious when looking at the playbook.
2. All tasks are named according to what they do.
3. Comments are added/improved to make it clearer what is going
   on.
4. The service catalog data extraction is re-ordered to group
   the two object-store tasks together, and the two object-cdn
   tasks together.
5. All jinja vars are spaced. eg: "{{ object_cdn_url }}" instead
   of "{{object_cdn_url}}".
6. The 'Upload Artifacts to Cloud Files' command is split into
   multiple lines to make it easier to read, and is re-arranged
   to be in the same sequence as the other swift commands later
   in the play.

JIRA: RE-1618

Issue: [RE-1618](https://rpc-openstack.atlassian.net/browse/RE-1618)