### PR TITLE
Update rpc_component to allow RC tags

### DIFF
--- a/constraints_rpc_component.txt
+++ b/constraints_rpc_component.txt
@@ -1,3 +1,3 @@
 GitPython==2.1.9
-git+https://github.com/rcbops/rpc_component@85f152ece9eee3c9cd7d68bd2ecc5982e17400ae#egg=rpc_component
+git+https://github.com/rcbops/rpc_component@2e7841146634850fef02ba392f5e3910031a0d63#egg=rpc_component
 schema==0.6.7


### PR DESCRIPTION
Currently only alpha/beta pre-release tags are supported.
This patch updates the rpc_component SHA to include the
change of schema which allows rc pre-release tags so that
they can be used for releases.

The accepted form is the same as with alpha/beta tags, eg:
1.0.0-rc.1, 1.0.0-rc.2, etc.


Issue: [RE-1894](https://rpc-openstack.atlassian.net/browse/RE-1894)