### PR TITLE
RE-1582 Reduce library clone size

### DIFF
--- a/job_dsl/release.groovy
+++ b/job_dsl/release.groovy
@@ -1,4 +1,4 @@
-library "rpc-gating@${RPC_GATING_BRANCH}"
+library "rpc-gating-master"
 common.globalWraps(){
   stage("Configure Git"){
     common.configure_git()

--- a/job_dsl/rpc_artifact_build.groovy
+++ b/job_dsl/rpc_artifact_build.groovy
@@ -1,7 +1,7 @@
 // Can't use env.FOO = {FOO} to transfer JJB vars to groovy
 // as this file won't be templated by JJB.
 // Alternative is to use parameters with JJB vars as the defaults.
-library "rpc-gating@${RPC_GATING_BRANCH}"
+library "rpc-gating-master"
 common.globalWraps(){
   image_list = [
     "nodepool-rpco-14.2-xenial-base",

--- a/job_dsl/rpc_gating_merge_trigger.groovy
+++ b/job_dsl/rpc_gating_merge_trigger.groovy
@@ -1,7 +1,7 @@
 // Can't use env.FOO = {FOO} to transfer JJB vars to groovy
 // as this file won't be templated by JJB.
 // Alternative is to use parameters with JJB vars as the defaults.
-library "rpc-gating@${RPC_GATING_BRANCH}"
+library "rpc-gating-master"
 common.globalWraps(){
 
   // We do not want to trigger any of these

--- a/job_dsl/standard_job_dep_update.groovy
+++ b/job_dsl/standard_job_dep_update.groovy
@@ -1,7 +1,7 @@
 // Can't use env.FOO = {FOO} to transfer JJB vars to groovy
 // as this file won't be templated by JJB.
 // Alternative is to use parameters with JJB vars as the defaults.
-library "rpc-gating@${RPC_GATING_BRANCH}"
+library "rpc-gating-master"
 common.globalWraps(){
   common.standard_job_slave(env.SLAVE_TYPE) {
     try {

--- a/rpc_jobs/standard_job_gate.yml
+++ b/rpc_jobs/standard_job_gate.yml
@@ -89,5 +89,5 @@
             A comma separated list of pull requsts IDs to enable the testing of a chain of pull requests.
 
     dsl: |
-      library "rpc-gating@${{RPC_GATING_BRANCH}}"
+      library "rpc-gating-master"
       common.stdJob("gate", "{credentials}", "", "{wrappers}")

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -86,5 +86,5 @@
       - timed: "{CRON}"
 
     dsl: |
-      library "rpc-gating@${{RPC_GATING_BRANCH}}"
+      library "rpc-gating-master"
       common.stdJob("periodic,post_merge_test", "{credentials}", "{jira_project_key}", "{wrappers}")

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -78,8 +78,10 @@
     dsl: |
       if ("{repo_name}" == "rpc-gating"){{
         env.RPC_GATING_BRANCH = "origin/pr/${{env.ghprbPullId}}/merge"
+        library "rpc-gating@${{RPC_GATING_BRANCH}}"
+      }} else {{
+        library "rpc-gating-master"
       }}
-      library "rpc-gating@${{RPC_GATING_BRANCH}}"
       if (! common.isSkippable(skip_pattern, "{credentials}")) {{
         common.stdJob("check,pre_merge_test", "{credentials}", "", "{wrappers}")
       }}

--- a/rpc_jobs/standard_job_release.yml
+++ b/rpc_jobs/standard_job_release.yml
@@ -20,7 +20,7 @@
     parameters:
       - rpc_gating_params
     dsl: |
-      library "rpc-gating@${RPC_GATING_BRANCH}"
+      library "rpc-gating-master"
       common.globalWraps(){
         dir("${env.WORKSPACE}/releases") {
           common.clone_with_pr_refs()


### PR DESCRIPTION
There are now two global libraries defined in jenkins, rpc-gating
and rpc-gating-master. rpc-gating does a full clone and fetches
additional refs such as PRs. rpc-gating master does a shallow clone
and does not fetch additional refs. Consequently rpc-gating-master
is faster and uses fewer resources on the master. This commit moves
production standard jobs to use rpc-gating-master. The pre merge
standard job will use rpc-gating when running against the rpc-gating
repo.

Issue: [RE-1582](https://rpc-openstack.atlassian.net/browse/RE-1582)