### PR TITLE
RE-1757 Increase Phobos NodePool Max Servers Value

### DIFF
--- a/nodepool/files/nodepool.yml
+++ b/nodepool/files/nodepool.yml
@@ -136,7 +136,7 @@ providers:
     diskimages: *provider_diskimage_block
     pools:
       - name: main
-        max-servers: 0
+        max-servers: 5
         availability-zones: []
         networks:
           - rpc-releng-private


### PR DESCRIPTION
- Increased value of phobos max-servers to 5 after VPN/Phobos network setup/configuration validation

JIRA: RE-1757