### PR TITLE
Separate the apt commands for OnMetal tests

### DIFF
--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -135,8 +135,23 @@
   remote_user: root
   gather_facts: False
   tasks:
-    - name: RLM-275 Adds python packages if python is not present
-      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal python-yaml)
+    - name: Update apt cache (RE-1752)
+      raw: apt-get update
+      args:
+        executable: /bin/bash
+      register: install_packages
+      until: install_packages | success
+      retries: 3
+      delay: 15
+
+    - name: Install python packages if python is not present (RLM-275)
+      raw: test -e /usr/bin/python || apt-get install -y python-minimal python-yaml
+      args:
+        executable: /bin/bash
+      register: install_packages
+      until: install_packages | success
+      retries: 3
+      delay: 15
 
 - hosts: singleuseslave
   tasks:


### PR DESCRIPTION
To ensure that we're able to effectively handle transient
failures, we split the apt cache update and installs, and
we add retries to both. We also shift to using 'apt-get'
instead of 'apt' as the output does not have color coding
and is therefore easier to read in Ansible's output.

JIRA: RE-1752

Issue: [RE-1752](https://rpc-openstack.atlassian.net/browse/RE-1752)