### PR TITLE
RE-1753 Periodic Cleanup Cloud Creds Fix

### DIFF
--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -87,7 +87,7 @@
                   git branch: env.RPC_GATING_BRANCH, url: "https://github.com/rcbops/rpc-gating"
                 }
                 stage("Public Cloud Cleanup"){
-                  common.withRequestedCredentials("jenkins_api_creds") {
+                  common.withRequestedCredentials("cloud_creds, jenkins_api_creds") {
                     clouds_cfg = common.writeCloudsCfg()
                     withEnv(["OS_CLIENT_CONFIG_FILE=${clouds_cfg}"]){
                       sh "python scripts/periodic_cleanup.py"


### PR DESCRIPTION
- Added `cloud_creds` to periodic cleanup creds wrapper so that python script env PUBCLOUD_* creds were available.

JIRA: RE-1753

Issue: [RE-1753](https://rpc-openstack.atlassian.net/browse/RE-1753)