### PR TITLE
Segment large file artifacts when uploading them

### DIFF
--- a/playbooks/tasks/artifact_upload/upload_file.yml
+++ b/playbooks/tasks/artifact_upload/upload_file.yml
@@ -65,12 +65,16 @@
 
     # The ansible os_object module does not currently support setting
     # the object expiration header field, nor does it do threaded uploads
-    # (which make this much faster), so we use the swift client instead.
+    # (which make this much faster), nor does it support setting a segment
+    # size (for large files), so we use the swift client instead. We use
+    # a segment size of 1GB to ensure that large files are segmented to
+    # less than the 5GB limit implemented by Cloud Files.
     - name: Upload Artifacts to Cloud Files
       command: >-
         swift upload {{ object_store_container_name }} {{ artifact_basename }}
         --object-threads 100
         --skip-identical
+        --segment-size 1073741824
         {{ artifact.expire_after is defined | ternary("--header 'X-Delete-After:" ~ artifact.get('expire_after') ~ "'", "") }}
       args:
         chdir: "{{ artifact['source'] | dirname }}"


### PR DESCRIPTION
Cloud Files only supports file sizes up to 5GB [1]. Anything larger
must be segmented. When serving these files via the CDN address
they are still delivered as a single file, so segmentation provides
the advantage of a faster upload and downloads still work as one
would expect by delivering a single large file. This ensures that
we are able to upload large files (such as VM images) and consume
them.

[1] https://support.rackspace.com/how-to/cloud-files-uploading-large-files/

Issue: [RE-1561](https://rpc-openstack.atlassian.net/browse/RE-1561)