### PR TITLE
RE-1839 Build Summary Date Accounting Errors

### DIFF
--- a/scripts/build_summary/cachequery.py
+++ b/scripts/build_summary/cachequery.py
@@ -1,23 +1,36 @@
-import click
-import pickle
+import json
+import dateutil.parser
+
+# These functions are not called anywhere directly, but are useful for
+# loading into an interactive environment for inspecting a json build
+# data file.
 
 
-@click.group()
-def cli():
-    pass
+# load build data
+def loadbd(filename):
+    data = json.load(open(filename))
+    builds = data['builds']
+    failures = data['failures']
+
+    # transform the uuids used to reference objects in json, back into
+    # object references
+    # also convert iso 8601 timestamps into date objects.
+    for b in builds.values():
+        b['failures'] = [failures[uuid] for uuid in b['failures']]
+        b['timestamp'] = dateutil.parser.parse(b['timestamp'])
+    for f in failures.values():
+        f['build'] = builds[f['build']]
+    return (data, builds.values(), failures.values())
 
 
-@cli.command()
-@click.option('--cache-file', default='test-cache')
-@click.option('--query')
-def query(cache_file, query):
-    with open(cache_file, 'rb') as f:
-        key, criteria = query.split('=')
-        buildobjs = pickle.load(f)
-        for name, build in buildobjs.items():
-            item = getattr(build, key, '')
-            if criteria in item:
-                print(build, item)
-
-
-cli()
+# get builds and failures for one day
+def objectsForDay(data, year, month, day):
+    def istd(b):
+        return (b['timestamp'].day == day
+                and b['timestamp'].month == month
+                and b['timestamp'].year == year)
+    builds = data['builds'].values()
+    failures = data['failures'].values()
+    daybuilds = [b for b in builds if istd(b)]
+    dayfailures = [f for f in failures if istd(f['build'])]
+    return (daybuilds, dayfailures)

--- a/scripts/build_summary/components.js
+++ b/scripts/build_summary/components.js
@@ -117,7 +117,7 @@ failureTypesTrend = Vue.component("failureTypesTrend",{
       },
     datasets: function(){
       var colours = this.$root.colours(this.topFailureTypes.length + 1)
-      var ds = this.topFailureTypes.reduce((a,c,i)=>{
+      var ds = this.topFailureTypes.reduce((a,c,i) => {
         a.push({
           label: c[1],
           // ensure success is always green
@@ -167,7 +167,7 @@ failureCategoriesTrend = Vue.component("failureCategoriesTrend",{
     datasets: function(){
       var failuresByCategory = this.$root.failuresByCategory(this.builds)
       var colours = this.$root.colours(failuresByCategory.length + 1)
-      var ds = failuresByCategory.reduce((a,c,i)=>{
+      var ds = failuresByCategory.reduce((a, c, i) => {
         a.push({
           label: c[1],
           // ensure success is always green
@@ -198,7 +198,7 @@ repoTable = Vue.component("repoTable",{
       sortBy: 'failPercent',
       descending: true
     }
-    d.rowsperpage = [5,15,25,50,100,{text:"All",value:-1}]
+    d.rowsperpage = [5, 15, 25, 50, 100, {text:"All",value:-1}]
     d.items = []
     Object.values(this.$root.repos).forEach(r => {
       var builds = r[2]
@@ -210,7 +210,7 @@ repoTable = Vue.component("repoTable",{
                 failPercent: 0}
       var buildFailures = builds.filter(b => b.result != "SUCCESS")
       var failCount = buildFailures.length
-      ro.failPercent = ((failCount/ro.numBuilds)*100).toFixed(0)
+      ro.failPercent = ((failCount / ro.numBuilds) * 100).toFixed(0)
       mostFailingJob = buildFailures.countBy("job_name")[0]
       ro.mostFailingJob = mostFailingJob[1]
       ro.mostFailingJobCount = mostFailingJob[0]
@@ -356,7 +356,7 @@ buildTable = Vue.component("buildTable",{
       // this is used with methods/filter to search
       // as the default search won't look into
       // nested structures
-      return this.builds.reduce((a,c)=> {
+      return this.builds.reduce((a, c)=> {
         c.searchText= [
           c.result,
           c.timestamp.toISOString(),
@@ -378,7 +378,7 @@ buildTable = Vue.component("buildTable",{
   methods: {
     filter: function(items, search, filter){
       return items.filter(i =>
-        i.searchText.indexOf(search.toLowerCase())>=0)
+        i.searchText.indexOf(search.toLowerCase()) >= 0)
     }
   },
   data: function(){
@@ -391,7 +391,7 @@ buildTable = Vue.component("buildTable",{
           {text: "Failures", value: "failures", sortable: false}
         ],
         search: '',
-        rowsperpage: [5,15,25,50,{text: "All", value: -1}],
+        rowsperpage: [5, 15, 25, 50, {text: "All", value: -1}],
         pagination: {
           sortBy: 'timestamp',
           descending: true
@@ -503,7 +503,7 @@ jobTable = Vue.component("jobTable",{
     //   return this.$root.repos[this.repo.name].jobs
     // },
     items: function(){
-      return this.builds.countBy("job_name").reduce((a,c) => {
+      return this.builds.countBy("job_name").reduce((a, c) => {
       //return Object.values(this.jobs).reduce((a,c) => {
         var builds = c[2]
         var name = c[1]
@@ -520,7 +520,7 @@ jobTable = Vue.component("jobTable",{
           numBuilds: numBuilds,
           oldest: this.$root.dfmt(oldestNewest.oldest.timestamp),
           newest: this.$root.dfmt(oldestNewest.newest.timestamp),
-          failPercent: ((numFailedBuilds/numBuilds)*100).toFixed(0),
+          failPercent: ((numFailedBuilds / numBuilds) * 100).toFixed(0),
           topFailureType: topFailureTypes[0][1]
         })
         return a
@@ -536,7 +536,7 @@ jobTable = Vue.component("jobTable",{
           {text: "Newest Build", value: "newest"}
         ],
         search: '',
-        rowsperpage: [5,10,25,50,{text: "All", value: -1}],
+        rowsperpage: [5, 10, 25, 50, {text: "All", value: -1}],
         pagination: this.sort,
       }
     if(this.showFailurePercent){
@@ -643,7 +643,7 @@ failureCategoryTable = Vue.component("failureCategoryTable", {
       var totalBuilds = Object.values(this.builds).length
       // builds by failure type
       var failuresByCategory = this.$root.failuresByCategory(Object.values(this.builds))
-      return failuresByCategory.reduce((a,c) => {
+      return failuresByCategory.reduce((a, c) => {
         // list of builds for this type
         var category = c[1]
         var categoryBuilds = c[2].map(f => f.build)
@@ -656,11 +656,11 @@ failureCategoryTable = Vue.component("failureCategoryTable", {
           // Category, then read its category.
           failureCategory: categoryFailures[0].category,
           failureOccurences: categoryBuilds.length,
-          failurePercent: ((categoryBuilds.length/totalBuilds)*100).toFixed(0),
+          failurePercent: ((categoryBuilds.length / totalBuilds) * 100).toFixed(0),
           oldest: oldestNewest.oldest.timestamp,
           newest: oldestNewest.newest.timestamp,
-          topJobs: categoryBuilds.countBy("job_name").slice(0,this.numTopJobs),
-          topFailureTypes: this.$root.failuresByType(categoryBuilds).slice(0,this.numTopTypes)
+          topJobs: categoryBuilds.countBy("job_name").slice(0, this.numTopJobs),
+          topFailureTypes: this.$root.failuresByType(categoryBuilds).slice(0, this.numTopTypes)
         })
         return a
       }, [])
@@ -677,7 +677,7 @@ failureCategoryTable = Vue.component("failureCategoryTable", {
           {text: "Top Failure Types", value: "topFailureTypes"},
         ],
         search: '',
-        rowsperpage: [5,10,25,50,{text: "All", value: -1}],
+        rowsperpage: [5, 10, 25, 50, {text: "All", value: -1}],
         pagination: {
           sortBy: 'failureOccurences',
           descending: true
@@ -763,7 +763,7 @@ failureTable = Vue.component("failureTable",{
       var totalBuilds = Object.values(this.builds).length
       // builds by failure type
       var failuresByType = this.$root.failuresByType(Object.values(this.builds))
-      return failuresByType.reduce((a,c) => {
+      return failuresByType.reduce((a, c) => {
         // list of builds for this type
         var type = c[1]
         var typeBuilds = c[2].map(f => f.build)
@@ -776,10 +776,10 @@ failureTable = Vue.component("failureTable",{
           // type, then read its category.
           failureCategory: typeFailures[0].category,
           failureOccurences: typeBuilds.length,
-          failurePercent: ((typeBuilds.length/totalBuilds)*100).toFixed(0),
+          failurePercent: ((typeBuilds.length / totalBuilds) * 100).toFixed(0),
           oldest: oldestNewest.oldest.timestamp,
           newest: oldestNewest.newest.timestamp,
-          topJobs: typeBuilds.countBy("job_name").slice(0,this.numTopJobs),
+          topJobs: typeBuilds.countBy("job_name").slice(0, this.numTopJobs),
         })
         return a
       }, [])
@@ -795,7 +795,7 @@ failureTable = Vue.component("failureTable",{
           {text: "Newest Occurence", value: "newest"},
         ],
         search: '',
-        rowsperpage: [5,10,25,50,{text: "All", value: -1}],
+        rowsperpage: [5, 10, 25, 50, {text: "All", value: -1}],
         pagination: {
           sortBy: 'failureOccurences',
           descending: true
@@ -891,10 +891,10 @@ toolbarmenu = Vue.component("toolbarmenu",{
   },
   computed: {
     items: function(){
-      return this.counteditems.reduce((a,c) => {
+      return this.counteditems.reduce((a, c) => {
         a.push({
           title: c[1],
-          url: '/'+this.urlbase+'/'+c[1]
+          url: '/' + this.urlbase + '/' + c[1]
         })
         return a
       },[])

--- a/scripts/build_summary/components.js
+++ b/scripts/build_summary/components.js
@@ -359,7 +359,9 @@ buildTable = Vue.component("buildTable",{
       return this.builds.reduce((a,c)=> {
         c.searchText= [
           c.result,
-          c.timestamp,
+          c.timestamp.toISOString(),
+          c.timestamp.toDateString(),
+          c.timestamp.toLocaleDateString(),
           c.branch,
           ...c.build_hierachy.map(b => b.name),
           ...c.build_hierachy.map(b => b.build_num),

--- a/scripts/build_summary/failure.py
+++ b/scripts/build_summary/failure.py
@@ -45,8 +45,6 @@ class Failure(ABC):
         cls.scan_logs(build)
         if (build.junit is not None):
             cls.scan_junit(build)
-        if not build.failures:
-            build.failures.append(UnknownFailure(build).id)
 
     @classmethod
     def scan_junit(cls, build):
@@ -447,11 +445,3 @@ class ArtifactArchiveFailure(Failure):
                     self.matches = True
                     self.detail = str.strip()
                     break
-
-
-class UnknownFailure(Failure):
-    description = "No known failures matched"
-    category = "C7 Uncategorised"
-
-    def scan(self):
-        return False

--- a/scripts/build_summary/index.html
+++ b/scripts/build_summary/index.html
@@ -164,13 +164,30 @@
           var r = Object.values(this.builds).countBy("repo")
           return r
         },
+        histogram_end: function(){
+          // Defines the most recent end of date based histogram.
+          // Buckets will be measured in units of 24 hours preceeding this point.
+
+          // Previously histogram end was always the current time, but this meant
+          // histogram buckets were the previous 24 hours before now, which didn't line
+          // up with the date labels on the graphs. It also meant that the values for
+          // each date varied during the day as a build could age enough to move up to
+          // the next bucket. This was exacerbated by a rounding error that caused
+          // builds for one day to be evenly split over two buckets
+          // (the correct day and the next day)
+          // Now histogram end is aligned with a day boundary so that the 24 hour
+          // buckets are aligned with calendar days.
+          end = new Date() // now
+          end.setHours(0,0,0,0) //start of today
+          end.setDate(end.getDate()+1) //start of tomorrow
+          return end
+        },
         labels: function(){
-          now = new Date()
           return [...Array(this.retention_days).keys()].map(
             (i) => {
               var daysAgo = this.retention_days-i
               var dayInMillis = 86400000
-              return new Date(now-dayInMillis * daysAgo).toLocaleDateString()
+              return new Date(this.histogram_end-dayInMillis * daysAgo).toLocaleDateString()
             }
           )
         }
@@ -178,14 +195,17 @@
       methods: {
         histogram: function(builds, length, inc) {
           histogram = new Array(length).fill(0);
-          now = new Date()
-          vueobj = this
+          histogram_end = this.histogram_end
+          // oldest bucket
+          histogram_start = new Date(histogram_end)
+          histogram_start.setDate(histogram_start.getDate()-length)
           builds.forEach(function(build) {
-            build_age = new Date(build.timestamp)
-            age_millis = (now - build_age)
-            age_days = Math.round(age_millis * 1.0 / (1000 * 60 * 60 * 24))
-            if (age_days < length) {
-              histogram[length - age_days - 1] += inc
+            age_millis = (histogram_end - build.timestamp)
+            // note previously math.round was used here which caused results for a day
+            // to be spread over it and the next day.
+            age_days = Math.ceil(age_millis * 1.0 / (1000 * 60 * 60 * 24))
+            if (build.timestamp > histogram_start) {
+              histogram[length - age_days] += inc
             }
           })
           return histogram

--- a/scripts/build_summary/index.html
+++ b/scripts/build_summary/index.html
@@ -144,6 +144,7 @@
             b.failures = b.failures.map(id => this.failures_raw[id])
             // convert build ids in failure objects to build objects
             b.failures.forEach(f => f.build = this.$root.builds_raw[f.build])
+            b.timestamp = new Date(b.timestamp)
           })
           // this method actually mutates the builds_raw dict,
           // but making use of the 'builds' computed var will cause
@@ -191,7 +192,7 @@
         },
         dateSortedBuilds: function(builds) {
           var sorted = builds.sort(function(a, b) {
-            return new Date(a.timestamp) - new Date(b.timestamp)
+            return a.timestamp - b.timestamp
           })
           return sorted;
         },
@@ -200,10 +201,9 @@
           return {oldest: dsb[0],
                   newest: dsb.slice(-1)[0]}
         },
-        dfmt: function(date_string) {
-          d = new Date(date_string)
+        dfmt: function(date) {
           //return `${d.toLocaleDateString()} ${d.toLocaleTimeString()}`
-          return d.toISOString()
+          return date.toISOString()
         },
         colours: function(numRequired){
           // Generate colours for chart series in hsla() format

--- a/scripts/build_summary/index.html
+++ b/scripts/build_summary/index.html
@@ -73,16 +73,16 @@
   Array.prototype.countBy = function(prop){
     var count = Object.entries(this.groupBy(prop))
       .map(t => [t[1].length, t[0], t[1]])
-      .sort((a,b) => a[0] < b[0] ? 1 : -1)
+      .sort((a, b) => a[0] < b[0] ? 1 : -1)
     if (count.length == 0){
-      return [0,"",[]]
+      return [0, "", []]
     }
     return count
   }
 
   // Recursively flatten a list
   Array.prototype.flatten = function(){
-    return this.reduce((a,c) => {
+    return this.reduce((a, c) => {
       if (Array.isArray(c)){
         c = c.flatten()
         return [...a, ...c]
@@ -178,16 +178,16 @@
           // Now histogram end is aligned with a day boundary so that the 24 hour
           // buckets are aligned with calendar days.
           end = new Date() // now
-          end.setHours(0,0,0,0) //start of today
-          end.setDate(end.getDate()+1) //start of tomorrow
+          end.setHours(0, 0, 0, 0) //start of today
+          end.setDate(end.getDate() + 1) //start of tomorrow
           return end
         },
         labels: function(){
           return [...Array(this.retention_days).keys()].map(
             (i) => {
-              var daysAgo = this.retention_days-i
+              var daysAgo = this.retention_days - i
               var dayInMillis = 86400000
-              return new Date(this.histogram_end-dayInMillis * daysAgo).toLocaleDateString()
+              return new Date(this.histogram_end - dayInMillis * daysAgo).toLocaleDateString()
             }
           )
         }
@@ -198,7 +198,7 @@
           histogram_end = this.histogram_end
           // oldest bucket
           histogram_start = new Date(histogram_end)
-          histogram_start.setDate(histogram_start.getDate()-length)
+          histogram_start.setDate(histogram_start.getDate() - length)
           builds.forEach(function(build) {
             age_millis = (histogram_end - build.timestamp)
             // note previously math.round was used here which caused results for a day
@@ -235,12 +235,12 @@
           // hue 0-359, green (used for success is 120)
           var greenHue = 120
           var maxHue = 359
-          var arc = (maxHue+1.0)/(numRequired+0.0)
+          var arc = (maxHue + 1.0)/(numRequired + 0.0)
           // push green in first
           colours.push('hsla('+greenHue+', 80%, 60%, 0.39)')
           // then add as many other colours as required.
-          for(i=1; i<=numRequired-1; i++){
-            var hue = ((greenHue + (i*arc)) % maxHue).toFixed(0)
+          for(i = 1; i <= numRequired - 1; i++){
+            var hue = ((greenHue + (i * arc)) % maxHue).toFixed(0)
             colours.push('hsla('+hue+', 80%, 60%, 0.39)')
           }
           return colours
@@ -251,9 +251,9 @@
           // based on an in put percent (Value between 0 and 1)
           var lumMax = 100
           var lumMin = 62
-          var lumRange = lumMax-lumMin
+          var lumRange = lumMax - lumMin
           var lum = lumMax - (percent * lumRange)
-          var c = 'hsl(5, 100%, '+lum+'%)'
+          var c = 'hsl(5, 100%, ' + lum + '%)'
           return c
         },
         failuresByCategory: function(builds){

--- a/scripts/build_summary/views.js
+++ b/scripts/build_summary/views.js
@@ -93,7 +93,7 @@ failureTypeView = Vue.component("failureTypeView",{
   computed: {
       failures: function(){
         return this.$root.failuresByType(Object.values(this.$root.builds))
-          .filter(l=> l[1]==this.type)[0][2]
+          .filter(l=> l[1] == this.type)[0][2]
       },
       builds: function(){
         return this.failures.map(f => f.build)
@@ -105,7 +105,7 @@ failureTypeView = Vue.component("failureTypeView",{
   methods: {
     dsFilter: function(ds){
       var type = this.type
-      return ds.label==type
+      return ds.label == type
     }
   },
   template: `
@@ -150,7 +150,7 @@ failureCategoryView = Vue.component("failureCategoryView",{
   computed: {
       failures: function(){
         return this.$root.failuresByCategory(Object.values(this.$root.builds))
-          .filter(l=> l[1]==this.category)[0][2]
+          .filter(l => l[1] == this.category)[0][2]
       },
       builds: function(){
         return this.failures.map(f => f.build)
@@ -159,7 +159,7 @@ failureCategoryView = Vue.component("failureCategoryView",{
   methods: {
     dsFilter: function(ds){
       var category = this.category
-      return ds.label==category
+      return ds.label == category
     },
     typeFilter: function(failure){
       var category = this.category


### PR DESCRIPTION
Addresses two grave bugs in the way build summary handles dates when
    producing graphs:

    1) The graphs are generated using a histogram, builds are divided into 60
    24 hour buckets, and each bucket is labeled with a date. The problem is
    that the start point is whenever the page is rendered so the 24 hour
    histogram buckets do not line up with calendar days. The resolution is to
    move the histogram start point to a day boundary so that histogram buckets
    and days lineup.

    2) The way that builds are allocated to buckets is by working out the
    difference between the histogram end, and the build timestamp in
    milliseconds, this in the divided by the number of milliseconds in a day
    and rounded to produce an integer. That integer is subtracted from the
    length of the histogram to get the bucket number.  Due to standard rounding
    some builds would be put in the correct bucket, and some in the bucket for
    the next day. The fix is to use the ceil function instead of round.

Issue: [RE-1839](https://rpc-openstack.atlassian.net/browse/RE-1839)