### PR TITLE
CEPHSTORA-236 Enable 3rd party dep updates

### DIFF
--- a/rpc_jobs/rpc_ceph.yml
+++ b/rpc_jobs/rpc_ceph.yml
@@ -153,7 +153,7 @@
       - "master"
     jira_project_key: "CEPHSTORA"
     component_dependencies_update: "true"
-    third_party_dependencies_update: "false"
+    third_party_dependencies_update: "true"
     trigger:
       - PR:
           CRON: ""


### PR DESCRIPTION
This enables 3rd party dep updates for rpc-ceph.

Issue: [CEPHSTORA-236](https://rpc-openstack.atlassian.net/browse/CEPHSTORA-236)