### PR TITLE
RE-1490 Fix failing snapshot script

### DIFF
--- a/scripts/create_cloud_image.py
+++ b/scripts/create_cloud_image.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 
 import argparse
 from time import sleep
-from six import xrange
+from six.moves import xrange
 
 import openstack.connection
 


### PR DESCRIPTION
Snapshots are currently failing due to a recent change in
scripts/create_cloud_image.py:

```
>>> from six import xrange
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name xrange
>>> from six.moves import xrange
>>>
```

This commit updates the six import.

Issue: [RE-1490](https://rpc-openstack.atlassian.net/browse/RE-1490)