### PR TITLE
RE-1756 Jenkins Master VPN Dies

### DIFF
--- a/nodepool/templates/systemd-service-override.conf.j2
+++ b/nodepool/templates/systemd-service-override.conf.j2
@@ -3,4 +3,3 @@
 #
 [Service]
 Environment="STATSD_HOST=statsd.re.rpc.rackspace.com"
-Restart=always

--- a/playbooks/templates/vpnc.service.j2
+++ b/playbooks/templates/vpnc.service.j2
@@ -8,6 +8,7 @@ ConditionPathExists=/dev/net/tun
 [Service]
 Type=forking
 PIDFile=/run/vpnc/phobos.pid
+Restart=always
 
 ExecStart=/usr/sbin/vpnc --pid-file /run/vpnc/phobos.pid /etc/vpnc/phobos.conf
 


### PR DESCRIPTION
- Added respawn limit unlimited line to restart VPN when process exists (added Restart to proper file)

JIRA: RE-1756

Issue: [RE-1756](https://rpc-openstack.atlassian.net/browse/RE-1756)