### PR TITLE
enabling ansible lint checks for rpc-ceph

### DIFF
--- a/rpc_jobs/rpc_ceph.yml
+++ b/rpc_jobs/rpc_ceph.yml
@@ -173,3 +173,25 @@
           BRANCH: "master"
     jobs:
       - 'RE-Release-PR_{repo}-{BRANCH}'
+
+- project:
+    name: "rpc-ceph-pre-merge-lint"
+
+    repo_name: "rpc-ceph"
+    repo_url: "https://github.com/rcbops/rpc-ceph"
+
+    branches:
+      - "master"
+
+    image:
+      - container:
+          SLAVE_TYPE: "container"
+
+    scenario:
+      - "ansible_lint"
+
+    action:
+      - "test"
+
+    jobs:
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'


### PR DESCRIPTION
https://rpc-openstack.atlassian.net/browse/CEPHSTORA-373
Adding lint checks for rpc-ceph playbooks/*.y[a]ml files.
Will submit a separate PR for code changes in rpc-ceph repo.

Issue: [CEPHSTORA-373](https://rpc-openstack.atlassian.net/browse/CEPHSTORA-373)