### PR TITLE
RE-1612 Add SLAVE params to premerge release test

### DIFF
--- a/rpc_jobs/standard_job_premerge_release.yml
+++ b/rpc_jobs/standard_job_premerge_release.yml
@@ -49,6 +49,11 @@
           cancel-builds-on-update: true
     parameters:
       - rpc_gating_params
+      - standard_job_params:
+          SLAVE_TYPE: "container"
+          SLAVE_CONTAINER_DOCKERFILE_REPO: "RE"
+          SLAVE_CONTAINER_DOCKERFILE_PATH: "./Dockerfile.standard_job"
+          SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS: "BASE_IMAGE=ubuntu:16.04"
       - string:
           name: "URL"
           description: URL of the repo to be release tested


### PR DESCRIPTION
job_dsl/release.groovy now uses a `SLAVE_TYPE` of `container`, so we
need to ensure all jobs using job_dsl/release.groovy have the necessary
params set.

Issue: [RE-1612](https://rpc-openstack.atlassian.net/browse/RE-1612)