### PR TITLE
RE-1756 Jenkins Master VPN Dies

### DIFF
--- a/nodepool/templates/systemd-service-override.conf.j2
+++ b/nodepool/templates/systemd-service-override.conf.j2
@@ -3,3 +3,4 @@
 #
 [Service]
 Environment="STATSD_HOST=statsd.re.rpc.rackspace.com"
+Restart=always

--- a/rpc_jobs/phobos_vpn_service.yml
+++ b/rpc_jobs/phobos_vpn_service.yml
@@ -65,6 +65,7 @@
 
       expect fork
       respawn
+      respawn limit unlimited
       exec /usr/sbin/vpnc --pid-file /run/vpnc/phobos.pid /etc/vpnc/phobos.conf
       EOF
 


### PR DESCRIPTION
- Added respawn limit unlimited line to restart VPN when process exists

JIRA: RE-1756

Issue: [RE-1756](https://rpc-openstack.atlassian.net/browse/RE-1756)