### PR TITLE
Set max-servers for nodepool to 0

### DIFF
--- a/nodepool/files/nodepool.yml
+++ b/nodepool/files/nodepool.yml
@@ -136,7 +136,7 @@ providers:
     diskimages: *provider_diskimage_block
     pools:
       - name: main
-        max-servers: 20
+        max-servers: 0
         availability-zones: []
         labels:
           - name: ubuntu-xenial-g1-8

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -406,7 +406,7 @@ clouds:
 
   phobos_nodepool:
     identity_api_version: 3
-    insecure: true
+    verify: False
     auth:
       auth_url: "${env.PHOBOS_NODEPOOL_AUTH_URL}"
       project_name: "${env.PHOBOS_NODEPOOL_PROJECT_NAME}"


### PR DESCRIPTION
In order to verify that image uploads are working correctly
before anything else, we set max-servers to 0. Once the image
uploads are confirmed to be working we can increase this
number so that Phobos takes on test workloads.

JIRA: RE-1559

Issue: [RE-1559](https://rpc-openstack.atlassian.net/browse/RE-1559)