### PR TITLE
Ensure release page month is padded with a 0

### DIFF
--- a/scripts/confluenceutils.py
+++ b/scripts/confluenceutils.py
@@ -184,7 +184,7 @@ def _publish_release_to_wiki(
     component, version, release_notes_url, comment,
 ):
     current_date = datetime.date.today()
-    meta_release = "{year}.{month}".format(
+    meta_release = "{year}.{month:02d}".format(
         year=current_date.year, month=current_date.month
     )
     space_key = "RE"


### PR DESCRIPTION
When confluenceutils.py is creating or updating a release page, it
should create the month as a double digit, with a leading 0, if the
month is only a single figure. So we would get a release of 2018.09
instead of 2018.9

Issue: RE-1942

Issue: [RE-1942](https://rpc-openstack.atlassian.net/browse/RE-1942)