### PR TITLE
RE-1500 Artifact index build summary job link

### DIFF
--- a/playbooks/templates/artifact/index.html
+++ b/playbooks/templates/artifact/index.html
@@ -399,7 +399,7 @@
             {
               icon: 'graphic_eq',
               title: 'Build Summary Dashboard',
-              url: "http://rpc-repo.rackspace.com/rpcgating/buildsummary/"
+              url: "http://rpc-repo.rackspace.com/rpcgating/buildsummary/index.html#/job/" + this.job_name
             },
 
           ]


### PR DESCRIPTION
Instead of linking to the main page of the build summary, link
to the build summary page for the job that generated the artifacts.

Issue: [RE-1500](https://rpc-openstack.atlassian.net/browse/RE-1500)