### PR TITLE
RE-1800 Add playbooks/roles/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,7 @@
 .lintvenv
 **/.?venv/
 **/.?lintvenv*/
-playbooks/roles/geerlingguy.nginx/
-playbooks/roles/jnv.unattended-upgrades/
-playbooks/roles/willshersystems.sshd/
-playbooks/roles/mongrelion.docker/
+playbooks/roles/
 runjenkins.yml
 
 


### PR DESCRIPTION
The rpc-gating venv contains openstack.logrotate, but it's not present
in .gitignore so anything attempting to do a `git add -A` in
rpc-gating will include this ansible role.

This commit updates .gitignore by adding playbookes/roles and removing
all individual roles specified in playbooks/roles/.

Issue: [RE-1800](https://rpc-openstack.atlassian.net/browse/RE-1800)