### PR TITLE
RE-1325 Create pluggable artifact upload hook

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -23,27 +23,37 @@ operations such as creating a single use instance for a project's jobs to
 execute on. As the console includes logging for steps not defined by a project,
 it's inefficient to wade through it when looking for the cause of a failure.
 
-## Artifacts
+## Log Artifacts
 While command outputs as viewed in blue ocean or the console are useful, they
-don't tell the whole story. Jobs can produce artifacts which are stored
-for a [set time](https://github.com/rcbops/rpc-gating/blob/master/playbooks/upload_to_swift.yml) after the completion of a job. Any job can produce artifacts
-and use the provided functions to publish those. Jobs artifacts should include
-everything required to debug a build.
+don't tell the whole story. Jobs can be configured to publish log artifacts to
+a Rackspace Cloud Files container, which automatically has CDN and web browsing
+enabled.
 
-To view artifacts, click "Build Artifact Links" in the sidebar from the standard
-Jenkins build page.
+Artifact gathering and publishing is configured by creating a file named
+``component_metadata.yml`` in the root of the git repository which has the
+following format:
 
-### Artifact Example: RPCO
+``` yaml
+"artifacts": [
+  {
+     "type": "log",
+     "source": "/foo"
+  }
+]
+```
+
+The above configuration will upload ``log`` files from every job, sourced from
+the ``/foo`` directory. These will be published and set to expire after 30 days.
+The link to where they are published will be available and displayed
+prominently in the Jenkins job result.
+
+### Log Artifact Example: RPCO
 
 RPC-O builds archive the etc and log dirs of each container and the host.
 This includes the openstack_deploy directory, all the ansible facts, the generated
 configuration files and log files for each service. This comprehensive set of
 artifacts saves times recreating problems as usually the required information
 is stored with the failing job.
-
-
-
-
 
 For AIO jobs, the host is the deploy node, so the openstack_deploy directory
 which contains all the ansible config can be found in the hosts's etc folder.

--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -234,24 +234,19 @@ def runonpubcloud(Map args=[:], Closure body){
   } //outer try
 }
 
-def uploadToSwift(Map args){
-  if (fileExists(args.path)) {
-    print("Directory ${args.path} found. Uploading contents.")
-    clouds_cfg = common.writeCloudsCfg()
-    withEnv(["OS_CLIENT_CONFIG_FILE=${clouds_cfg}"]){
-      common.venvPlaybook(
-        playbooks: ["rpc-gating/playbooks/upload_to_swift.yml"],
-        vars: [
-          artifacts_dir: args.path,
-          container: args.container,
-          job_name: env.JOB_NAME,
-          build_number: env.BUILD_NUMBER,
-        ]
-      ) // venvPlaybook
-    } // withEnv
-  } else {
-    print("Directory ${args.path} not found. Skipping upload.")
-  }
+def uploadArtifacts(Map args = [:]){
+  print("Uploading artifacts.")
+  clouds_cfg = common.writeCloudsCfg()
+  withEnv(["OS_CLIENT_CONFIG_FILE=${clouds_cfg}"]){
+    common.venvPlaybook(
+      playbooks: [
+        "rpc-gating/playbooks/artifact_upload.yml"
+      ],
+      vars: [
+        artifact_type_include: args.artifact_types
+      ]
+    ) // venvPlaybook
+  } // withEnv
 }
 
 return this

--- a/playbooks/artifact_upload.yml
+++ b/playbooks/artifact_upload.yml
@@ -1,0 +1,73 @@
+---
+- name: Artifact uploader
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  vars:
+    region: "DFW"
+    cloud_name: "public_cloud"
+    component_metadata_file_path: "{{ lookup('env', 'WORKSPACE') }}/{{ lookup('env', 'RE_JOB_REPO_NAME') }}/component_metadata.yml"
+    legacy_artifact_log_type:
+      - "type": "log"
+        "source": "{{ lookup('env', 'RE_HOOK_ARTIFACT_DIR') | default(lookup('env', 'WORKSPACE') ~ '/artifacts', true) }}"
+    artifact_type_include: all
+  tasks:
+    - name: Check for component metadata file
+      stat:
+        path: "{{ component_metadata_file_path }}"
+        get_attributes: no
+        get_checksum: no
+        get_md5: no
+        get_mime: no
+      register: _component_metadata_file
+
+    - name: Load and display the component metadata
+      when:
+        - "_component_metadata_file.stat.exists | bool"
+      block:
+        - name: Import component metadata file if it exists
+          set_fact:
+            component_metadata: "{{ lookup('file', component_metadata_file_path) | from_yaml }}"
+
+        - name: Show the component metadata
+          debug:
+            var: component_metadata
+
+    - name: Try analysing the file, but fall back to the legacy hook if we fail
+      block:
+        - name: Determine the list of artifacts to upload
+          set_fact:
+            component_artifacts: >-
+              {%- if (_component_metadata_file.stat.exists | bool) and (component_metadata.artifacts is defined) %}
+              {%-   if 'log' in component_metadata.artifacts | json_query('[*].type') %}
+              {%-     set _result = component_metadata.artifacts %}
+              {%-   else %}
+              {%-     set _result = component_metadata.artifacts + legacy_artifact_log_type %}
+              {%-   endif %}
+              {%- else %}
+              {%-   set _result = legacy_artifact_log_type %}
+              {%- endif %}
+              {{- _result }}
+      rescue:
+        - name: Fall back to the default/legacy log artifact hook
+          set_fact:
+            component_artifacts: "{{ legacy_artifact_log_type }}"
+
+    - name: Show the component artifacts data
+      debug:
+        var: component_artifacts
+
+    - name: Upload any artifacts destined for Cloud Files
+      when:
+        - "((component_artifacts | json_query('[*].type') | list) | intersect(['file', 'log'])) | length > 0"
+      block:
+        - include: tasks/artifact_upload/cloudfiles_authenticate.yml
+          static: no
+
+        - include: "tasks/artifact_upload/upload_{{ artifact.type }}.yml"
+          static: no
+          when:
+            - "(artifact_type_include == 'all') or (artifact.type == artifact_type_include)"
+          with_items: "{{ component_artifacts }}"
+          loop_control:
+            loop_var: artifact

--- a/playbooks/tasks/artifact_upload/cloudfiles_authenticate.yml
+++ b/playbooks/tasks/artifact_upload/cloudfiles_authenticate.yml
@@ -1,0 +1,23 @@
+---
+- name: Check for required variables
+  assert:
+    msg: |
+      The variables 'cloud_name' and 'region' are required.
+    that:
+      - "cloud_name is defined"
+      - "region is defined"
+
+- name: Authenticate to the cloud and retrieve the service catalog
+  os_auth:
+    cloud: "{{ cloud_name }}"
+    region_name: "{{ region }}"
+  no_log: true
+  register: _auth
+  until: (_auth | success) and
+         (auth_token is defined) and
+         (auth_token is not none) and
+         (auth_token | trim != '') and
+         (service_catalog is defined) and
+         (service_catalog is not none)
+  retries: 10
+  delay: 30

--- a/playbooks/tasks/artifact_upload/cloudfiles_create_container.yml
+++ b/playbooks/tasks/artifact_upload/cloudfiles_create_container.yml
@@ -1,0 +1,76 @@
+---
+- name: Check for required variables
+  assert:
+    msg: |
+      The variables 'object_store_container_name', 'cloud_name', and 'region' are required.
+    that:
+      - "object_store_container_name is defined"
+      - "cloud_name is defined"
+      - "region is defined"
+
+- name: Create a Cloud Files container
+  os_object:
+    container: "{{ object_store_container_name }}"
+    container_access: "public"
+    region_name: "{{ region }}"
+    cloud: "{{ cloud_name }}"
+  register: _create_container
+  until: _create_container | success
+  retries: 10
+  delay: 30
+
+- name: Extract object-store service catalog
+  set_fact:
+    object_store: "{{ service_catalog | selectattr('type', 'equalto', 'object-store') | first }}"
+
+- name: Determine the object-store service endpoint URL for the region
+  set_fact:
+    object_store_url: "{{ (object_store['endpoints'] | selectattr('region', 'equalto', region ) | first)['publicURL']}}"
+
+- name: Extract object-cdn service catalog
+  set_fact:
+    object_cdn: "{{ service_catalog | selectattr('type', 'equalto', 'rax:object-cdn') | first }}"
+
+- name: Determine the object-cdn service endpoint URL for the region
+  set_fact:
+    object_cdn_url: "{{ (object_cdn['endpoints'] | selectattr('region', 'equalto', region) | first)['publicURL'] }}/{{ object_store_container_name }}"
+
+- name: Enable CDN for the Cloud Files container
+  uri:
+    url: "{{ object_cdn_url }}"
+    method: PUT
+    headers:
+      X-AUTH-TOKEN: "{{ auth_token }}"
+      X-Ttl: 900
+      X-Cdn-Enabled: True
+    # 201 (Created): The container was CDN-enabled as requested.
+    # 202 (Accepted): The container was already CDN-enabled.
+    # 204 (No Content): The container was CDN-enabled as requested, but has no content.
+    status_code: "201, 202, 204"
+  register: _enable_cdn
+  until: (_enable_cdn | success) and ('x_cdn_ssl_uri' in _enable_cdn)
+  retries: 10
+  delay: 30
+
+- name: Set fact for the user-accessible CDN URL for the container
+  set_fact:
+    container_public_url: "{{ _enable_cdn['x_cdn_ssl_uri'] }}"
+
+# In order for uploaded files to be browsable:
+# 1. Static hosting must be enabled (this links index.html to requests for container/)
+# 2. CDN must be enabled (to allow anonymous http access to the container)
+# 3. An index page must be generated and/or web listings enabled.
+- name: Enable static web hosting
+  uri:
+    url: "{{ object_store_url }}/{{ object_store_container_name }}"
+    method: POST
+    headers:
+      X-AUTH-TOKEN: "{{ auth_token }}"
+      X-Container-Meta-Web-Index: index.html
+      X-Container-Meta-Web-Listings: True
+    # 204 (No Content): The container was enabled as requested.
+    status_code: 204
+  register: _enable_static_hosting
+  until: _enable_static_hosting | success
+  retries: 10
+  delay: 30

--- a/playbooks/tasks/artifact_upload/upload_file.yml
+++ b/playbooks/tasks/artifact_upload/upload_file.yml
@@ -1,0 +1,87 @@
+---
+- name: Check that the artifacts source path has been provided
+  assert:
+    msg: |
+      The file artifact source path must be provided.
+    that:
+      - "artifact['source'] is defined"
+
+# TODO(odyssey4me):
+# Perhaps have these facts provided by variables
+# defined in groovy instead so that we do not have
+# to rely on environment variables. This may make
+# the switch to declaritive pipelines easier.
+- name: Set dependent facts
+  set_fact:
+    object_store_container_name: "{{ lookup('env', 'RE_JOB_REPO_NAME') }}"
+
+- name: Check that the RE_JOB_REPO_NAME has been provided
+  debug:
+    msg: |
+      The RE_JOB_REPO_NAME environment variable must be set. Skipping artifact upload.
+  when:
+    - "object_store_container_name == ''"
+
+- name: Check if the source exists
+  stat:
+    path: "{{ artifact['source'] }}"
+    follow: yes
+    get_attributes: no
+    get_checksum: no
+    get_md5: no
+    get_mime: no
+  register: _artifact_path
+
+- name: Show whether the source exists
+  debug:
+    msg: "source {{ artifact['source'] }} exists: {{ _artifact_path.stat.exists | bool }}"
+
+- name: Upload the artifacts if all conditions are met
+  when:
+    - "_artifact_path.stat.exists | bool"
+    - "object_store_container_name != ''"
+  block:
+
+    - include: cloudfiles_create_container.yml
+
+    - name: Create the destination path and move the source file(s) into it
+      shell: |
+        mkdir -p {{ artifact['dest'] }}
+        mv {{ artifact['source'] | basename }} {{ artifact['dest'] }}/
+      args:
+        warn: no
+        executable: /bin/bash
+        chdir: "{{ artifact['source'] | dirname }}"
+      when:
+        - "artifact['dest'] is defined"
+
+    - name: Set the name of the file/folder to upload
+      set_fact:
+        artifact_basename: "{{ (artifact['dest'] is defined) | ternary(artifact.get('dest').split('/')[0], artifact['source'] | basename) }}"
+
+    - name: Show the name of the file/folder to upload
+      debug:
+        var: artifact_basename
+
+    # The ansible os_object module does not currently support setting
+    # the object expiration header field, nor does it do threaded uploads
+    # (which make this much faster), so we use the swift client instead.
+    - name: Upload Artifacts to Cloud Files
+      command: >-
+        swift upload {{ object_store_container_name }} {{ artifact_basename }}
+        --object-threads 100
+        --skip-identical
+        {{ artifact.expire_after is defined | ternary("--header 'X-Delete-After:" ~ artifact.get('expire_after') ~ "'", "") }}
+      args:
+        chdir: "{{ artifact['source'] | dirname }}"
+      environment:
+        OS_AUTH_TOKEN: "{{ auth_token }}"
+        OS_STORAGE_URL: "{{ (object_store['endpoints'] | selectattr('region', 'equalto', region) | first)['publicURL'] }}"
+      register: upload_archive
+      until: upload_archive | success
+      retries: 10
+      delay: 30
+
+    - name: Show the public CDN URL for file artifacts
+      debug:
+        msg: "Public CDN URL: {{ container_public_url }}"

--- a/playbooks/tasks/artifact_upload/upload_log.yml
+++ b/playbooks/tasks/artifact_upload/upload_log.yml
@@ -1,25 +1,63 @@
 ---
-- hosts: localhost
-  connection: local
-  gather_facts: False
-  vars:
-    region: "DFW"
-    cloud_name: "public_cloud"
+- name: Check for required variables
+  assert:
+    msg: |
+      The log artifact source must be provided.
+    that:
+      - "artifact.source is defined"
+
+# TODO(odyssey4me):
+# Perhaps have these facts provided by variables
+# defined in groovy instead so that we do not have
+# to rely on environment variables. This may make
+# the switch to declaritive pipelines easier.
+- name: Set dependent facts
+  set_fact:
     # 30 days
-    retention: 2592000
-  tasks:
-    - name: Set the archive base name
+    artifacts_expire_after: 2592000
+    job_name: "{{ lookup('env', 'JOB_NAME') }}"
+    build_number: "{{ lookup('env', 'BUILD_NUMBER') }}"
+
+- name: Check that the JOB_NAME and BUILD_NUMBER have been provided
+  debug:
+    msg: |
+      The JOB_NAME and BUILD_NUMBER environment variables must be set. Skipping artifact upload.
+  when:
+    - "(job_name == '') or (build_number == '')"
+
+- name: Check if the source exists
+  stat:
+    path: "{{ artifact.source }}"
+    follow: yes
+    get_attributes: no
+    get_checksum: no
+    get_md5: no
+    get_mime: no
+  register: _artifact_path
+
+- name: Show whether the source exists
+  debug:
+    msg: "source {{ artifact.source }} exists: {{ _artifact_path.stat.exists | bool }}"
+
+- name: Upload the artifacts if all conditions are met
+  when:
+    - "_artifact_path.stat.exists | bool"
+    - "job_name != ''"
+    - "build_number != ''"
+  block:
+    - name: Set the archive base name and object container name
       set_fact:
         archive_base_name: "{{ job_name }}_{{ build_number }}"
+        object_store_container_name: "jenkinsjob_{{ job_name }}_{{ build_number }}"
 
     - name: Move artifacts dir so that downloaded archives have a useful name
-      shell: mv "{{ artifacts_dir | basename }}" "{{ archive_base_name }}"
+      shell: mv "{{ artifact['source'] | basename }}" "{{ archive_base_name }}"
       args:
-        chdir: "{{ artifacts_dir | dirname }}"
+        chdir: "{{ artifact['source'] | dirname }}"
 
     - name: Set the archive directory
       set_fact:
-        adir: "{{ artifacts_dir | dirname }}/{{archive_base_name}}"
+        adir: "{{ artifact['source'] | dirname }}/{{ archive_base_name }}"
 
     # Links are unlikely to work when expanded on a different
     # system so remove them. Create a list of removed links
@@ -33,14 +71,14 @@
           -delete \
           | tee {{ adir | basename }}/removedlinks.txt
       args:
-        chdir: "{{ adir |dirname }}"
+        chdir: "{{ adir | dirname }}"
       register: removed_links
 
     # This task runs async while the individual files are being uploaded
     # then when compression is complete, the resultant archive is uploaded.
     # 3 Hour Timeout
     - name: Create archive asynchronously
-      shell: "tar -c {{ adir | basename }} | gzip --fast > {{archive_base_name}}.tar.gz"
+      shell: "tar -c {{ adir | basename }} | gzip --fast > {{ archive_base_name }}.tar.gz"
       args:
         chdir: "{{ adir | dirname }}"
       async: 10800
@@ -49,86 +87,7 @@
       tags:
         - skip_ansible_lint
 
-    - name: Create a Cloud Files container
-      os_object:
-        container: "{{ container }}"
-        container_access: "public"
-        region_name: "{{ region }}"
-        cloud: "{{ cloud_name }}"
-      register: _create_container
-      until: _create_container | success
-      retries: 10
-      delay: 30
-
-    - name: Authenticate to the cloud and retrieve the service catalog
-      os_auth:
-        cloud: "{{ cloud_name }}"
-        region_name: "{{ region }}"
-      no_log: true
-      register: _auth
-      until: (_auth | success) and
-             (auth_token is defined) and
-             (auth_token is not none) and
-             (auth_token | trim != '') and
-             (service_catalog is defined) and
-             (service_catalog is not none)
-      retries: 10
-      delay: 30
-
-    - name: Extract object-store service catalog
-      set_fact:
-        object_store: "{{ service_catalog | selectattr('type', 'equalto', 'object-store') | first }}"
-
-    - name: Determine the object-store service endpoint URL for the region
-      set_fact:
-        object_store_url: "{{ (object_store['endpoints'] | selectattr('region', 'equalto', region ) | first)['publicURL']}}"
-
-    - name: Extract object-cdn service catalog
-      set_fact:
-        object_cdn: "{{ service_catalog | selectattr('type', 'equalto', 'rax:object-cdn') | first }}"
-
-    - name: Determine the object-cdn service endpoint URL for the region
-      set_fact:
-        object_cdn_url: "{{ (object_cdn['endpoints'] | selectattr('region', 'equalto', region) | first)['publicURL'] }}/{{ container }}"
-
-    - name: Enable CDN for the Cloud Files container
-      uri:
-        url: "{{ object_cdn_url }}"
-        method: PUT
-        headers:
-          X-AUTH-TOKEN: "{{ auth_token }}"
-          X-Cdn-Enabled: True
-        # 201 (Created): The container was CDN-enabled as requested.
-        # 202 (Accepted): The container was already CDN-enabled.
-        # 204 (No Content): The container was CDN-enabled as requested, but has no content.
-        status_code: "201, 202, 204"
-      register: _enable_cdn
-      until: (_enable_cdn | success) and ('x_cdn_ssl_uri' in _enable_cdn)
-      retries: 10
-      delay: 30
-
-    - name: Set fact for the user-accessible CDN URL for the container
-      set_fact:
-        container_public_url: "{{ _enable_cdn['x_cdn_ssl_uri'] }}"
-
-    # In order for uploaded files to be browsable:
-    # 1. Static hosting must be enabled (this links index.html to requests for container/)
-    # 2. CDN must be enabled (to allow anonymous http access to the container)
-    # 3. An index page must be generated and/or web listings enabled.
-    - name: Enable static web hosting
-      uri:
-        url: "{{ object_store_url }}/{{ container }}"
-        method: POST
-        headers:
-          X-AUTH-TOKEN: "{{ auth_token }}"
-          X-Container-Meta-Web-Index: index.html
-          X-Container-Meta-Web-Listings: True
-        # 204 (No Content): The container was enabled as requested.
-        status_code: 204
-      register: _enable_static_hosting
-      until: _enable_static_hosting | success
-      retries: 10
-      delay: 30
+    - include: cloudfiles_create_container.yml
 
     # Do this before generating index.html, styles.css and data.json
     # So they don't show up on the final page.
@@ -159,12 +118,12 @@
     # Checksum validation is also disabled to improve upload speed.
     - name: Upload Artifacts to Cloud Files
       command: >-
-        swift upload {{ container }} {{ adir | basename }}
+        swift upload {{ object_store_container_name }} {{ adir | basename }}
         --object-threads 100
         --ignore-checksum
-        --header 'X-Delete-After:{{ retention }}'
+        --header 'X-Delete-After:{{ artifacts_expire_after }}'
       args:
-        chdir: "{{ adir |dirname }}"
+        chdir: "{{ adir | dirname }}"
       environment:
         OS_AUTH_TOKEN: "{{ auth_token }}"
         OS_STORAGE_URL: "{{ (object_store['endpoints'] | selectattr('region', 'equalto', region) | first)['publicURL'] }}"
@@ -214,8 +173,8 @@
     # (which make this much faster), so we use the swift client instead.
     - name: Upload index data (data.json) to Cloud Files
       command: >-
-        swift upload {{ container }} {{ adir | basename }}/data.json
-        --header 'X-Delete-After: {{ retention }}'
+        swift upload {{ object_store_container_name }} {{ adir | basename }}/data.json
+        --header 'X-Delete-After: {{ artifacts_expire_after }}'
       args:
         chdir: "{{ adir | dirname }}"
       environment:
@@ -239,8 +198,8 @@
     # (which make this much faster), so we use the swift client instead.
     - name: Upload archive to Cloud Files
       command: >-
-        swift upload {{ container }} {{ archive_base_name }}.tar.gz
-        --header 'X-Delete-After: {{ retention }}'
+        swift upload {{ object_store_container_name }} {{ archive_base_name }}.tar.gz
+        --header 'X-Delete-After: {{ artifacts_expire_after }}'
       args:
         chdir: "{{ adir | dirname }}"
       environment:
@@ -255,4 +214,4 @@
     # build description.
     - name: "Write public url file"
       shell: |
-        echo "{{ container_public_url }}/{{archive_base_name}}/index.html" > ${WORKSPACE}/artifact_public_url
+        echo "{{ container_public_url }}/{{ archive_base_name }}/index.html" > ${WORKSPACE}/artifact_public_url

--- a/rpc_jobs/unit/artefact_publish.yml
+++ b/rpc_jobs/unit/artefact_publish.yml
@@ -26,7 +26,24 @@
             echo "<html>dstat report placeholder</html>" \
               > /var/log/dstat.html
             cp -vr /var/log artifacts
+            cp -r artifacts file_artifacts
           """
+
+          // Set the RE_JOB_REPO_NAME (normally done by standard jobs)
+          env.RE_JOB_REPO_NAME = "rpc-gating"
+
+          // Create a temporary component_metadata file
+          def artifacts_data = [
+            artifacts: [
+              [
+                type: "file",
+                source: "${env.WORKSPACE}/file_artifacts",
+                dest: "${env.JOB_NAME}/${env.BUILD_NUMBER}/",
+                expire_after: 86400
+              ]
+            ]
+          ]
+          writeYaml file: "${env.WORKSPACE}/${env.RE_JOB_REPO_NAME}/component_metadata.yml", data: artifacts_data
         }
-        common.archive_artifacts()
+        common.archive_artifacts(artifact_types: "all")
       }


### PR DESCRIPTION
In this PR, we create a pluggable artifact upload hook which currently implements two types: 'log' and 'file'.

This new hook makes use of the in-repo ``component_metadata.yml`` file to discover its configuration.

The 'log' type works in exactly the same way as the current job artifact publishing, and has a shim for the ``RE_HOOK_ARTIFACT_DIR`` environment variable for backwards compatibility.

The 'file' type provides the capability to upload any file or recursively upload any folder to public cloud's cloudfiles, in a container name which matches the repository running the test.

We also switch the current log archiving mechanism to use the 'log' type.

There is follow up work in [RE-1813](https://rpc-openstack.atlassian.net/browse/RE-1813) to automatically publish the URL where these files can be accessed to some place that's easy to find.

Issue: [RE-1325](https://rpc-openstack.atlassian.net/browse/RE-1325)
Issue: [RE-1812](https://rpc-openstack.atlassian.net/browse/RE-1812)