### PR TITLE
Add note clarifying that CIT/Release is not a check job

### DIFF
--- a/rpc_jobs/pull_request_whisperer.yml
+++ b/rpc_jobs/pull_request_whisperer.yml
@@ -11,6 +11,9 @@
       sufficient number of reviews, the repository's `gate` jobs can be triggered by
       adding a comment of `:shipit:` to this pull request.
 
+      Note that the `CIT/Release` job is not a check job, so it will stay in `Expected`
+      state until the release job is started with the `:shipit:` comment. 
+
       When the `gate` jobs have completed successfully, this pull request will get
       merged automatically.
     triggers:


### PR DESCRIPTION
Add a note to the whisperer comment to make it clear that CIT/Release is not a check job, so it doesn't need to be complete before posting `:shipit`.