### PR TITLE
Ensure merge requirements met before gate/release

### DIFF
--- a/rpc_jobs/standard_job_gate.yml
+++ b/rpc_jobs/standard_job_gate.yml
@@ -26,6 +26,12 @@
 
       common.globalWraps(){{
           testWithAntecedents = "{test_with_antecedents}".toBoolean()
+          if (! github.is_pr_approved(["{status_context}"])) {{
+              throw new Exception(
+                  "Gate process cannot continue until the pull request is "
+                  + "approved by required reviewers and checks."
+              )
+          }}
           gate.testPullRequest("{repo_name}", testWithAntecedents, "{status_context}")
       }} // globalWraps
 

--- a/rpc_jobs/standard_job_release.yml
+++ b/rpc_jobs/standard_job_release.yml
@@ -24,6 +24,12 @@
       common.globalWraps(){
         dir("${env.WORKSPACE}/releases") {
           common.clone_with_pr_refs()
+          if (! github.is_pr_approved(["CIT/release"])) {
+            throw new Exception(
+              "Release process cannot continue until the pull request is "
+              + "approved by required reviewers and checks."
+            )
+          }
           common.runReleasesPullRequestWorkflow("origin/master", "HEAD", "RE", "CIT/release")
         } // dir
       } // globalWraps


### PR DESCRIPTION
This change seeks to make gate and release trigger builds fail early if
GitHub branch protection requirements are not met. This helps to protect
against builds with side effects failing on merge. Specifically,
Component-Gate-Trigger_ and Component-Release-Trigger will now fail if
either the required number of approvals have not been given or the
required checks have not passed.

The new function `github.is_pr_approved` allows for GitHub checks to be
excluded from the test so that, for example, a build triggered by a
required GitHub check can make use of the function even though it will
not yet be registered as succeeding by GitHub.

JIRA: RE-1630

Issue: [RE-1630](https://rpc-openstack.atlassian.net/browse/RE-1630)

Fails: https://rpc.jenkins.cit.rackspace.net/job/Component-Gate-Trigger_rpc-product-1/40
Succeeds: https://rpc.jenkins.cit.rackspace.net/job/Component-Gate-Trigger_rpc-product-1/39