### PR TITLE
Added in a gating test of building the release notes

### DIFF
--- a/rpc_jobs/rpc_ceph.yml
+++ b/rpc_jobs/rpc_ceph.yml
@@ -207,3 +207,24 @@
     jobs:
       - 'Pull-Request-Whisperer_{repo}'
 
+- project:
+    name: "rpc-ceph-pre-merge-releasenotes"
+
+    repo_name: "rpc-ceph"
+    repo_url: "https://github.com/rcbops/rpc-ceph"
+
+    branches:
+      - "master"
+
+    image:
+      - container:
+          SLAVE_TYPE: "container"
+
+    scenario:
+      - "build_releasenotes"
+
+    action:
+      - "test"
+
+    jobs:
+      - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'


### PR DESCRIPTION
The job scenario "build_releasenotes" is run.  This does not install
Ceph or do anything other than try and build the release notes.