### PR TITLE
RE-1616 Run release tooling inside container

### DIFF
--- a/job_dsl/release.groovy
+++ b/job_dsl/release.groovy
@@ -1,44 +1,46 @@
 library "rpc-gating-master"
 common.globalWraps(){
-  stage("Configure Git"){
-    common.configure_git()
-  }
-
-  stage("Release"){
-    // If this is a PR test, then we need to set some
-    // of the environment variables automatically as
-    // they will not be provided by a human.
-    if ( env.ghprbPullId != null ) {
-      List source_repo = env.ghprbGhRepository.split("/")
-      env.ORG = source_repo[0]
-      env.REPO = source_repo[1]
-      env.RC_BRANCH = "pr/${env.ghprbPullId}/merge"
+  common.standard_job_slave(env.SLAVE_TYPE) {
+    stage("Configure Git"){
+      common.configure_git()
     }
-    withCredentials([
-      string(
-        credentialsId: 'rpc-jenkins-svc-github-pat',
-        variable: 'PAT'
-      ),
-      string(
-        credentialsId: 'mailgun_mattt_endpoint',
-        variable: 'MAILGUN_ENDPOINT'
-      ),
-      string(
-        credentialsId: 'mailgun_mattt_api_key',
-        variable: 'MAILGUN_API_KEY'
-      ),
-      usernamePassword(
-        credentialsId: "jira_user_pass",
-        usernameVariable: "JIRA_USER",
-        passwordVariable: "JIRA_PASS"
-      )
-    ]){
-      sshagent (credentials:['rpc-jenkins-svc-github-ssh-key']){
-        sh """#!/bin/bash -xe
-          set +x; . .venv/bin/activate; set -x
-          ${env.COMMAND}
-        """
-      } // sshagent
-    } // withCredentials
-  } // stage
+
+    stage("Release"){
+      // If this is a PR test, then we need to set some
+      // of the environment variables automatically as
+      // they will not be provided by a human.
+      if ( env.ghprbPullId != null ) {
+        List source_repo = env.ghprbGhRepository.split("/")
+        env.ORG = source_repo[0]
+        env.REPO = source_repo[1]
+        env.RC_BRANCH = "pr/${env.ghprbPullId}/merge"
+      }
+      withCredentials([
+        string(
+          credentialsId: 'rpc-jenkins-svc-github-pat',
+          variable: 'PAT'
+        ),
+        string(
+          credentialsId: 'mailgun_mattt_endpoint',
+          variable: 'MAILGUN_ENDPOINT'
+        ),
+        string(
+          credentialsId: 'mailgun_mattt_api_key',
+          variable: 'MAILGUN_API_KEY'
+        ),
+        usernamePassword(
+          credentialsId: "jira_user_pass",
+          usernameVariable: "JIRA_USER",
+          passwordVariable: "JIRA_PASS"
+        )
+      ]){
+        sshagent (credentials:['rpc-jenkins-svc-github-ssh-key']){
+          sh """#!/bin/bash -xe
+            set +x; . .venv/bin/activate; set -x
+            ${env.COMMAND}
+          """
+        } // sshagent
+      } // withCredentials
+    } // stage
+  } // standard_job_slave
 } // globalWraps

--- a/rpc_jobs/re_release_manual.yml
+++ b/rpc_jobs/re_release_manual.yml
@@ -15,6 +15,11 @@
           num-to-keep: 30
     parameters:
       - rpc_gating_params
+      - standard_job_params:
+          SLAVE_TYPE: "container"
+          SLAVE_CONTAINER_DOCKERFILE_REPO: "RE"
+          SLAVE_CONTAINER_DOCKERFILE_PATH: "./Dockerfile.standard_job"
+          SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS: "BASE_IMAGE=ubuntu:16.04"
       - text:
           name: COMMAND
           default: |


### PR DESCRIPTION
This commit runs the release.py script inside a docker container,
removing the need for a project's generate_release_notes tooling to run
their scripts inside a docker container.

We will need to coordinate this change with changes to the following
projects to remove the docker references in their generate_release_notes
scripts:

rpc-openstack master/queens/pike/newton
rpc-maas master
rpc-upgrades master
rpc-ceph master

Issue: [RE-1616](https://rpc-openstack.atlassian.net/browse/RE-1616)