### PR TITLE
TURTLES-1017: Add bandit to rpc-maas premerge

### DIFF
--- a/rpc_jobs/rpc_maas.yml
+++ b/rpc_jobs/rpc_maas.yml
@@ -77,6 +77,7 @@
     scenario:
       - "ansible-lint"
       - "ansible-syntax"
+      - "bandit"
       - "bashate"
       - "docs"
       - "pep8"


### PR DESCRIPTION
Now that we've added bandit to rpc-maas' tox.ini, we'd like to have it as a Jenkins job.

JIRA: TURTLES-1017

Issue: [TURTLES-1017](https://rpc-openstack.atlassian.net/browse/TURTLES-1017)