### PR TITLE
RE-1819 Remove ORD when using custom RPC images

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -450,6 +450,9 @@
     repo_url: "https://github.com/rcbops/rpc-openstack"
     branch: "newton"
     jira_project_key: "RO"
+    # NOTE(mattt): ORD doesn't have the custom RPC images in it
+    REGIONS: "DFW"
+    FALLBACK_REGIONS: "IAD"
     image:
       - xenial:
           IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
@@ -518,6 +521,9 @@
     repo_url: "https://github.com/rcbops/rpc-openstack"
     branch: "newton-rc"
     jira_project_key: "RO"
+    # NOTE(mattt): ORD doesn't have the custom RPC images in it
+    REGIONS: "DFW"
+    FALLBACK_REGIONS: "IAD"
     image:
       - xenial:
           IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"

--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -75,6 +75,9 @@
     name: "rpc-upgrades-aio-newton-head-pm"
     repo_name: "rpc-upgrades"
     repo_url: "https://github.com/rcbops/rpc-upgrades"
+    # NOTE(mattt): ORD doesn't have the custom RPC images in it
+    REGIONS: "DFW"
+    FALLBACK_REGIONS: "IAD"
     image:
       - trusty_aio:
           FLAVOR: "performance2-15"
@@ -94,6 +97,9 @@
     name: "rpc-upgrades-aio-newton-head-pm-minor"
     repo_name: "rpc-upgrades"
     repo_url: "https://github.com/rcbops/rpc-upgrades"
+    # NOTE(mattt): ORD doesn't have the custom RPC images in it
+    REGIONS: "DFW"
+    FALLBACK_REGIONS: "IAD"
     image:
       - xenial_aio:
           FLAVOR: "performance2-15"
@@ -113,6 +119,9 @@
     name: "rpc-upgrades-aio-newton-release-pm"
     repo_name: "rpc-upgrades"
     repo_url: "https://github.com/rcbops/rpc-upgrades"
+    # NOTE(mattt): ORD doesn't have the custom RPC images in it
+    REGIONS: "DFW"
+    FALLBACK_REGIONS: "IAD"
     image:
       - trusty_aio:
           FLAVOR: "performance2-15"
@@ -207,6 +216,9 @@
     name: "rpc-upgrades-aio-newton-head-incremental"
     repo_name: "rpc-upgrades"
     repo_url: "https://github.com/rcbops/rpc-upgrades"
+    # NOTE(mattt): ORD doesn't have the custom RPC images in it
+    REGIONS: "DFW"
+    FALLBACK_REGIONS: "IAD"
     image:
       - xenial_aio:
           FLAVOR: "performance2-15"


### PR DESCRIPTION
ORD has only a small subset of custom images, this commit removes this
region on jobs using these images.

Issue: [RE-1819](https://rpc-openstack.atlassian.net/browse/RE-1819)