### PR TITLE
Revert "RE-1725 Add PR info to dep_update issue message"

### DIFF
--- a/scripts/dep_update.sh
+++ b/scripts/dep_update.sh
@@ -54,8 +54,7 @@ ssh_url="git@github.com:${owner}/${repo}"
 if [[ -n "$(git status -s)" ]] || [[ ${start_sha} != $(git rev-parse --verify HEAD) ]]; then
   echo "Looking for Jira issue, will create if not found."
   issue_message="This issue was generated automatically by the Jenkins job ${RE_JOB_NAME}.
-  Please refer to the associated pull request ${ghprbPullLink}
-  More details are available at update_dependencies in https://rpc-openstack.atlassian.net/wiki/spaces/RE/pages/19005457/RE+for+Projects."
+  See update_dependencies in https://rpc-openstack.atlassian.net/wiki/spaces/RE/pages/19005457/RE+for+Projects for more details."
   jira_summary="Update ${repo}:${BRANCH} dependencies"
   issue=$(python ${WORKSPACE}/rpc-gating/scripts/jirautils.py \
         --user "${JIRA_USER}" \


### PR DESCRIPTION
Reverts rcbops/rpc-gating#939

Harry pointed out that the pull request is already available in the side window and having the pull request in the message is not necessary or worth the trouble, so we decided to back-out the changes and consider RE-1725 and RE-1787 as done

Issue: [RE-1725](https://rpc-openstack.atlassian.net/browse/RE-1725)