### PR TITLE
Revert "Skip release tests with existing successful builds"

### DIFF
--- a/rpc_jobs/params.yml
+++ b/rpc_jobs/params.yml
@@ -135,13 +135,6 @@
             build. This defaults to "BASE_IMAGE=ubuntu:16.04", which is
             specifically applicable to the "./Dockerfile.standard_job" in
             rpc-gating.
-      - string:
-          name: "_BUILD_SHA"
-          default: ""
-          description: >
-            This parameter is for tracking completed builds and is set
-            automatically. This variable should not be used by a project's
-            gating scripts and overriding the default value has no effect.
 
 - parameter:
     name: phobos_params

--- a/scripts/lint_support_groovy/ParametersAction.groovy
+++ b/scripts/lint_support_groovy/ParametersAction.groovy
@@ -1,4 +1,0 @@
-//Dummy ParametersAction class for lint jobs
-public class ParametersAction {
-
-}

--- a/scripts/lint_support_groovy/StringParameterValue.groovy
+++ b/scripts/lint_support_groovy/StringParameterValue.groovy
@@ -1,4 +1,0 @@
-//Dummy StringParameterValue class for lint jobs
-public class StringParameterValue {
-
-}


### PR DESCRIPTION
We're hitting some container build failures as a result of this change,
which may or may not be related to the `dir()` step used inside the
container.

Additional work needs to be done to validate that this is in fact the
issue and a further testing will need to be done on the proposed fix.

Reverts rcbops/rpc-gating#1005