### PR TITLE
RE-1725 Add PR info to dep_update issue message

### DIFF
--- a/scripts/dep_update.sh
+++ b/scripts/dep_update.sh
@@ -54,7 +54,8 @@ ssh_url="git@github.com:${owner}/${repo}"
 if [[ -n "$(git status -s)" ]] || [[ ${start_sha} != $(git rev-parse --verify HEAD) ]]; then
   echo "Looking for Jira issue, will create if not found."
   issue_message="This issue was generated automatically by the Jenkins job ${RE_JOB_NAME}.
-  See update_dependencies in https://rpc-openstack.atlassian.net/wiki/spaces/RE/pages/19005457/RE+for+Projects for more details."
+  Please refer to the associated pull request ${ghprbPullLink}
+  More details are available at update_dependencies in https://rpc-openstack.atlassian.net/wiki/spaces/RE/pages/19005457/RE+for+Projects."
   jira_summary="Update ${repo}:${BRANCH} dependencies"
   issue=$(python ${WORKSPACE}/rpc-gating/scripts/jirautils.py \
         --user "${JIRA_USER}" \


### PR DESCRIPTION
The original message posted in the JIRA ticket created by dep_update is
"This issue was generated automatically by the Jenkins job
${RE_JOB_NAME}. See update_dependencies in https://rpc-openstack.atlass-
ian.net/wiki/spaces/RE/pages/19005457/RE+for+Projects for more details."
This task should modify the message to include pull request information.
For the sake of keeping the message relatively short, only the PR link
will be included, but additional PR info can be added if desired.

According to jenkinsci/plugins/ghprb/GhprbTrigger.java, which sets pull
request related environment variables, the pull request link environment
variable that should be used for this modification is $ghprbPullLink

JIRA: RE-1725

Issue: [RE-1725](https://rpc-openstack.atlassian.net/browse/RE-1725)