### PR TITLE
ASC-870 Add qTest API Credentials

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -176,6 +176,8 @@
       - "kilo_to_newton_leap"
       - "liberty_to_newton_leap_system"
     jira_project_key: "RLM"
+    # Required by RPC-ASC team to upload test results qTest
+    credentials: "rpc_asc_creds"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
     CRON: "@weekly"
@@ -208,6 +210,8 @@
       - "kilo_to_r14.current_leap"
       - "liberty_to_r14.current_leap_system"
     jira_project_key: "RLM"
+    # Required by RPC-ASC team to upload test results qTest
+    credentials: "rpc_asc_creds"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
     CRON: "@weekly"


### PR DESCRIPTION
In order for the system test upgrade jobs to publish results to qTest the
"rpc_asc_creds" package needs to be configured.