### PR TITLE
Disable whisperer comment on rpc-gating

### DIFF
--- a/rpc_jobs/rpc_gating.yml
+++ b/rpc_jobs/rpc_gating.yml
@@ -49,5 +49,6 @@
       - rpc_gating:
           repo_url: "https://github.com/rcbops/rpc-gating"
           run_issue_linker: true
+          run_commenter: false
     jobs:
       - 'Pull-Request-Whisperer_{repo}'


### PR DESCRIPTION
rpc-gating does not currently make use of the component mechanisms,
disabling the comment prevents confusion given the suggested actions are
not available on the repository.

JIRA: RE-1624

Issue: [RE-1624](https://rpc-openstack.atlassian.net/browse/RE-1624)