### PR TITLE
Resolve artifact upload error when no dest is specified

### DIFF
--- a/playbooks/tasks/artifact_upload/upload_file.yml
+++ b/playbooks/tasks/artifact_upload/upload_file.yml
@@ -46,18 +46,26 @@
 
     - name: Create the destination path and move the source file(s) into it
       shell: |
-        mkdir -p {{ artifact['dest'] }}
-        mv {{ artifact['source'] | basename }} {{ artifact['dest'] }}/
+        mkdir -p {{ artifact['dest'] | dirname }}
+        mv -v {{ artifact['source'] | basename }} {{ artifact['dest'] }}
       args:
         warn: no
         executable: /bin/bash
         chdir: "{{ artifact['source'] | dirname }}"
+      register: _move_source_files
+      when:
+        - "artifact['dest'] is defined"
+
+    - name: Show the output of the artifact move
+      debug:
+        var: _move_source_files.stdout
       when:
         - "artifact['dest'] is defined"
 
     - name: Set the name of the file/folder to upload
       set_fact:
-        artifact_basename: "{{ (artifact['dest'] is defined) | ternary(artifact.get('dest').split('/')[0], artifact['source'] | basename) }}"
+        artifact_basename: >-
+          {{ (artifact['dest'] is defined) | ternary(artifact.get('dest') | regex_replace('^(\/?[^\/]*).*$', '\1'), artifact['source'] | basename) }}
 
     - name: Show the name of the file/folder to upload
       debug:

--- a/rpc_jobs/unit/artefact_publish.yml
+++ b/rpc_jobs/unit/artefact_publish.yml
@@ -26,7 +26,8 @@
             echo "<html>dstat report placeholder</html>" \
               > /var/log/dstat.html
             cp -vr /var/log artifacts
-            cp -r artifacts file_artifacts
+            cp -r artifacts file_artifacts_dest
+            cp -r artifacts file_artifacts_no_dest
           """
 
           // Set the RE_JOB_REPO_NAME (normally done by standard jobs)
@@ -37,8 +38,13 @@
             artifacts: [
               [
                 type: "file",
-                source: "${env.WORKSPACE}/file_artifacts",
-                dest: "${env.JOB_NAME}/${env.BUILD_NUMBER}/",
+                source: "${env.WORKSPACE}/file_artifacts_dest",
+                dest: "${env.JOB_NAME}/${env.BUILD_NUMBER}",
+                expire_after: 86400
+              ],
+              [
+                type: "file",
+                source: "${env.WORKSPACE}/file_artifacts_no_dest",
                 expire_after: 86400
               ]
             ]


### PR DESCRIPTION
When no destination is provided, the set_fact fails to resolve
because the split function is still evaluated by Ansible at run
time. In this patch we do the following:

1. We switch to using a regex_replace filter instead, which
   should only get evaluated if the dest is defined. The regex
   will result in '/foo/bar' or 'foo/bar' returning 'foo'.
2. We add the configuration to the unit test to verify that
   this works.
3. We resolve a bug where if the source was 'foo' and the dest
   was 'bar/baz', the resulting upload would go into 'bar/baz/foo'
   which is not what was intended. With the change in the task
   which handles the move of content, it will now go into the
   destination path 'bar/baz' as intended.


Issue: [RE-1901](https://rpc-openstack.atlassian.net/browse/RE-1901)