### PR TITLE
Improve jenkins slave setup resilience

### DIFF
--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -163,6 +163,13 @@
   remote_user: root
   gather_facts: False
   tasks:
+    # To assist with debugging any problems if there
+    # is an apt failure, we set enable debugging.
+    - name: Add apt debug configuration
+      raw: echo 'Debug::Acquire::http "true";' > /etc/apt/apt.conf.d/99debug
+      args:
+        executable: /bin/bash
+
     - name: Check whether python is present on the host
       raw: |
         if [[ -e /usr/bin/python ]]; then
@@ -180,13 +187,6 @@
       when:
         - "not (_python_check.stdout | trim) | bool"
       block:
-        # To assist with debugging any problems if there
-        # is an apt failure, we set enable debugging.
-        - name: Add apt debug configuration
-          raw: echo 'Debug::Acquire::http "true";' > /etc/apt/apt.conf.d/99debug
-          args:
-            executable: /bin/bash
-
         # The apt sources in the OnMetal builds uses
         # archive.ubuntu.com which has turned out to
         # be a bit unreliable in providing complete

--- a/playbooks/setup_jenkins_slave.yml
+++ b/playbooks/setup_jenkins_slave.yml
@@ -21,6 +21,10 @@
       timeout: 180
       # Sleep 5 seonds between checks
       sleep: 5
+    jenkins_apt_packages:
+      - git-core
+      - openjdk-8-jre-headless
+      - libxml2-utils
   roles:
     - role: willshersystems.sshd
       sshd:
@@ -41,25 +45,44 @@
     - name: Add OpenJDK PPA
       apt_repository:
         repo: ppa:openjdk-r/ppa
+        update_cache: no
       register: install_ppa
       until: install_ppa | success
-      retries: 5
-      delay: 2
+      retries: 3
+      delay: 15
       when: ansible_distribution_release | lower == 'trusty'
 
-    - name: Install apt packages
-      apt:
-        pkg: "{{ item }}"
-        state: installed
-        update_cache: yes
-      register: install_packages
-      until: install_packages | success
-      retries: 5
-      delay: 2
-      with_items:
-        - git-core
-        - openjdk-8-jre-headless
-        - libxml2-utils
+    # TODO(odyssey4me):
+    # Once we use Ansible 2.5+ we can use the apt/package
+    # module here instead of the shell module, because
+    # it will expose the apt errors properly. In Ansible
+    # 2.3 and below the errors are swallowed.
+    - name: Update apt cache
+      shell: |
+        apt-get update
+      args:
+        executable: /bin/bash
+        warn: no
+      register: _update_cache
+      until: _update_cache | success
+      retries: 3
+      delay: 15
+
+    # TODO(odyssey4me):
+    # Once we use Ansible 2.5+ we can use the apt/package
+    # module here instead of the shell module, because
+    # it will expose the apt errors properly. In Ansible
+    # 2.3 and below the errors are swallowed.
+    - name: Install minimal jenkins requirements
+      shell: |
+        apt-get install -y {{ jenkins_apt_packages | join(' ') }}
+      args:
+        executable: /bin/bash
+        warn: no
+      register: _install_packages
+      until: _install_packages | success
+      retries: 3
+      delay: 15
 
     - name: Create Jenkins user
       user:


### PR DESCRIPTION
The current play combines the apt cache update and the
package install task in one, which is nice and concise
but makes it difficult to understand whether the install
failed due to an apt cache update failure or a package
install failure. Compounding the issue is the fact that
the apt module swallows the error in Ansible 2.3, so we
do not get to see it. Also, by default the apt_repository
module tries to update the apt cache after changing the
repository configuration, but if that fails then it will
retry and find on the second round that the file needs no
change and will not bother doing the cache update.

To improve our ability to diagnose errors when executing
these tasks, we move the setup of apt debug mode to be
done on all instances created (not just those without
python). We then disable the cache update when the
repository has changed, and implement a subsequent apt
cache update task on its own. We also convert the single
apt module task into two seperate shell tasks which each
do one thing. This means if either fail we have a specific
output of the error in more detail.

We also ensure that the retries/delays are consistent
with those recently implemented for the OnMetal nodes.

JIRA: RE-1783

Issue: [RE-1783](https://rpc-openstack.atlassian.net/browse/RE-1783)