### PR TITLE
Skip failure to add issue link to pull request

### DIFF
--- a/rpc_jobs/pull_request_whisperer.yml
+++ b/rpc_jobs/pull_request_whisperer.yml
@@ -43,7 +43,11 @@
         Boolean run_commenter = "{run_commenter}".toBoolean()
 
         if (run_issue_linker) {{
-          github.add_issue_url_to_pr()
+          try {{
+              github.add_issue_url_to_pr()
+          }} catch (e) {{
+            print "Failure adding an issue link to the pull request: ${{e}}"
+          }}
         }}
         if (run_commenter) {{
           github.add_comment_to_pr(env.COMMENT_BODY)


### PR DESCRIPTION
Adding the issue link is useful but not required, this change prevents
the build from failing because the user did not add an issue reference
to their commits.

JIRA: RE-1944

Issue: [RE-1944](https://rpc-openstack.atlassian.net/browse/RE-1944)