### PR TITLE
Cryptography version update

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -12,7 +12,7 @@ cmd2==0.8.7
 configparser==3.5.0
 contextlib2==0.5.5
 croniter==0.3.20
-cryptography==1.8.1
+cryptography==2.3.1
 debtcollector==1.13.0
 decorator==4.3.0
 defusedxml==0.5.0

--- a/lint.sh
+++ b/lint.sh
@@ -18,6 +18,10 @@ install(){
     $python -m virtualenv ${venv}_${python}
   fi
   . ${venv}_${python}/bin/activate
+
+  # find homebrew libs on macOS
+  [[ "$OSTYPE" =~ "darwin" ]] && export CFLAGS="-I/usr/local/include -L/usr/local/lib"
+
   ${venv}_${python}/bin/${python} -m pip install -c constraints.txt -r test-requirements.txt  >/dev/null \
     || {
       echo "Failed to create venv for $python"


### PR DESCRIPTION
This commit bumps cryptography as there are problems with the wheels
for the version we were using previously.

It also adds OS detection to the lint script and sets appropriate
vars so that c libs from homebrew can be located when building
wheels. This shouldn't affect builds in CI (due to the conditional) but
will enable developers to build venvs (and run lint) on local
macOS environments.

Issue: [RE-1923](https://rpc-openstack.atlassian.net/browse/RE-1923)