### PR TITLE
Ensure merge requirements met before gate/release

### DIFF
--- a/pipeline_steps/github.groovy
+++ b/pipeline_steps/github.groovy
@@ -133,4 +133,40 @@ def create_status(
 }
 
 
+/**
+ * Confirm state of pull request merge pre-conditions
+ */
+void is_pr_approved(List excluded_checks){
+  List org_repo = env.ghprbGhRepository.split("/")
+  String org = org_repo[0]
+  String repo = org_repo[1]
+  Integer pull_request_number = env.ghprbPullId as Integer
+
+  String is_approved_output
+  withCredentials([
+    string(
+      credentialsId: 'rpc-jenkins-svc-github-pat',
+      variable: 'pat'
+    )
+  ]){
+    String excluded_args = excluded_checks.collect() {"--excluded-check ${it}"}.join(" ")
+    is_approved_output = sh(
+      script: """#!/bin/bash -xe
+      cd $env.WORKSPACE
+      set +x; . .venv/bin/activate; set -x
+      python rpc-gating/scripts/ghutils.py\
+        --org '$org'\
+        --repo '$repo'\
+        --pat '$pat'\
+        is_pull_request_approved\
+        --pull-request-number '$pull_request_number'\
+        ${excluded_args}
+      """,
+      returnStdout: true,
+    )
+  }
+  print is_approved_output
+  return is_approved_output.split("\n")[-1].trim() == "Pull request meets approval requirements."
+}
+
 return this;

--- a/rpc_jobs/standard_job_gate.yml
+++ b/rpc_jobs/standard_job_gate.yml
@@ -26,6 +26,12 @@
 
       common.globalWraps(){{
           testWithAntecedents = "{test_with_antecedents}".toBoolean()
+          if (! github.is_pr_approved(["CIT/gate"])) {
+              throw new Exception(
+                  "Gate process cannot continue until the pull request is "
+                  + "approved by required reviewers and checks."
+              )
+          }
           gate.testPullRequest("{repo_name}", testWithAntecedents, "{status_context}")
       }} // globalWraps
 

--- a/rpc_jobs/standard_job_release.yml
+++ b/rpc_jobs/standard_job_release.yml
@@ -24,6 +24,12 @@
       common.globalWraps(){
         dir("${env.WORKSPACE}/releases") {
           common.clone_with_pr_refs()
+          if (! github.is_pr_approved(["CIT/release"])) {
+            throw new Exception(
+              "Release process cannot continue until the pull request is "
+              + "approved by required reviewers and checks."
+            )
+          }
           common.runReleasesPullRequestWorkflow("origin/master", "HEAD", "RE", "CIT/release")
         } // dir
       } // globalWraps

--- a/scripts/ghutils.py
+++ b/scripts/ghutils.py
@@ -3,14 +3,18 @@
 # This script contains github related utilties for Jenkins.
 
 
+from functools import partial
 import json
 import logging
 import re
+import sys
 from time import sleep
 
 import click
 import git
 import github3
+import jmespath
+import requests
 
 from notifications import try_context
 
@@ -51,7 +55,32 @@ def cli(ctxt, org, repo, pat, debug):
         raise ValueError("Failed to connect to repo {o}/{r}".format(
             o=org, r=repo
         ))
+
+    session = requests.Session()
+    adapter = requests.adapters.HTTPAdapter(max_retries=3)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    session.headers["Authorization"] = "bearer {token}".format(token=pat)
+    # This Accept header field allows use of functionality not currently part
+    # part of the official API - https://developer.github.com/v4/previews
+    session.headers["Accept"] = "application/vnd.github.luke-cage-preview+json"
+    repo_.v4_query = partial(
+        v4_query, partial(session.post, "https://api.github.com/graphql")
+    )
+
     ctxt.obj = repo_
+
+
+def v4_query(post, query, variables=None):
+    logger.debug(query)
+    logger.debug(variables)
+    resp = post(json={"query": query, "variables": variables})
+    logger.debug(resp)
+    resp.raise_for_status()
+
+    data = resp.json()
+    logger.debug(json.dumps(data, indent=4))
+    return data
 
 
 @cli.command()
@@ -466,6 +495,194 @@ def create_pr(repo, source_branch, target_branch, title, body):
     print("{org}/{repo}#{num}".format(org=repo.owner,
                                       repo=repo.name,
                                       num=pr.number))
+
+
+@cli.command()
+@click.option(
+    "--pull-request-number",
+    type=click.INT,
+    help="Pull request to update",
+    required=True,
+)
+@click.option(
+    "--excluded-check",
+    "excluded_checks",
+    help="Pull request check context to exclude from validation",
+    multiple=True,
+)
+def is_pull_request_approved(pull_request_number, excluded_checks):
+    """Report status of pull request approval by reviewers and tests."""
+    ctx_obj = click.get_current_context().obj
+    querier = ctx_obj.v4_query
+    org = ctx_obj.owner.login
+    repo = ctx_obj.name
+
+    is_approved = all(
+        (
+            _is_pull_request_reviewer_approved(
+                querier, org, repo, pull_request_number
+            ),
+            _is_pull_request_test_approved(
+                querier, org, repo, pull_request_number, excluded_checks
+            ),
+        )
+    )
+    if is_approved:
+        click.echo("Pull request meets approval requirements.")
+    else:
+        click.echo("Pull request fails approval requirements.")
+
+
+def _is_pull_request_reviewer_approved(querier, org, repo, pr_id):
+    """Confirm whether or not pull request has been approved by reviewers."""
+    query = """
+      query($org:String!, $repo:String!, $pullRequestID:Int!) {
+        repository(owner: $org, name: $repo) {
+          protectedBranches(first: 100) {
+            nodes {
+              name
+              requiredApprovingReviewCount
+            }
+          }
+          pullRequest(number: $pullRequestID) {
+            baseRefName
+            reviews(last: 100) {
+              nodes {
+                state
+                author {
+                  login
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+    variables = {
+      "pullRequestID": pr_id,
+      "org": org,
+      "repo": repo,
+    }
+
+    data = querier(query, variables)
+
+    base_ref_name = jmespath.search(
+        "data.repository.pullRequest.baseRefName",
+        data
+    )
+
+    required_approval_count = jmespath.search(
+        """
+            data
+            .repository
+            .protectedBranches
+            .nodes[?name == '{branch}']
+            |[0]
+            .requiredApprovingReviewCount
+        """.format(branch=base_ref_name),
+        data
+    )
+
+    review_history = jmespath.search(
+        """
+            data
+            .repository
+            .pullRequest
+            .reviews
+            .nodes[*]
+            .{approver: author.login, state: state}
+        """,
+        data
+    )
+    reviews = {r["approver"]: r["state"] for r in review_history}
+    approval_count = reviews.values().count("APPROVED")
+
+    if required_approval_count and approval_count < required_approval_count:
+        is_approved = False
+    else:
+        is_approved = True
+
+    return is_approved
+
+
+def _is_pull_request_test_approved(querier, org, repo, pr_id, excluded=None):
+    """Confirm whether or not pull request has passed required checks."""
+    if not excluded:
+        excluded = []
+    query = """
+      query($org:String!, $repo:String!, $pullRequestID:Int!) {
+        repository(owner: $org, name: $repo) {
+          protectedBranches(first: 100) {
+            nodes {
+              name
+              requiredStatusCheckContexts
+            }
+          }
+          pullRequest(number: $pullRequestID) {
+            baseRefName
+            commits(last: 1) {
+              nodes {
+                commit {
+                  status {
+                    contexts {
+                      context
+                      state
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+    variables = {
+      "pullRequestID": pr_id,
+      "org": org,
+      "repo": repo,
+    }
+
+    data = querier(query, variables)
+
+    base_ref_name = jmespath.search(
+        "data.repository.pullRequest.baseRefName",
+        data
+    )
+
+    required_checks = jmespath.search(
+        """
+            data
+            .repository
+            .protectedBranches
+            .nodes[?name == '{branch}']
+            | [0]
+            .requiredStatusCheckContexts
+        """.format(branch=base_ref_name),
+        data
+    )
+
+    check_statuses = jmespath.search(
+        """
+            data
+            .repository
+            .pullRequest
+            .commits
+            .nodes[0]
+            .commit
+            .status
+            .contexts[?contains(`{required}`, context) == `true`]
+        """.format(required=json.dumps(required_checks)),
+        data
+    )
+    if len(required_checks) != len(check_statuses):
+        is_required_success = False
+    else:
+        is_required_success = all(
+            c["state"] == "SUCCESS"
+            for c in check_statuses
+            if c["context"] not in excluded
+        )
+    return is_required_success
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change seeks to make gate and release trigger builds fail early if
GitHub branch protection requirements are not met. This helps to protect
against builds with side effects failing on merge. Specifically,
Component-Gate-Trigger_ and Component-Release-Trigger will now fail if
either the required number of approvals have not been given or the
required checks have not passed.

The new function `github.is_pr_approved` allows for GitHub checks to be
excluded from the test so that, for example, a build triggered by a
required GitHub check can make use of the function even though it will
not yet be registered as succeeding by GitHub.

JIRA: RE-1630

Issue: [RE-1630](https://rpc-openstack.atlassian.net/browse/RE-1630)