### PR TITLE
RE-1490 Add job to bump snapshot versions

### DIFF
--- a/gating/common/run_snapshot.sh
+++ b/gating/common/run_snapshot.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -xeu
+
+cd /opt/rpc-openstack
+git branch

--- a/rpc_jobs/bump_snapshots.yml
+++ b/rpc_jobs/bump_snapshots.yml
@@ -47,12 +47,13 @@
 
           for ( r in releases ) {
             def release = r
-            println r
+            println release
 
             parallelBuilds["${release['series']}-${release['image']}"] = {
-              build(
+              def buildResult = build(
                 job: 'PM_rpc-gating-master-snapshot-snapshot-test',
                 wait: true,
+                propagate: false,
                 parameters: [
                   [
                     $class: "StringParameterValue",
@@ -71,15 +72,21 @@
                   ]
                 ]
               )
+              if (buildResult.result != "SUCCESS") {
+                println "Build failed, no updates will take place for image rpc-${release['latest']}-${release['image']}"
+              }
+              release['result'] = buildResult.result
             } // parallelBuilds
           } // for
 
           parallel parallelBuilds
 
           for ( release in releases ) {
-            sh """#!/bin/bash -xe
-              sed -i "s/rpc-${release['previous']}-${release['image']}/rpc-${release['latest']}-${release['image']}/g" rpc_jobs/*.yml
-            """
+            if (release['result'] == "SUCCESS") {
+              sh """#!/bin/bash -xe
+                sed -i "s/rpc-${release['previous']}-${release['image']}/rpc-${release['latest']}-${release['image']}/g" rpc_jobs/*.yml
+              """
+            }
           } // for
 
           withEnv(

--- a/rpc_jobs/bump_snapshots.yml
+++ b/rpc_jobs/bump_snapshots.yml
@@ -12,44 +12,42 @@
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
       common.globalWraps(){
-        List releases = [[series: 'newton', major: '14', image: 'xenial_loose_artifacts-swift'],
-                         [series: 'newton', major: '14', image: 'trusty_loose_artifacts-swift'],
-                         [series: 'pike', major: '16', image: 'xenial_no_artifacts-swift'],
-                         [series: 'queens', major: '17', image: 'xenial_no_artifacts-swift']]
-        dir("rpc-openstack") {
-          git branch: 'master', url: 'https://github.com/rcbops/rpc-openstack'
-
-          for ( release in releases ) {
-
-            String latest = sh(
-              returnStdout: true,
-              script: """#!/bin/bash -xe
-                git tag --list | egrep "r${release['major']}\\." | sort --version-sort -r | head -1
-              """
-            ).trim()
-
-            String previous = sh(
-              returnStdout: true,
-              script: """#!/bin/bash -xe
-                git tag --list | egrep "r${release['major']}\\." | sort --version-sort -r | head -2 | tail -1
-              """
-            ).trim()
-
-            release['latest'] = latest
-            release['previous'] = previous
-          } // for
-        } // dir
+        dir("releases") {
+          git branch: 'master', url: 'https://github.com/rcbops/releases'
+        }
         // NOTE(mattt): We re-clone rpc-gating here because the existing clone
         // has cruft in it which we don't want to have committed in our
         // subsequent PR
         dir("rpc-gating-master") {
           git branch: 'master', url: 'https://github.com/rcbops/rpc-gating'
 
+          def componentData = readFile "${env.WORKSPACE}/releases/components/rpc-openstack.yml"
+          def rpcoReleases = readYaml text: componentData
+
+          List releases = []
+
+          for ( r in rpcoReleases['releases'] ) {
+            if (r['series'] == 'newton') {
+              for ( s in ['trusty', 'xenial'] ) {
+                def image = "${s}_loose_artifacts-swift"
+                releases << [series: r['series'],
+                             latest: r['versions'][0]['version'],
+                             previous: r['versions'][1]['version'],
+                             image: image]
+              } // for
+            } else {
+              releases << [series: r['series'],
+                           latest: r['versions'][0]['version'],
+                           previous: r['versions'][1]['version'],
+                           image: 'xenial_no_artifacts-swift' ]
+            } // if
+          } // for
+
           def parallelBuilds = [:]
 
           for ( r in releases ) {
             def release = r
-            println "series => ${release['series']}, latest => ${release['latest']}, previous => ${release['previous']}"
+            println r
 
             parallelBuilds["${release['series']}-${release['image']}"] = {
               build(
@@ -59,6 +57,11 @@
                   [
                     $class: "StringParameterValue",
                     name: "RPC_GATING_BRANCH",
+                    value: env.RPC_GATING_BRANCH,
+                  ],
+                  [
+                    $class: "StringParameterValue",
+                    name: "BRANCH",
                     value: env.RPC_GATING_BRANCH,
                   ],
                   [

--- a/rpc_jobs/bump_snapshots.yml
+++ b/rpc_jobs/bump_snapshots.yml
@@ -16,7 +16,7 @@
                          [series: 'newton', major: '14', image: 'trusty_loose_artifacts-swift'],
                          [series: 'pike', major: '16', image: 'xenial_no_artifacts-swift'],
                          [series: 'queens', major: '17', image: 'xenial_no_artifacts-swift']]
-        dir("rpc-openstack"){
+        dir("rpc-openstack") {
           git branch: 'master', url: 'https://github.com/rcbops/rpc-openstack'
 
           for ( release in releases ) {
@@ -39,7 +39,12 @@
             release['previous'] = previous
           } // for
         } // dir
-        dir("rpc-gating"){
+        // NOTE(mattt): We re-clone rpc-gating here because the existing clone
+        // has cruft in it which we don't want to have committed in our
+        // subsequent PR
+        dir("rpc-gating-master") {
+          git branch: 'master', url: 'https://github.com/rcbops/rpc-gating'
+
           def parallelBuilds = [:]
 
           for ( r in releases ) {
@@ -74,71 +79,46 @@
             """
           } // for
 
-          withCredentials(
+          withEnv(
             [
-              string(
-                credentialsId: 'rpc-jenkins-svc-github-pat',
-                variable: 'PAT'
-              ),
-              usernamePassword(
-                credentialsId: "jira_user_pass",
-                usernameVariable: "JIRA_USER",
-                passwordVariable: "JIRA_PASS"
-              ),
+              "ISSUE_SUMMARY=Bump snapshot versions",
+              "ISSUE_DESCRIPTION=This change was triggered by the jenkins job Bump-Snapshot-Images.",
+              "LABELS=snapshot-bump",
+              "JIRA_PROJECT_KEY=RE",
+              "TARGET_BRANCH=master",
+              "COMMIT_TITLE=Bump snapshot versions",
+              "COMMIT_MESSAGE=This change was triggered by the jenkins job Bump-Snapshot-Images.",
             ]
           ) {
-            sshagent (credentials:['rpc-jenkins-svc-github-ssh-key']) {
-              // NOTE(matt): We end up with untracked files in this repo, so
-              // we skip showing untracked files when we run git status
-              String git_status = sh(
-                returnStdout: true,
-                script: """#!/bin/bash -xe
-                  git status -s -uno
-                """
-              ).trim()
-
-              if (git_status) {
-                String owner = "rcbops"
-                String repo = "rpc-gating"
-                String ssh_url = "git@github.com:${owner}/${repo}"
-                String title = "Bump snapshot versions"
-                String message = "This change was triggered by the jenkins job Bump-Snapshot-Images."
-
-                String jira_issue = sh(
+            withCredentials(
+              [
+                string(
+                  credentialsId: 'rpc-jenkins-svc-github-pat',
+                  variable: 'PAT'
+                ),
+                usernamePassword(
+                  credentialsId: "jira_user_pass",
+                  usernameVariable: "JIRA_USER",
+                  passwordVariable: "JIRA_PASS"
+                ),
+              ]
+            ) {
+              sshagent (credentials:['rpc-jenkins-svc-github-ssh-key']) {
+                String git_status = sh(
                   returnStdout: true,
                   script: """#!/bin/bash -xe
-                    set +x; . ${WORKSPACE}/.venv/bin/activate; set -x
-                    python ${WORKSPACE}/rpc-gating/scripts/jirautils.py \
-                      --user "${JIRA_USER}" \
-                      --password "${JIRA_PASS}" \
-                      get_or_create_issue \
-                        --project "RE" \
-                        --summary "${title}" \
-                        --description "${message}" \
-                        --label SNAPSHOT_BUMP \
-                        --label jenkins
+                    git status -s
                   """
                 ).trim()
 
-                String pr_branch = "${jira_issue}_snapshot_version_bump"
-
-                sh """#!/bin/bash -xe
-                  git commit -a -m "${jira_issue} ${title}" -m "${message}"
-                  git push -f "$ssh_url" "HEAD:${pr_branch}"
-
-                  set +x; . ${WORKSPACE}/.venv/bin/activate; set -x
-                  python scripts/ghutils.py \
-                    --org "$owner" \
-                    --repo "$repo" \
-                    --debug \
-                    create_pr \
-                      --source-branch "${pr_branch}" \
-                      --target-branch "master" \
-                      --title "${jira_issue} ${title}" \
-                      --body "${message}"
-                """
-              } // if
-            } // sshagent
-          } // withCredentials
+                if (git_status) {
+                  sh """#!/bin/bash -xe
+                    set +x; . ${WORKSPACE}/.venv/bin/activate; set -x
+                    ${WORKSPACE}/rpc-gating/scripts/commit_and_pull_request.sh
+                  """
+                } // if
+              } // sshagent
+            } // withCredentials
+          } // withEnv
         } // dir
       } // globalWraps

--- a/rpc_jobs/bump_snapshots.yml
+++ b/rpc_jobs/bump_snapshots.yml
@@ -10,6 +10,8 @@
     triggers:
       - timed: "@daily"
     dsl: |
+      import org.jenkinsci.plugins.workflow.job.WorkflowJob
+
       library "rpc-gating@${RPC_GATING_BRANCH}"
       common.globalWraps(){
         dir("releases") {
@@ -25,6 +27,7 @@
           def rpcoReleases = readYaml text: componentData
 
           List releases = []
+          Boolean sendFailure = false
 
           for ( r in rpcoReleases['releases'] ) {
             if (r['series'] == 'newton') {
@@ -33,14 +36,33 @@
                 releases << [series: r['series'],
                              latest: r['versions'][0]['version'],
                              previous: r['versions'][1]['version'],
-                             image: image]
+                             image: image,
+                             consecutiveFailures: 0]
               } // for
             } else {
               releases << [series: r['series'],
                            latest: r['versions'][0]['version'],
                            previous: r['versions'][1]['version'],
-                           image: 'xenial_no_artifacts-swift' ]
+                           image: 'xenial_no_artifacts-swift',
+                           consecutiveFailures: 0]
             } // if
+          } // for
+
+          def allWorkflowJobs = Hudson.instance.getAllItems(WorkflowJob)
+          def job = (allWorkflowJobs.find {it.displayName =~ /PM_rpc-gating-master-snapshot-snapshot-test/})
+
+          // NOTE(mattt): We reverse job.getBuilds() so we operate on oldest to newest jobs
+          for ( build in job.getBuilds().reverse() ) {
+            for ( r in releases ) {
+              def image = build.getAction(ParametersAction).getParameter("IMAGE").getValue()
+              if (image == "rpc-${r['latest']}-${r['image']}") {
+                if (build.getResult().isWorseThan(Result.fromString("SUCCESS"))) {
+                  r['consecutiveFailures'] += 1
+                } else {
+                  r['consecutiveFailures'] = 0
+                }
+              } // if
+            } // for
           } // for
 
           def parallelBuilds = [:]
@@ -49,34 +71,39 @@
             def release = r
             println release
 
-            parallelBuilds["${release['series']}-${release['image']}"] = {
-              def buildResult = build(
-                job: 'PM_rpc-gating-master-snapshot-snapshot-test',
-                wait: true,
-                propagate: false,
-                parameters: [
-                  [
-                    $class: "StringParameterValue",
-                    name: "RPC_GATING_BRANCH",
-                    value: env.RPC_GATING_BRANCH,
-                  ],
-                  [
-                    $class: "StringParameterValue",
-                    name: "BRANCH",
-                    value: env.RPC_GATING_BRANCH,
-                  ],
-                  [
-                    $class: "StringParameterValue",
-                    name: "IMAGE",
-                    value: "rpc-${release['latest']}-${release['image']}",
+            if (release['consecutiveFailures'] < 7) {
+              parallelBuilds["${release['series']}-${release['image']}"] = {
+                def buildResult = build(
+                  job: 'PM_rpc-gating-master-snapshot-snapshot-test',
+                  wait: true,
+                  propagate: false,
+                  parameters: [
+                    [
+                      $class: "StringParameterValue",
+                      name: "RPC_GATING_BRANCH",
+                      value: env.RPC_GATING_BRANCH,
+                    ],
+                    [
+                      $class: "StringParameterValue",
+                      name: "BRANCH",
+                      value: env.RPC_GATING_BRANCH,
+                    ],
+                    [
+                      $class: "StringParameterValue",
+                      name: "IMAGE",
+                      value: "rpc-${release['latest']}-${release['image']}",
+                    ]
                   ]
-                ]
-              )
-              if (buildResult.result != "SUCCESS") {
-                println "Build failed, no updates will take place for image rpc-${release['latest']}-${release['image']}"
-              }
-              release['result'] = buildResult.result
-            } // parallelBuilds
+                )
+                if (buildResult.result != "SUCCESS") {
+                  println "Build failed, no updates will take place for image rpc-${release['latest']}-${release['image']}"
+                }
+                release['result'] = buildResult.result
+              } // parallelBuilds
+            } else {
+              println "rpc-${release['latest']}-${release['image']} has failed 7 times consecutively, creating RE issue for follow-up"
+              sendFailure = true
+            } // if
           } // for
 
           parallel parallelBuilds
@@ -130,5 +157,12 @@
               } // sshagent
             } // withCredentials
           } // withEnv
+
+          if (sendFailure) {
+            common.create_jira_issue("RE",
+                                     "Bump Snapshots Failure: ${env.BUILD_TAG}",
+                                     "[${env.BUILD_TAG}|${env.BUILD_URL}]",
+                                     ["jenkins", "bump_snapshots_fail"])
+          } // if
         } // dir
       } // globalWraps

--- a/rpc_jobs/bump_snapshots.yml
+++ b/rpc_jobs/bump_snapshots.yml
@@ -1,0 +1,144 @@
+- job:
+    name: 'Bump-Snapshot-Images'
+    project-type: pipeline
+    concurrent: false
+    properties:
+      - build-discarder:
+          days-to-keep: 30
+    parameters:
+      - rpc_gating_params
+    triggers:
+      - timed: "@daily"
+    dsl: |
+      library "rpc-gating@${RPC_GATING_BRANCH}"
+      common.globalWraps(){
+        List releases = [[series: 'newton', major: '14', image: 'xenial_loose_artifacts-swift'],
+                         [series: 'newton', major: '14', image: 'trusty_loose_artifacts-swift'],
+                         [series: 'pike', major: '16', image: 'xenial_no_artifacts-swift'],
+                         [series: 'queens', major: '17', image: 'xenial_no_artifacts-swift']]
+        dir("rpc-openstack"){
+          git branch: 'master', url: 'https://github.com/rcbops/rpc-openstack'
+
+          for ( release in releases ) {
+
+            String latest = sh(
+              returnStdout: true,
+              script: """#!/bin/bash -xe
+                git tag --list | egrep "r${release['major']}\\." | sort --version-sort -r | head -1
+              """
+            ).trim()
+
+            String previous = sh(
+              returnStdout: true,
+              script: """#!/bin/bash -xe
+                git tag --list | egrep "r${release['major']}\\." | sort --version-sort -r | head -2 | tail -1
+              """
+            ).trim()
+
+            release['latest'] = latest
+            release['previous'] = previous
+          } // for
+        } // dir
+        dir("rpc-gating"){
+          def parallelBuilds = [:]
+
+          for ( r in releases ) {
+            def release = r
+            println "series => ${release['series']}, latest => ${release['latest']}, previous => ${release['previous']}"
+
+            parallelBuilds["${release['series']}-${release['image']}"] = {
+              build(
+                job: 'PM_rpc-gating-master-snapshot-snapshot-test',
+                wait: true,
+                parameters: [
+                  [
+                    $class: "StringParameterValue",
+                    name: "RPC_GATING_BRANCH",
+                    value: env.RPC_GATING_BRANCH,
+                  ],
+                  [
+                    $class: "StringParameterValue",
+                    name: "IMAGE",
+                    value: "rpc-${release['latest']}-${release['image']}",
+                  ]
+                ]
+              )
+            } // parallelBuilds
+          } // for
+
+          parallel parallelBuilds
+
+          for ( release in releases ) {
+            sh """#!/bin/bash -xe
+              sed -i "s/rpc-${release['previous']}-${release['image']}/rpc-${release['latest']}-${release['image']}/g" rpc_jobs/*.yml
+            """
+          } // for
+
+          withCredentials(
+            [
+              string(
+                credentialsId: 'rpc-jenkins-svc-github-pat',
+                variable: 'PAT'
+              ),
+              usernamePassword(
+                credentialsId: "jira_user_pass",
+                usernameVariable: "JIRA_USER",
+                passwordVariable: "JIRA_PASS"
+              ),
+            ]
+          ) {
+            sshagent (credentials:['rpc-jenkins-svc-github-ssh-key']) {
+              // NOTE(matt): We end up with untracked files in this repo, so
+              // we skip showing untracked files when we run git status
+              String git_status = sh(
+                returnStdout: true,
+                script: """#!/bin/bash -xe
+                  git status -s -uno
+                """
+              ).trim()
+
+              if (git_status) {
+                String owner = "rcbops"
+                String repo = "rpc-gating"
+                String ssh_url = "git@github.com:${owner}/${repo}"
+                String title = "Bump snapshot versions"
+                String message = "This change was triggered by the jenkins job Bump-Snapshot-Images."
+
+                String jira_issue = sh(
+                  returnStdout: true,
+                  script: """#!/bin/bash -xe
+                    set +x; . ${WORKSPACE}/.venv/bin/activate; set -x
+                    python ${WORKSPACE}/rpc-gating/scripts/jirautils.py \
+                      --user "${JIRA_USER}" \
+                      --password "${JIRA_PASS}" \
+                      get_or_create_issue \
+                        --project "RE" \
+                        --summary "${title}" \
+                        --description "${message}" \
+                        --label SNAPSHOT_BUMP \
+                        --label jenkins
+                  """
+                ).trim()
+
+                String pr_branch = "${jira_issue}_snapshot_version_bump"
+
+                sh """#!/bin/bash -xe
+                  git commit -a -m "${jira_issue} ${title}" -m "${message}"
+                  git push -f "$ssh_url" "HEAD:${pr_branch}"
+
+                  set +x; . ${WORKSPACE}/.venv/bin/activate; set -x
+                  python scripts/ghutils.py \
+                    --org "$owner" \
+                    --repo "$repo" \
+                    --debug \
+                    create_pr \
+                      --source-branch "${pr_branch}" \
+                      --target-branch "master" \
+                      --title "${jira_issue} ${title}" \
+                      --body "${message}"
+                """
+              } // if
+            } // sshagent
+          } // withCredentials
+        } // dir
+      } // globalWraps

--- a/rpc_jobs/rpc_gating.yml
+++ b/rpc_jobs/rpc_gating.yml
@@ -18,3 +18,24 @@
               - "${RPC_GATING_BRANCH}"
             credentials-id: "github_account_rpc_jenkins_svc"
       script-path: job_dsl/rpc_gating_merge_trigger.groovy
+
+- project:
+    name: "rpc-gating-snapshot-test"
+    repo_name: "rpc-gating"
+    repo_url: "https://github.com/rcbops/rpc-gating"
+    branch: "master"
+    jira_project_key: "RE"
+    CRON: "@monthly"
+    image:
+      - snapshot:
+          IMAGE: "rpc-r17.0.0-xenial_no_artifacts-swift"
+          REGIONS: "DFW"
+          FALLBACK_REGIONS: ""
+          FLAVOR: "7"
+          BOOT_TIMEOUT: 1500
+    scenario:
+      - snapshot
+    action:
+      - test
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'


### PR DESCRIPTION
This commit adds a new job called Bump-Snapshot-Images that cycles
through rpc-openstack branches finding the latest tag and then bumps
versions of snapshot images in rpc_gating/.

Note that before we update any images, we test the image to ensure that
it is functional. Currently the latest snapshot image for each branch
will be tested regardless of whether a change has been detected, but
this serves as a bit rot test to help us identify problematic
rpc-openstack snapshots before users do.

Issue: [RE-1490](https://rpc-openstack.atlassian.net/browse/RE-1490)