### PR TITLE
RE-1490 Remove unneeded rpco snapshot jobs

### DIFF
--- a/rpc_jobs/rpc_appformix.yml
+++ b/rpc_jobs/rpc_appformix.yml
@@ -18,11 +18,11 @@
 
     scenario:
       - newton:
-          IMAGE: "rpc-r14.13.0-xenial-swift"
+          IMAGE: "rpc-r14.15.0-xenial_loose_artifacts-swift"
       - pike:
-          IMAGE: "rpc-r16.2.0-xenial_no_artifacts-swift"
+          IMAGE: "rpc-r16.2.2-xenial_no_artifacts-swift"
       - queens:
-          IMAGE: "rpc-r18.0.0-xenial_no_artifacts-swift"
+          IMAGE: "rpc-r17.0.0-xenial_no_artifacts-swift"
     action:
       - "functional"
 

--- a/rpc_jobs/rpc_designate.yml
+++ b/rpc_jobs/rpc_designate.yml
@@ -18,11 +18,11 @@
 
     scenario:
       - newton:
-          IMAGE: "rpc-r14.9.0-xenial-swift"
+          IMAGE: "rpc-r14.15.0-xenial_loose_artifacts-swift"
       - pike:
-          IMAGE: "rpc-r16.1.0-xenial_no_artifacts-swift"
+          IMAGE: "rpc-r16.2.2-xenial_no_artifacts-swift"
       - queens:
-          IMAGE: "rpc-r18.0.0-xenial_no_artifacts-swift"
+          IMAGE: "rpc-r17.0.0-xenial_no_artifacts-swift"
     action:
       - "deploy"
 
@@ -49,11 +49,11 @@
 
     scenario:
       - newton:
-          IMAGE: "rpc-r14.9.0-xenial-swift"
+          IMAGE: "rpc-r14.15.0-xenial_loose_artifacts-swift"
       - pike:
-          IMAGE: "rpc-r16.1.0-xenial_no_artifacts-swift"
+          IMAGE: "rpc-r16.2.2-xenial_no_artifacts-swift"
       - queens:
-          IMAGE: "rpc-r18.0.0-xenial_no_artifacts-swift"
+          IMAGE: "rpc-r17.0.0-xenial_no_artifacts-swift"
     action:
       - "deploy"
 

--- a/rpc_jobs/rpc_octavia.yml
+++ b/rpc_jobs/rpc_octavia.yml
@@ -16,7 +16,7 @@
     # Use image for RPC-O install
     image:
       - xenial_snapshot:
-          IMAGE: "rpc-r14.15.0-xenial-swift"
+          IMAGE: "rpc-r14.15.0-xenial_loose_artifacts-swift"
           REGIONS: "DFW"
           FALLBACK_REGIONS: ""
           FLAVOR: "7"
@@ -86,7 +86,7 @@
     # upstream installer
     branch:
       - "master":
-          IMAGE: "rpc-r14.15.0-xenial-swift"
+          IMAGE: "rpc-r14.15.0-xenial_loose_artifacts-swift"
       - "pike":
           IMAGE: "rpc-r16.2.2-xenial_no_artifacts-swift"
 

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -453,13 +453,30 @@
     image:
       - xenial:
           IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
+      - trusty:
+          IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+    scenario:
+      - "swift"
+    action:
+      - deploy:
+          FLAVOR: "7"
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+# We create a separate snapshot project since we don't need all newton-aio
+# jobs triggering snapshot builds.
+- project:
+    name: "rpc-openstack-newton-aio-postmerge-snapshot"
+    repo_name: "rpc-openstack"
+    repo_url: "https://github.com/rcbops/rpc-openstack"
+    branch: "newton"
+    jira_project_key: "RO"
+    image:
       - xenial_loose_artifacts:
           IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
           # We have an MNAIO equivalent of this PM job, but we need to keep
           # this for the push triggering for snapshot building.
           CRON: "@monthly"
-      - trusty:
-          IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
       - trusty_loose_artifacts:
           IMAGE: "Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)"
     scenario:
@@ -504,13 +521,31 @@
     image:
       - xenial:
           IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
+      - trusty:
+          IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+    scenario:
+      - "swift"
+    action:
+      - deploy:
+          FLAVOR: "7"
+    # This is the build that will be triggered by the push trigger job
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+# We create a separate snapshot project since we don't need all newton-rc-aio
+# jobs triggering snapshot builds.
+- project:
+    name: "rpc-openstack-newton-rc-aio-postmerge-snapshot"
+    repo_name: "rpc-openstack"
+    repo_url: "https://github.com/rcbops/rpc-openstack"
+    branch: "newton-rc"
+    jira_project_key: "RO"
+    image:
       - xenial_loose_artifacts:
           IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
           # We have an MNAIO equivalent of this PM job, but we need to keep
           # this for the push triggering for snapshot building.
           CRON: "@monthly"
-      - trusty:
-          IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
       - trusty_loose_artifacts:
           IMAGE: "Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)"
     scenario:


### PR DESCRIPTION
We're currently building newton/newton-rc snapshots for
trusty/trusty_loose_artifacts and xenial/xenial_loose_artifacts but
as only 'loose' artifact mode is being used in production we should
force all jobs to use the 'loose' image and skip building the 'strict'
images.

This commit adds a separate project for newton/newton-rc for snapshots
so we can be specific about which images get built.

Additionally, we bump all existing jobs using snapshots to use the
'loose' newton image, and bump all other snapshots to the latest
released version. Note that for queens, we actually fix the image to
rpc-r17 rather than rpc-r18.

Issue: [RE-1490](https://rpc-openstack.atlassian.net/browse/RE-1490)