### PR TITLE
Move hardening MNAIO jobs to use nodepool

### DIFF
--- a/rpc_jobs/hardening.yml
+++ b/rpc_jobs/hardening.yml
@@ -6,10 +6,7 @@
     jira_project_key: "RQE"
     image:
       - xenial_mnaio_loose_artifacts:
-          FLAVOR: "onmetal-io2"
-          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
-          REGIONS: "IAD"
-          FALLBACK_REGIONS: "DFW"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
     scenario:
       - "swift"
     action:


### PR DESCRIPTION
Now that nodepool can properly cater to providing
OnMetal instances, we can switch these jobs over
to use it.