### PR TITLE
RE-1767 Prevent Instance Leak

### DIFF
--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -210,10 +210,10 @@
               exit 1
             fi
             cat << EOF >/etc/apt/sources.list
-            deb ${DISTRO_MIRROR} ${DISTRO__RELEASE} ${DISTRO_COMPONENTS//,/ }
-            deb ${DISTRO_MIRROR} ${DISTRO__RELEASE}-updates ${DISTRO_COMPONENTS//,/ }
-            deb ${DISTRO_MIRROR} ${DISTRO__RELEASE}-backports ${DISTRO_COMPONENTS//,/ }
-            deb ${DISTRO_MIRROR} ${DISTRO__RELEASE}-security ${DISTRO_COMPONENTS//,/ }
+            deb ${DISTRO_MIRROR} ${DISTRO_RELEASE} ${DISTRO_COMPONENTS//,/ }
+            deb ${DISTRO_MIRROR} ${DISTRO_RELEASE}-updates ${DISTRO_COMPONENTS//,/ }
+            deb ${DISTRO_MIRROR} ${DISTRO_RELEASE}-backports ${DISTRO_COMPONENTS//,/ }
+            deb ${DISTRO_MIRROR} ${DISTRO_RELEASE}-security ${DISTRO_COMPONENTS//,/ }
             EOF
           args:
             executable: /bin/bash

--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -166,9 +166,9 @@
     - name: Check whether python is present on the host
       raw: |
         if [[ -e /usr/bin/python ]]; then
-          echo yes
+          echo -n yes
         else
-          echo no
+          echo -n no
         fi
       register: _python_check
 
@@ -178,7 +178,7 @@
 
     - name: Install python onto the host if it is not already present
       when:
-        - "_python_check.stdout | bool"
+        - "(_python_check.stdout | trim) | bool"
       block:
         # To assist with debugging any problems if there
         # is an apt failure, we set enable debugging.

--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -195,28 +195,7 @@
         # us with reliable and quick responses.
         # ref: RE-1758
         - name: Reconfigure the host to use Rackspace Mirrors
-          raw: |
-            mv /etc/apt/sources.list /etc/apt/sources.list.original
-            DISTRO_MIRROR="http://mirror.rackspace.com/ubuntu"
-            DISTRO_COMPONENTS="main,universe"
-            if [[ -e /etc/lsb-release ]]; then
-              source /etc/lsb-release
-              DISTRO_RELEASE=${DISTRIB_CODENAME}
-            elif [[ -e /etc/os-release ]]; then
-              source /etc/os-release
-              DISTRO_RELEASE=${UBUNTU_CODENAME}
-            else
-              echo "Unable to determine distribution due to missing lsb/os-release files."
-              exit 1
-            fi
-            cat << EOF >/etc/apt/sources.list
-            deb ${DISTRO_MIRROR} ${DISTRO_RELEASE} ${DISTRO_COMPONENTS//,/ }
-            deb ${DISTRO_MIRROR} ${DISTRO_RELEASE}-updates ${DISTRO_COMPONENTS//,/ }
-            deb ${DISTRO_MIRROR} ${DISTRO_RELEASE}-backports ${DISTRO_COMPONENTS//,/ }
-            deb ${DISTRO_MIRROR} ${DISTRO_RELEASE}-security ${DISTRO_COMPONENTS//,/ }
-            EOF
-          args:
-            executable: /bin/bash
+          script: "{{ playbook_dir }}/../scripts/reconfigure_apt_sources.sh"
 
         - name: Check the resulting apt sources file
           raw: cat /etc/apt/sources.list

--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -218,6 +218,16 @@
           args:
             executable: /bin/bash
 
+        - name: Check the resulting apt sources file
+          raw: cat /etc/apt/sources.list
+          args:
+            executable: /bin/bash
+          register: _apt_sources_result
+
+        - name: Show the resulting apt sources file
+          debug:
+            var: _apt_sources_result
+
         - name: Update apt cache
           raw: apt-get update
           args:

--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -178,7 +178,7 @@
 
     - name: Install python onto the host if it is not already present
       when:
-        - "(_python_check.stdout | trim) | bool"
+        - "not (_python_check.stdout | trim) | bool"
       block:
         # To assist with debugging any problems if there
         # is an apt failure, we set enable debugging.

--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -10,6 +10,11 @@
     boot_timeout: "{{ lookup('env', 'BOOT_TIMEOUT') | default(900, true) }}"
   tasks:
 
+    - name: Create inventory directory
+      file:
+        path: "{{ inventory_path }}"
+        state: directory
+
     # regions, and fallback_regions should be CSV strings
     # We randomly shuffle them both, then use the first
     # item of the resulting lists for the try/rescue block.
@@ -59,13 +64,34 @@
             timeout: "{{ boot_timeout }}"
           register: _instance_provision
 
+        - name: Write inventory
+          copy:
+            content: |
+              [job_nodes:children]
+              hosts
+
+              [hosts]
+              {{ _instance_provision.server.name }} ansible_host={{ _instance_provision.server.accessIPv4 }} ansible_user=root rax_region={{ _instance_provision.server.region }}
+            dest: '{{ inventory_path }}/hosts'
+
         - name: Wait for SSH connectivity to the cloud instance (10 min timeout)
-          wait_for_connection:
+          wait_for:
             timeout: 600
             port: 22
             host: "{{ _instance_provision.server.accessIPv4 }}"
+            sleep: 10
+            search_regex: "OpenSSH"
 
       rescue:
+        - name: Ensure first attempt instance is removed.
+          os_server:
+            name: "{{ instance_name }}"
+            state: absent
+            cloud: "{{ cloud_name }}"
+            region_name: "{{ regions_shuff[0] }}"
+            wait: yes
+            timeout: "{{ boot_timeout }}"
+
         - name: Output the fallback region list
           debug:
             msg: "Job-provided secondary regions: {{ fallback_regions }}; Resulting shuffled regions: {{ fallback_regions_shuff }}"
@@ -93,11 +119,23 @@
             timeout: "{{ boot_timeout }}"
           register: _instance_provision
 
+        - name: Write inventory
+          copy:
+            content: |
+              [job_nodes:children]
+              hosts
+
+              [hosts]
+              {{ _instance_provision.server.name }} ansible_host={{ _instance_provision.server.accessIPv4 }} ansible_user=root rax_region={{ _instance_provision.server.region }}
+            dest: '{{ inventory_path }}/hosts'
+
         - name: Wait for SSH connectivity to the fallback cloud instance (10 min timeout)
-          wait_for_connection:
+          wait_for:
             timeout: 600
             port: 22
             host: "{{ _instance_provision.server.accessIPv4 }}"
+            sleep: 10
+            search_regex: "OpenSSH"
 
     - name: Show results of instance provision task
       debug:
@@ -107,21 +145,6 @@
       add_host:
         hostname: "singleuseslave"
         ansible_ssh_host: "{{ _instance_provision.server.accessIPv4 }}"
-
-    - name: Create inventory directory
-      file:
-        path: "{{ inventory_path }}"
-        state: directory
-
-    - name: Write inventory
-      copy:
-        content: |
-          [job_nodes:children]
-          hosts
-
-          [hosts]
-          {{ _instance_provision.server.name }} ansible_host={{ _instance_provision.server.accessIPv4 }} ansible_user=root rax_region={{ _instance_provision.server.region }}
-        dest: '{{ inventory_path }}/hosts'
 
     - name: Show generated inventory
       debug:

--- a/scripts/reconfigure_apt_sources.sh
+++ b/scripts/reconfigure_apt_sources.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Save a backup of the original file
+mv /etc/apt/sources.list /etc/apt/sources.list.original
+
+# Set the environment variables
+DISTRO_MIRROR="http://mirror.rackspace.com/ubuntu"
+DISTRO_COMPONENTS="main,universe"
+
+# Get the distribution name
+if [[ -e /etc/lsb-release ]]; then
+  source /etc/lsb-release
+  DISTRO_RELEASE=${DISTRIB_CODENAME}
+elif [[ -e /etc/os-release ]]; then
+  source /etc/os-release
+  DISTRO_RELEASE=${UBUNTU_CODENAME}
+else
+  echo "Unable to determine distribution due to missing lsb/os-release files."
+  exit 1
+fi
+
+# Rewrite the apt sources file
+cat << EOF >/etc/apt/sources.list
+deb ${DISTRO_MIRROR} ${DISTRO_RELEASE} ${DISTRO_COMPONENTS//,/ }
+deb ${DISTRO_MIRROR} ${DISTRO_RELEASE}-updates ${DISTRO_COMPONENTS//,/ }
+deb ${DISTRO_MIRROR} ${DISTRO_RELEASE}-backports ${DISTRO_COMPONENTS//,/ }
+deb ${DISTRO_MIRROR} ${DISTRO_RELEASE}-security ${DISTRO_COMPONENTS//,/ }
+EOF


### PR DESCRIPTION
**Ensure retries cleanup**
  The allocate_pubcloud playbook will try in a second region if creating an   
  instance in the first region fails, or if the instance in the first region
  can't be contacted via ssh.

  This commit ensures that any instance created in the first region is
  removed before attempting to create an instance in a second region.

  This commit also ensures that writing the inventory file is the first task
  after each instance creation task so that the cleanup stage has the highest
  chance of success.

  This commit also switches back from wait_for_connection to wait_for
  as wait_for_connection ignores host and port parameters, only checking
  connectivity to the host the task is targeted at.

**Ensure inventory stash happens**
  If an error happens during the playbook that allocates instances, then
  groovy throws an exception and the stash task doesn't happen. If the stash
  doesn't happen then cleanup fails, as cleanup relies on retrieving an
  inventory file from a stash.

  So if the playbook succesfully allocates an instance, then fails, the
  instance will be leaked because cleaup will fail.

  This change adds try/finally to ensure that stash is always attempted
  regardless of playbook success.

Jira:  RE-1767

Issue: [RE-1767](https://rpc-openstack.atlassian.net/browse/RE-1767)