### PR TITLE
Extend release to publish details to Confluence

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -4,6 +4,7 @@ appdirs==1.4.3
 asn1crypto==0.22.0
 Babel==2.4.0
 backports.ssl-match-hostname==3.5.0.1
+beautifulsoup4==4.6.1
 cffi==1.10.0
 click==6.7
 cliff==2.12.0

--- a/job_dsl/release.groovy
+++ b/job_dsl/release.groovy
@@ -26,6 +26,11 @@ common.globalWraps(){
       string(
         credentialsId: 'mailgun_mattt_api_key',
         variable: 'MAILGUN_API_KEY'
+      ),
+      usernamePassword(
+        credentialsId: "jira_user_pass",
+        usernameVariable: "JIRA_USER",
+        passwordVariable: "JIRA_PASS"
       )
     ]){
       sshagent (credentials:['rpc-jenkins-svc-github-ssh-key']){

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
 ansible
 appdirs
+beautifulsoup4
 click
 croniter
 github3.py
 gitpython
 influxdb
+Jinja2
 jenkins-job-builder
 jenkinsapi
 jira
@@ -20,6 +22,7 @@ PyYAML
 rackspace-monitoring
 rackspace-monitoring-cli
 rackspaceauth
+requests
 shade
 six
 urllib3

--- a/rpc_jobs/re_release_manual.yml
+++ b/rpc_jobs/re_release_manual.yml
@@ -71,6 +71,10 @@
                     --mainline "${MAINLINE}" \
                 mailgun \
                     --to "${NOTIFICATION_ADDRESS}"
+                publish_release_to_wiki \
+                    --component "${REPO}" \
+                    --version "${VERSION}" \
+
           description: |
             Commands and available options.
               Note that options that are also used
@@ -148,3 +152,18 @@
                 --body TEXT     Body of release announcement message. May be omitted if<br>
                                 create_release is used.<br>
                 --help          Show this message and exit.<br>
+              <br>publish_release_to_wiki:<br>
+                --username TEXT                Confluence username.  [required]<br>
+                --password TEXT                Confluence password.  [required]<br>
+                --base-url TEXT                Confluence instance.<br>
+                --scheduled-release-page TEXT<br>
+                --async-release-page TEXT<br>
+                --component TEXT               Component name, e.g. rpc-foo.  [required]<br>
+                --version TEXT                 Component release version, e.g. 1.0.4.<br>
+                                               [required]<br>
+                --release-notes-url TEXT       Component release notes URL, e.g.<br>
+                                               https://github.com/rcbops/rpc-<br>
+                                               foo/release/tag/1.0.0.<br>
+                --comment TEXT                 Additional information to add against release<br>
+                                               in wiki.<br>
+                --help                         Show this message and exit.<br>

--- a/rpc_jobs/standard_job_release.yml
+++ b/rpc_jobs/standard_job_release.yml
@@ -120,6 +120,9 @@
                 create_release \
                     --version "${VERSION}" \
                     --bodyfile "${RELEASE_NOTES_FILE}" \
+                publish_release_to_wiki \
+                    --component "${REPO}" \
+                    --version "${VERSION}" \
           """
         } else{
           println "An RC branch called ${RC_BRANCH} was found, releasing from ${RC_BRANCH}"
@@ -146,6 +149,9 @@
                 update_rc_branch \
                     --rc "${RC_BRANCH}" \
                     --mainline "${MAINLINE}" \
+                publish_release_to_wiki \
+                    --component "${REPO}" \
+                    --version "${VERSION}" \
           """
         }
         build(

--- a/scripts/confluence_release_page.j2
+++ b/scripts/confluence_release_page.j2
@@ -1,0 +1,13 @@
+<p><strong>Date</strong>: {{ date }}</p>
+<p><strong>Meta Version</strong>: {{ meta_version }}</p>
+<p><strong>Product versions included</strong></p>
+<table class="wrapped">
+<colgroup><col /><col /><col /><col /></colgroup>
+<tbody>
+<tr><th>Product</th><th>Version</th><th>Release Notes</th><th>Comments</th></tr>
+{% for row in rows %}
+<tr><td>{{ row.product }}</td><td>{{ row.version }}</td><td>{{ row.release_notes | urlize }}</td><td>{{ row.comments | wordwrap(width=79, break_long_words=False, wrapstring="<br/>") }}</td></tr>
+{% endfor %}
+</tbody>
+</table>
+<p class="auto-cursor-target"><br /></p>

--- a/scripts/confluenceutils.py
+++ b/scripts/confluenceutils.py
@@ -1,0 +1,326 @@
+import datetime
+import json
+import logging
+from operator import itemgetter
+import os.path
+import sys
+
+from bs4 import BeautifulSoup, NavigableString
+import click
+from jinja2 import Template
+import requests
+
+
+logger = logging.getLogger("confluenceutils")
+
+
+class PageNotFound(Exception):
+    pass
+
+
+class Confluence(object):
+    """https://developer.atlassian.com/cloud/confluence/rest/"""
+
+    def __init__(self, username, password, base_url):
+        self.session = requests.Session()
+        adapter = requests.adapters.HTTPAdapter(max_retries=3)
+        self.session.mount('http://', adapter)
+        self.session.mount('https://', adapter)
+        self.session.auth = (username, password)
+        self.base_url = base_url
+        self.content_url = self.base_url + "/wiki/rest/api/content"
+        self.search_url = self.content_url + "/search"
+
+    def get_page(self, title, space_key, parent=None, additional_params=None):
+        fields = {
+            "title": '"{t}"'.format(t=title),
+            "space": space_key,
+            "type": "page",
+        }
+        if parent:
+            fields["parent"] = parent
+
+        params = {
+            "cql": " and ".join("=".join(i) for i in fields.items())
+        }
+        if additional_params:
+            params.update(additional_params)
+
+        resp = self.session.get(self.search_url, params=params)
+        resp.raise_for_status()
+        resp_data = resp.json()
+        if resp_data["size"] == 0:
+            raise PageNotFound
+        elif resp_data["size"] > 1:
+            logger.error(
+                json.dumps(
+                    resp_data,
+                    sort_keys=True,
+                    indent=4,
+                    separators=(',', ': '),
+                )
+            )
+            raise Exception("More than one page found.")
+
+        return resp_data["results"][0]
+
+    def create_page(self, title, body, space_key, parent):
+        content = {
+            "ancestors": [
+                {
+                    "id": parent
+                }
+            ],
+            "type": "page",
+            "title": title,
+            "space": {"key": space_key},
+            "body": {"storage": {"value": body, "representation": "storage"}},
+        }
+        resp = self.session.post(self.content_url, json=content)
+        resp.raise_for_status()
+        resp_data = resp.json()
+        logger.info(
+            "The following page has been created: {url}".format(
+                url=resp_data["_links"]["base"] + resp_data["_links"]["webui"],
+            )
+        )
+
+    def update_page(self, page_id, page_version_id, space_key, title, body):
+        content = {
+            "type": "page",
+            "title": title,
+            "space": {"key": space_key},
+            "body": {"storage": {"value": body, "representation": "storage"}},
+            "version": {"number": page_version_id},
+        }
+        url = "{base}/{page_id}".format(base=self.content_url, page_id=page_id)
+        resp = self.session.put(url, json=content)
+        resp.raise_for_status()
+        resp_data = resp.json()
+        logger.info(
+            "The following page has been updated: {url}".format(
+                url=resp_data["_links"]["base"] + resp_data["_links"]["webui"],
+            )
+        )
+
+
+def generate_release_page_html(meta_version, date, rows):
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    with open(os.path.join(script_dir, "confluence_release_page.j2")) as tf:
+        page_template = tf.read()
+
+    template = Template(page_template)
+    body = template.render(
+        date=date,
+        meta_version=meta_version,
+        rows=rows,
+    )
+
+    return body
+
+
+def extract_string(element):
+    return " ".join(
+        filter(lambda x: isinstance(x, NavigableString), element.descendants)
+    )
+
+
+def extract_table(raw_page):
+    page = BeautifulSoup(raw_page, "html.parser")
+    table = page.find("table", attrs={"class": "wrapped"})
+    table_body = table.find("tbody")
+    rows_with_header = table_body.find_all("tr")
+    rows = rows_with_header[1:]
+    output = []
+    for row in rows:
+        output.append([extract_string(c) for c in row])
+
+    return [
+        {
+            "product": row[0],
+            "version": row[1],
+            "release_notes": row[2],
+            "comments": row[3],
+        }
+        for row in output
+    ]
+
+
+def extract_date(raw_page):
+    page = BeautifulSoup(raw_page, "html.parser")
+    date = extract_string(page.p).split(":", 1)[1].strip()
+
+    return date
+
+
+def is_async_release(date, scheduled_window_days=7):
+    month_start = date.replace(day=1)
+    one_day = datetime.timedelta(days=1)
+
+    saturday = 6
+    sunday = 7
+    if month_start.isoweekday() == saturday:
+        month_start = month_start + one_day
+
+    if month_start.isoweekday() == sunday:
+        month_start = month_start + one_day
+
+    scheduled_window_end = month_start + scheduled_window_days * one_day
+    if date < scheduled_window_end:
+        is_async = False
+    else:
+        is_async = True
+
+    logger.info(
+        "This release has been classified as {release_type}.".format(
+            release_type=("asynchronous" if is_async else "scheduled"),
+        )
+    )
+    return is_async
+
+
+def _publish_release_to_wiki(
+    username, password, base_url, scheduled_release_page, async_release_page,
+    component, version, release_notes_url, comment,
+):
+    current_date = datetime.date.today()
+    meta_release = "{year}.{month}".format(
+        year=current_date.year, month=current_date.month
+    )
+    space_key = "RE"
+
+    c = Confluence(username, password, base_url)
+
+    product_releases_page_id = c.get_page(
+        scheduled_release_page, space_key,
+    )["id"]
+
+    if is_async_release(current_date):
+        async_releases_page_id = c.get_page(
+            async_release_page,
+            space_key,
+            parent=product_releases_page_id,
+        )["id"]
+
+        parent_page_id = async_releases_page_id
+        page_title = "{name} {version}".format(
+            name=component,
+            version=version,
+        )
+    else:
+        parent_page_id = product_releases_page_id
+        page_title = meta_release
+
+    try:
+        resp = c.get_page(
+            page_title,
+            space_key,
+            parent=parent_page_id,
+            additional_params={"expand": "body.storage,version"},
+        )
+    except PageNotFound:
+        page_id = None
+        page_version_id = None
+        date = current_date.isoformat()
+        rows = []
+    else:
+        page_id = resp["id"]
+        page_version_id = resp["version"]["number"] + 1
+        existing_page_content = resp["body"]["storage"]["value"]
+        date = extract_date(existing_page_content)
+        rows = [
+            row for row in extract_table(existing_page_content)
+            if not (
+                row["product"] == component
+                and row["version"] == version
+            )
+        ]
+
+    new_row = {
+        "product": component,
+        "version": version,
+        "release_notes": release_notes_url,
+        "comments": comment,
+    }
+    rows.append(new_row)
+    rows.sort(key=itemgetter("version"))
+    rows.sort(key=itemgetter("product"))
+
+    page_body = generate_release_page_html(meta_release, date, rows)
+    if page_id:
+        c.update_page(
+            page_id, page_version_id, space_key, page_title, page_body
+        )
+    else:
+        c.create_page(page_title, page_body, space_key, parent_page_id)
+
+
+@click.command()
+@click.option(
+    "--username",
+    required=True,
+    envvar="JIRA_USER",
+    help="Confluence username.",
+)
+@click.option(
+    "--password",
+    required=True,
+    envvar="JIRA_PASS",
+    help="Confluence password.",
+)
+@click.option(
+    "--base-url",
+    required=False,
+    default="https://rpc-openstack.atlassian.net",
+    help="Confluence instance.",
+)
+@click.option(
+    "--scheduled-release-page",
+    default="Product Releases",
+)
+@click.option(
+    "--async-release-page",
+    default="Patch and Async Releases",
+)
+@click.option(
+    "--component",
+    required=True,
+    help="Component name, e.g. rpc-foo.",
+)
+@click.option(
+    "--version",
+    required=True,
+    help="Component release version, e.g. 1.0.4.",
+)
+@click.option(
+    "--release-notes-url",
+    help=(
+        "Component release notes URL, e.g. "
+        "https://github.com/rcbops/rpc-foo/release/tag/1.0.0."
+    ),
+)
+@click.option(
+    "--comment",
+    default="",
+    help="Additional information to add against release in wiki.",
+)
+def publish_release_to_wiki(
+    username, password, base_url, scheduled_release_page, async_release_page,
+    component, version, release_notes_url, comment,
+):
+    if not release_notes_url:
+        ctx_obj = click.get_current_context().obj
+        try:
+            release_notes_url = ctx_obj.release_url
+            del ctx_obj
+        except AttributeError:
+            sys.exit(
+                "'--release-notes-url' cannot be determined because a release "
+                "is not being created, this option is therefore required."
+            )
+
+    _publish_release_to_wiki(**vars())
+
+
+if __name__ == "__main__":
+    publish_release_to_wiki()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -7,6 +7,7 @@ import traceback
 import click
 import git
 
+import confluenceutils
 import ghutils
 from notifications import mail, mailgun, try_context
 
@@ -187,6 +188,7 @@ ghutils.cli.add_command(publish_tag)
 ghutils.cli.add_command(mail)
 ghutils.cli.add_command(mailgun)
 ghutils.cli.add_command(usage)
+ghutils.cli.add_command(confluenceutils.publish_release_to_wiki)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The purpose of this change is to automate the publishing of releases to
the Confluence wiki.

`release.py` is extended to include the new sub-command
`publish_release_to_wiki`. This updates the table on the page to include
an entry for the new release. If the release already exists on the page,
its details, such as comment, are updated.

If a release is done within 7 days of the first working day of the month
it is considered a scheduled release, if it is outside of that window it
is considered an asynchronous release. The wiki page "Product Releases"
details the differences between these two types of release.

JIRA: RE-1534

Issue: [RE-1534](https://rpc-openstack.atlassian.net/browse/RE-1534)