### PR TITLE
RE-783 Change the label for build failure issues

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -711,8 +711,9 @@ def safe_jira_comment(body, String repo_path="rpc-openstack"){
 
 // This function creates or updates issues related to build failures.
 // Should be used to report build failures by calling:
-//    common.build_failure_issue(project)
-String build_failure_issue(String project){
+//    common.build_failure_issue(project, labels)
+String build_failure_issue(String project,
+                           List labels = []){
   withCredentials([
     usernamePassword(
       credentialsId: "jira_user_pass",
@@ -727,7 +728,7 @@ String build_failure_issue(String project){
         --user '$JIRA_USER' \
         --password '$JIRA_PASS' \
         build_failure_issue \
-          --project "${project}" \
+          --project "${project}" ${generate_label_options(labels)} \
           --job-name "${env.JOB_NAME}" \
           --job-url "${env.JOB_URL}" \
           --build-tag "${env.BUILD_TAG}" \
@@ -1448,7 +1449,8 @@ void stdJob(String hook_dir, String credentials, String jira_project_key, String
           currentBuild.result="FAILURE"
           if (env.ghprbPullId == null && ! isUserAbortedBuild() && jira_project_key != '') {
             print("Creating build failure issue.")
-            build_failure_issue(jira_project_key)
+            def labels = ['post-merge-test-failure', 'jenkins', env.JOB_NAME]
+            build_failure_issue(jira_project_key, labels)
           } else {
             print("Skipping build failure issue creation.")
           }

--- a/scripts/jirautils.py
+++ b/scripts/jirautils.py
@@ -179,12 +179,19 @@ def get_or_create_issue(project, status, labels, description, summary):
 
 @cli.command()
 @click.option('--project')
+@click.option('--label',
+              'labels',
+              help="Add label to issue, can be specified multiple times",
+              multiple=True,
+              default=[])  # leave empty by default, will be set below
 @click.option('--job-name', help="Name of the job")
 @click.option('--job-url', help="URL of the job")
 @click.option('--build-tag',
               help="Build Tag (string the identifies the job and build.)")
 @click.option('--build-url', help="URL of the build")
-def build_failure_issue(project, job_name, job_url, build_tag, build_url):
+def build_failure_issue(
+        project, labels, job_name, job_url, build_tag,
+        build_url):
     """Create issue for build failure.
 
     1) Identify or create an issue relating to the Job that failed.
@@ -193,10 +200,14 @@ def build_failure_issue(project, job_name, job_url, build_tag, build_url):
     ctx = click.get_current_context()
     authed_jira = ctx.obj
 
+    # set labels to default values if not defined
+    if not labels:
+        labels = ["jenkins-build-failure", "jenkins", job_name]
+
     issue = _get_or_create_issue(
         project=project,
         status="BACKLOG",
-        labels=["jenkins-build-failure", "jenkins", job_name],
+        labels=labels,
         summary="JBF: {jn}".format(jn=job_name),
         description="The following job failed a build: [{jn}|{ju}]"
                     .format(jn=job_name, ju=job_url))


### PR DESCRIPTION
The post merge test standard job (Created in RE-507) creates
JIRA issues on failure. These issues use the default label from
jirautils.py which is "jenkins-build-failure".  This task should allow a
label to be set in common.groovy (as "post-merge-test-failure" in
stdJob) and passes the label to jirautil.py.

JIRA: RE-783

Issue: [RE-783](https://rpc-openstack.atlassian.net/browse/RE-783)