### PR TITLE
RE-1729 Update NodePool to include RE-1521 and related configuration

### DIFF
--- a/nodepool/files/nodepool.yml
+++ b/nodepool/files/nodepool.yml
@@ -53,6 +53,8 @@ providers:
         config-drive: true
     pools:
       - name: main
+        # Ignore the quota given by public cloud and only respect what we provide as max-servers
+        ignore-provider-quota: True
         max-servers: 20
         availability-zones: []
         labels: &provider_pools_main_labels_block
@@ -106,10 +108,14 @@ providers:
     diskimages: *provider_diskimage_block
     pools:
       - name: main
+        # Ignore the quota given by public cloud and only respect what we provide as max-servers
+        ignore-provider-quota: True
         max-servers: 20
         availability-zones: []
         labels: *provider_pools_main_labels_block
       - name: onmetal
+        # Ignore the quota given by public cloud and only respect what we provide as max-servers
+        ignore-provider-quota: True
         max-servers: 10
         availability-zones: []
         labels: *provider_pools_onmetal_labels_block

--- a/nodepool/setup_nodepool.yml
+++ b/nodepool/setup_nodepool.yml
@@ -29,7 +29,7 @@
   serial: 1
   vars:
     nodepool_file_nodepool_yaml_src: "{{ lookup('env', 'WORKSPACE') }}/rpc-gating/nodepool/files/nodepool.yml"
-    nodepool_git_version: 3de0b20faa6f90437eb62c56ec23c59c6e15b5fa # HEAD of 'master' as of 20 Mar 2018
+    nodepool_git_version: 67824d8e64250ede0cb4a3ebe344412f5cba2218 # HEAD of 'master' as of 25 July 2018
     nodepool_pip_executable: pip3
     nodepool_file_nodepool_builder_service_config_src: systemd-service-override.conf.j2
     nodepool_file_nodepool_launcher_service_config_src: systemd-service-override.conf.j2


### PR DESCRIPTION
- Bumped NodePool Launcher SHA/version to include support for the new 'ignore-provider-quota' configuration option
- Added new 'ignore-provider-quota' configuration flag to each provider - this will allow to configuration to respect the max-servers value.

JIRA: RE-1729

Issue: [RE-1729](https://rpc-openstack.atlassian.net/browse/RE-1729)