### PR TITLE
[RE-1735] Revert "RE-1555 Implement VPN Connectivity"

### DIFF
--- a/playbooks/phobos_vpn.yml
+++ b/playbooks/phobos_vpn.yml
@@ -1,5 +1,5 @@
-- name: Configure Phobos VPN Tunnel
-  hosts: "{{ target_hosts | default('localhost') }}"
+- name: Configure Phobos VPN Tunnel (should only be run on single use slaves)
+  hosts: localhost
   tasks:
     # Use shell because python-apt isn't available so the apt module fails.
     # I don't want to add python-apt to one of the more general slave setup

--- a/rpc_jobs/setup_nodepool.yml
+++ b/rpc_jobs/setup_nodepool.yml
@@ -73,8 +73,7 @@
                 common.venvPlaybook(
                   playbooks: [
                     "drop_ssh_auth_keys.yml",
-                    "slave_security.yml",
-                    "phobos_vpn.yml"
+                    "slave_security.yml"
                   ],
                   args: [
                     "-v",


### PR DESCRIPTION
This reverts commit 54c71e1ac47deb617ab139f964dee6f1ffe4c970.

This commit is causing the setup_nodepool job to fail as it is not
passing the correct vars to it.

Issue: [RE-1735](https://rpc-openstack.atlassian.net/browse/RE-1735)