### PR TITLE
Override default ansible plugin paths to prevent interference

### DIFF
--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -1,6 +1,15 @@
 [defaults]
 host_key_checking = False
 force_color = True
+library = $WORKSPACE/.venv/lib/python2.7/site-packages/ansible/plugins/library
+action_plugins = $WORKSPACE/.venv/lib/python2.7/site-packages/ansible/plugins/action
+callback_plugins = $WORKSPACE/.venv/lib/python2.7/site-packages/ansible/plugins/callback
+connection_plugins = $WORKSPACE/.venv/lib/python2.7/site-packages/ansible/plugins/connection
+filter_plugins = $WORKSPACE/.venv/lib/python2.7/site-packages/ansible/plugins/filter
+lookup_plugins = $WORKSPACE/.venv/lib/python2.7/site-packages/ansible/plugins/lookup
+strategy_plugins = $WORKSPACE/.venv/lib/python2.7/site-packages/ansible/plugins/strategy
+vars_plugins = $WORKSPACE/.venv/lib/python2.7/site-packages/ansible/plugins/vars
+roles_path = $WORKSPACE/rpc-gating/playbooks/roles
 
 [ssh_connection]
 retries = 3


### PR DESCRIPTION
The various tests which run may include implementing an ansible.cfg
file in the default search paths that ansible uses, resulting in
our playbooks trying to load/use things which are not meant to be.

To combat this, we override the paths for all plugin types and set
them to the location in the rpc-gating venv. We do the same for the
roles packaged into the rpc-gating tarball.

JIRA: [RE-1870](https://rpc-openstack.atlassian.net/browse/RE-1870)