### PR TITLE
RE-1599 Add dep update for dependents after release

### DIFF
--- a/constraints_rpc_component.txt
+++ b/constraints_rpc_component.txt
@@ -1,3 +1,3 @@
 GitPython==2.1.9
-git+https://github.com/rcbops/rpc_component@2e7841146634850fef02ba392f5e3910031a0d63#egg=rpc_component
+git+https://github.com/rcbops/rpc_component@1a3f0ddac31ff118f4aa2b1d3dd3081d4c353a10#egg=rpc_component
 schema==0.6.7


### PR DESCRIPTION
This change triggers any component that is dependent on a project to be
(dep) updated immediately after the project is released instead of
relying solely on a weekly dep update.  In this configuration, the third
party dependencies are not updated.  The dependent search is performed
via modifications also made in the component tool (rpc_component)

JIRA: RE-1599

Issue: [RE-1599](https://rpc-openstack.atlassian.net/browse/RE-1599)