### PR TITLE
RE-1682 Check SHA before running RELEASE_*

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1530,23 +1530,23 @@ void runReleasesPullRequestWorkflow(String baseBranch, String prBranch, String j
         "master",
       )
       println "=== Checking that the specified SHA exists ==="
-      Integer no_sha = sh(
+      Boolean sha_exists = ! sh(
         script: """#!/bin/bash -xe
           git rev-parse --verify ${SHA}^{commit}
         """,
         returnStatus: true,
       )
-      if (no_sha) {
+      if (! sha_exists) {
         throw new Exception("The supplied SHA ${SHA} was not found.")
       }
       println "=== Checking for the existence of an RC branch ==="
-      Integer no_rc = sh(
+      Boolean has_rc_branch = ! sh(
         script: """#!/bin/bash -xe
           git rev-parse --verify remotes/origin/${RC_BRANCH}
         """,
         returnStatus: true,
       )
-      if (!no_rc) {
+      if (has_rc_branch) {
         println "=== Checking that the specified SHA is the tip of RC branch ${RC_BRANCH} ==="
         String latest_sha = sh(
           script: """#!/bin/bash -xe
@@ -1564,7 +1564,7 @@ void runReleasesPullRequestWorkflow(String baseBranch, String prBranch, String j
       }
 
       testRelease(componentText)
-      createRelease(componentText, !no_rc)
+      createRelease(componentText, has_rc_branch)
     }
   }else if (type == "registration"){
     registerComponent(componentText, jiraProjectKey)

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1513,13 +1513,61 @@ def findHookDir(String hook_dirs) {
 }
 
 void runReleasesPullRequestWorkflow(String baseBranch, String prBranch, String jiraProjectKey){
-  (prType, componentText) = getComponentChange(baseBranch, prBranch)
+  def (prType, componentText) = getComponentChange(baseBranch, prBranch)
+  def componentYaml = readYaml text: componentText
 
   if (prType == "release"){
-    testRelease(component_text)
-    createRelease()
+    String REPO_NAME=componentYaml["name"]
+    String REPO_URL=componentYaml["repo_url"]
+    String SHA=componentYaml["release"]["sha"]
+    String MAINLINE=componentYaml["release"]["series"]
+    String RC_BRANCH="${MAINLINE}-rc"
+
+    dir(REPO_NAME){
+      clone_with_pr_refs(
+        "./",
+        REPO_URL,
+        "master",
+      )
+      println "=== Checking that the specified SHA exists ==="
+      Integer no_sha = sh(
+        script: """#!/bin/bash -xe
+          git rev-parse --verify ${SHA}^{commit}
+        """,
+        returnStatus: true,
+      )
+      if (no_sha) {
+        throw new Exception("The supplied SHA ${SHA} was not found.")
+      }
+      println "=== Checking for the existence of an RC branch ==="
+      Integer no_rc = sh(
+        script: """#!/bin/bash -xe
+          git rev-parse --verify remotes/origin/${RC_BRANCH}
+        """,
+        returnStatus: true,
+      )
+      if (!no_rc) {
+        println "=== Checking that the specified SHA is the tip of RC branch ${RC_BRANCH} ==="
+        String latest_sha = sh(
+          script: """#!/bin/bash -xe
+            git rev-parse --verify remotes/origin/${RC_BRANCH}
+          """,
+          returnStdout: true,
+        ).trim()
+        // (NOTE(mattt): We should be releasing the tip of ${RC_BRANCH}, so
+        //               if the SHA specified in the release does not match
+        //               the tip of ${RC_BRANCH} we throw an exception to
+        //               abort the release.
+        if (latest_sha != SHA) {
+          throw new Exception("The supplied SHA ${SHA} is not the tip on RC branch ${RC_BRANCH}.")
+        }
+      }
+
+      testRelease(componentText)
+      createRelease(componentText, !no_rc)
+    }
   }else if (type == "registration"){
-    registerComponent(component_text, jiraProjectKey)
+    registerComponent(componentText, jiraProjectKey)
   }else{
     throw new Exception("The pull request type ${prType} is unsupported.")
   }
@@ -1723,7 +1771,7 @@ void testRelease(component_text){
   parallel parallelBuilds
 }
 
-void createRelease(){
+void createRelease(String component_text, Boolean from_rc_branch){
   build(
     job: "Component-Release",
     wait: true,
@@ -1747,6 +1795,11 @@ void createRelease(){
         $class: "StringParameterValue",
         name: "pr_number",
         value: ghprbPullId,
+      ],
+      [
+        $class: "BooleanParameterValue",
+        name: "from_rc_branch",
+        value: from_rc_branch,
       ],
     ]
   )

--- a/rpc_jobs/standard_job_release.yml
+++ b/rpc_jobs/standard_job_release.yml
@@ -39,6 +39,9 @@
       - rpc_gating_params
       - text:
           name: component_text
+      - bool:
+          name: from_rc_branch
+          default: false
       - validating-string:
           name: pr_repo
           regex: "[a-zA-Z0-9-]+/[a-zA-Z0-9._-]+"
@@ -94,21 +97,8 @@
         RELEASE_NOTES_FILE="${WORKSPACE}/artifacts/release_notes"
         MAINLINE=component["release"]["series"]
         RC_BRANCH="${MAINLINE}-rc"
-        dir(REPO){
-          println "=== Checking for the existence of an RC branch ==="
-          common.clone_with_pr_refs(
-            "./",
-            component["repo_url"],
-            "master",
-          )
-          no_rc = sh(
-            script: """#!/bin/bash -xe
-              git rev-parse --verify remotes/origin/${RC_BRANCH}
-            """,
-            returnStatus: true,
-          )
-        }
-        if (no_rc){
+
+        if (from_rc_branch == "false"){
           println "An RC branch called ${RC_BRANCH} was not found, releasing from ${MAINLINE}"
           release_command = """\
             python rpc-gating/scripts/release.py \


### PR DESCRIPTION
This commit updates the release process to check for the following:

- if the specified SHA is valid
- if the component has an RC branch
- if the tip of the RC branch matches the supplied SHA

Rather than checking this after the RELEASE_* jobs have run, we move
these checks into runReleasesPullRequestWorkflow(). This means an
issue with a SHA will surface before we've wasted time running
RELEASE_* jobs.

Additionally, we correctly reference `componentYaml` in
runReleasesPullRequestWorkflow() rather than `component_text` since
`component_text` is being made available from some outer scope.

Lastly, since we're now checking for the RC branch in
runReleasesPullRequestWorkflow(), we add a bool parameter called
`from_rc_branch` to the `Component-Release` job and correctly pass this
in in `createRelease()`.

Issue: [RE-1682](https://rpc-openstack.atlassian.net/browse/RE-1682)