### PR TITLE
Add phobos network parameter and correct key name

### DIFF
--- a/nodepool/files/nodepool.yml
+++ b/nodepool/files/nodepool.yml
@@ -138,36 +138,38 @@ providers:
       - name: main
         max-servers: 0
         availability-zones: []
+        networks:
+          - rpc-releng-private
         labels:
           - name: ubuntu-xenial-g1-8
             diskimage: ubuntu-xenial
             flavor-name: releng-general1-8
-            key-name: openstack_phobos_nodepool
+            key-name: jenkins
             console-log: true
           - name: ubuntu-trusty-g1-8
             diskimage: ubuntu-trusty
             flavor-name: releng-general1-8
-            key-name: openstack_phobos_nodepool
+            key-name: jenkins
             console-log: true
           - name: ubuntu-xenial-p2-15
             diskimage: ubuntu-xenial
             flavor-name: releng-performance2-15
-            key-name: openstack_phobos_nodepool
+            key-name: jenkins
             console-log: true
           - name: ubuntu-trusty-p2-15
             diskimage: ubuntu-trusty
             flavor-name: releng-performance2-15
-            key-name: openstack_phobos_nodepool
+            key-name: jenkins
             console-log: true
           - name: rpco-14.2-xenial-base
             diskimage: rpco-14.2-xenial-artifacts
             flavor-name: releng-7
-            key-name: openstack_phobos_nodepool
+            key-name: jenkins
             console-log: true
           - name: rpco-14.2-trusty-base
             diskimage: rpco-14.2-trusty-artifacts
             flavor-name: releng-7
-            key-name: openstack_phobos_nodepool
+            key-name: jenkins
             console-log: true
 
 diskimages:


### PR DESCRIPTION
Nodepool needs to know which network to build instances on,
so we add the appropriate configuration to inform it.

Also, the key name set out in the configuration was incorrect,
so we fix that.

JIRA: RE-1559