### PR TITLE
RE-1682 Tag SHA not branch

### DIFF
--- a/rpc_jobs/standard_job_release.yml
+++ b/rpc_jobs/standard_job_release.yml
@@ -88,6 +88,7 @@
 
         ORG=component["repo_url"].split("/")[3]
         REPO=component["name"]
+        SHA=component["release"]["sha"]
         VERSION=component["release"]["version"]
         PREVIOUS_VERSION=pred_version
         RELEASE_NOTES_FILE="${WORKSPACE}/artifacts/release_notes"
@@ -117,7 +118,7 @@
                 clone \
                     --ref "${MAINLINE}" \
                 publish_tag \
-                    --ref "${MAINLINE}" \
+                    --ref "${SHA}" \
                     --version "${VERSION}" \
                 generate_release_notes \
                     --version "${VERSION}" \
@@ -140,7 +141,7 @@
                 clone \
                     --ref "${RC_BRANCH}" \
                 publish_tag \
-                    --ref "${RC_BRANCH}" \
+                    --ref "${SHA}" \
                     --version "${VERSION}" \
                 generate_release_notes \
                     --version "${VERSION}" \


### PR DESCRIPTION
Currently, when we release through the pipeline we're tagging with the
branch (mainline or mainline-rc) instead of the specified SHA. This
commit updates rpc_jobs/standard_job_release.yml to tag the SHA incase
the specified SHA is not the latest commit in the branch.

Issue: [RE-1682](https://rpc-openstack.atlassian.net/browse/RE-1682)