### PR TITLE
Move upgrade MNAIO jobs to use nodepool

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -164,10 +164,7 @@
     image:
       # in mnaio builds, the OS equals the VMs OS
       - trusty_mnaio:
-          FLAVOR: "onmetal-io2"
-          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
-          REGIONS: "IAD"
-          FALLBACK_REGIONS: "DFW"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
     scenario:
       - "swift"
     action:
@@ -189,10 +186,7 @@
     image:
       # in mnaio builds, the OS equals the VMs OS
       - trusty_mnaio:
-          FLAVOR: "onmetal-io2"
-          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
-          REGIONS: "IAD"
-          FALLBACK_REGIONS: "DFW"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
     scenario:
       - "swift"
     action:
@@ -243,10 +237,7 @@
     repo_url: "https://github.com/rcbops/rpc-upgrades"
     image:
       - xenial_mnaio:
-          FLAVOR: "onmetal-io2"
-          IMAGE: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
-          REGIONS: "IAD"
-          FALLBACK_REGIONS: "DFW"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
     scenario:
       - "swift"
     action:


### PR DESCRIPTION
Now that nodepool can properly cater to providing
OnMetal instances, we can switch these jobs over
to use it.

As per the issue, the team has agreed to go ahead
with this without pre-testing all the jobs.


Issue: [RE-1732](https://rpc-openstack.atlassian.net/browse/RE-1732)