### PR TITLE
RE-1782 Temporarily disable phobos builds

### DIFF
--- a/nodepool/files/nodepool.yml
+++ b/nodepool/files/nodepool.yml
@@ -152,7 +152,7 @@ providers:
           hypervisor_type: qemu
     pools:
       - name: main
-        max-servers: 5
+        max-servers: 0
         availability-zones: []
         networks:
           - rpc-releng-private


### PR DESCRIPTION
Phobos builds are causing issues w/ rpc-maas tests (lack of created
entity), temporarily disabling phobos builds until rpc-maas is able to
address.

Issue: [RE-1782](https://rpc-openstack.atlassian.net/browse/RE-1782)