### PR TITLE
Skip release tests with existing successful builds

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1469,6 +1469,13 @@ void stdJob(String hook_dir, String credentials, String jira_project_key, String
                   "${env.WORKSPACE}/${env.RE_JOB_REPO_NAME}",
                 )
               }
+              dir("${env.WORKSPACE}/${env.RE_JOB_REPO_NAME}"){
+                updateStringParam(
+                  "_BUILD_SHA",
+                  sh(script: "git rev-parse --verify HEAD", returnStdout: true).trim(),
+                  "The SHA tested by this build."
+                )
+              }
             }
 
             found_hook_dir = findHookDir(hook_dir)
@@ -1862,4 +1869,18 @@ List loadCSV(String str){
 
 String dumpCSV(List l){
   l.join(",")
+}
+
+/**
+ * Update string parameter.
+ *
+ * This procedure updates the value and description of an existing string
+ * parameter.
+ */
+void updateStringParam(String name, String value, String description){
+    println "Updating string parameter '${name}' to '${value}'."
+    List updatedParam = [new StringParameterValue(name, value, description)]
+    ParametersAction existingAction = currentBuild.rawBuild.getAction(ParametersAction)
+    ParametersAction newAction = existingAction.createUpdated(updatedParam)
+    currentBuild.rawBuild.addOrReplaceAction(newAction)
 }

--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -135,6 +135,13 @@
             build. This defaults to "BASE_IMAGE=ubuntu:16.04", which is
             specifically applicable to the "./Dockerfile.standard_job" in
             rpc-gating.
+      - string:
+          name: "_BUILD_SHA"
+          default: ""
+          description: >
+            This parameter is for tracking completed builds and is set
+            automatically. This variable should not be used by a project's
+            gating scripts and overriding the default value has no effect.
 
 - parameter:
     name: phobos_params

--- a/scripts/lint_support_groovy/ParametersAction.groovy
+++ b/scripts/lint_support_groovy/ParametersAction.groovy
@@ -1,0 +1,4 @@
+//Dummy ParametersAction class for lint jobs
+public class ParametersAction {
+
+}

--- a/scripts/lint_support_groovy/StringParameterValue.groovy
+++ b/scripts/lint_support_groovy/StringParameterValue.groovy
@@ -1,0 +1,4 @@
+//Dummy StringParameterValue class for lint jobs
+public class StringParameterValue {
+
+}


### PR DESCRIPTION
`testRelease` is extended to enable it to discover any existing RELEASE_
or PM_ build that completed successfully for a particular SHA. RELEASE_
and PM_ jobs are treated as equivalent if they only differ by the prefix
(RELEASE_/PM_). If a build exists, the job does not need to be run
again.

To determine if a test was for a particular SHA the parameter
`_BUILD_SHA` is checked.

This change should, in general, reduce the time the release process
takes to complete, while allowing it to automatically resolve any
missing prerequisites.

JIRA: RE-1671

Issue: [RE-1671](https://rpc-openstack.atlassian.net/browse/RE-1671)