### PR TITLE
Add extra validation conditionals for auth_token

### DIFF
--- a/playbooks/upload_to_swift.yml
+++ b/playbooks/upload_to_swift.yml
@@ -66,7 +66,12 @@
         region_name: "{{ region }}"
       no_log: true
       register: _auth
-      until: (_auth | success) and (auth_token is defined) and (service_catalog is defined)
+      until: (_auth | success) and
+             (auth_token is defined) and
+             (auth_token is not none) and
+             (auth_token | trim != '') and
+             (service_catalog is defined) and
+             (service_catalog is not none)
       retries: 5
       delay: 10
 


### PR DESCRIPTION
When doing authentication, just validating that auth_token
is defined may not be enough. In this patch we make sure
that it is defined and that it is not empty.

JIRA: RE-1618

Issue: [RE-1618](https://rpc-openstack.atlassian.net/browse/RE-1618)