### PR TITLE
Update trigger phrase for gate and release

### DIFF
--- a/rpc_jobs/pull_request_whisperer.yml
+++ b/rpc_jobs/pull_request_whisperer.yml
@@ -9,7 +9,7 @@
 
       Once all `check` jobs have passed and the pull request has received a
       sufficient number of reviews, the repository's `gate` jobs can be triggered by
-      adding a comment of `check_component_gate` to this pull request.
+      adding a comment of `:shipit:` to this pull request.
 
       When the `gate` jobs have completed successfully, this pull request will get
       merged automatically.

--- a/rpc_jobs/releases.yml
+++ b/rpc_jobs/releases.yml
@@ -36,7 +36,7 @@
 
             Once all `check` jobs have passed and the pull request has received a
             sufficient number of reviews, the repository's `release` jobs can be triggered by
-            adding a comment of `run_component_release` to this pull request.
+            adding a comment of `:shipit:` to this pull request.
 
             When the `release` jobs have completed successfully and the release itself has been
             completed, this pull request will get merged automatically.

--- a/rpc_jobs/standard_job_gate.yml
+++ b/rpc_jobs/standard_job_gate.yml
@@ -9,7 +9,7 @@
           org-list:
             - rcbops
           github-hooks: true
-          trigger-phrase: '(re)?check_component_gate'
+          trigger-phrase: ":shipit:"
           only-trigger-phrase: true
           auth-id: "github_account_rpc_jenkins_svc"
           status-context: "{status_context}"

--- a/rpc_jobs/standard_job_release.yml
+++ b/rpc_jobs/standard_job_release.yml
@@ -7,7 +7,7 @@
           org-list:
             - rcbops
           github-hooks: true
-          trigger-phrase: 'run_component_release'
+          trigger-phrase: ":shipit:"
           only-trigger-phrase: true
           auth-id: "github_account_rpc_jenkins_svc"
           status-context: 'CIT/release'


### PR DESCRIPTION
This change standardises the trigger phrase for the gate and release
process. :shipit: as a phrase is shorter and hopefully easier to
remember and also corresponds to an emoji that is commonly used on
GitHub to indicate approval of a change. By having one common phrase,
this should also reduce the impact of its use on developers.

JIRA: RE-1568

Issue: [RE-1568](https://rpc-openstack.atlassian.net/browse/RE-1568)