### PR TITLE
RE-730 Make jenkins label consistent for JIRA cards

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1697,7 +1697,7 @@ void createComponentSkeleton(String name, String repoUrl, String jiraProjectKey)
       [
         "ISSUE_SUMMARY=Add component skeleton to ${name}",
         "ISSUE_DESCRIPTION=This issue was generated automatically as part of registering a new component.",
-        "LABELS=component-skeleton",
+        "LABELS=component-skeleton jenkins",
         "JIRA_PROJECT_KEY=${jiraProjectKey}",
         "TARGET_BRANCH=master",
         "COMMIT_TITLE=Add new component gating skeleton",

--- a/rpc_jobs/bump_snapshots.yml
+++ b/rpc_jobs/bump_snapshots.yml
@@ -120,7 +120,7 @@
             [
               "ISSUE_SUMMARY=Bump snapshot versions",
               "ISSUE_DESCRIPTION=This change was triggered by the jenkins job Bump-Snapshot-Images.",
-              "LABELS=snapshot-bump",
+              "LABELS=snapshot-bump jenkins",
               "JIRA_PROJECT_KEY=RE",
               "TARGET_BRANCH=master",
               "COMMIT_TITLE=Bump snapshot versions",

--- a/scripts/add_component_gate_trigger_job.sh
+++ b/scripts/add_component_gate_trigger_job.sh
@@ -24,6 +24,7 @@ EOF
           --description "${issue_message}" \
           --label COMPONENT_GATE_TRIGGER \
           --label "${COMPONENT_NAME}" \
+          --label jenkins
   )
   echo "Issue: ${issue}"
 


### PR DESCRIPTION
The original task asked to add a label for cards that were created
automatically.  At the time I began this task, the label "jenkins" had
been added to almost every automated PR/card, but after further
examination, some recent features do not include the "jenkins" label. So
this task now involves simply adding the "jenkins" label to any missing
automated card - for the sake of consistency.

JIRA: RE-730

Issue: [RE-730](https://rpc-openstack.atlassian.net/browse/RE-730)