### PR TITLE
Enable releasing with failed tests

### DIFF
--- a/rpc_jobs/releases.yml
+++ b/rpc_jobs/releases.yml
@@ -38,6 +38,10 @@
             sufficient number of reviews, the repository's `release` jobs can be triggered by
             adding a comment of `:shipit:` to this pull request.
 
+            If the requested release has one or more failing tests and there are valid reasons
+            to ignore the failure, a release can be forced through by triggering the process
+            a with comment of `:shipit: skip validation`.
+
             When the `release` jobs have completed successfully and the release itself has been
             completed, this pull request will get merged automatically.
     jobs:

--- a/rpc_jobs/standard_job_release.yml
+++ b/rpc_jobs/standard_job_release.yml
@@ -7,7 +7,7 @@
           org-list:
             - rcbops
           github-hooks: true
-          trigger-phrase: ":shipit:"
+          trigger-phrase: ":shipit:|:shipit: skip validation"
           only-trigger-phrase: true
           auth-id: "github_account_rpc_jenkins_svc"
           status-context: 'CIT/release'
@@ -30,7 +30,7 @@
               + "approved by required reviewers and checks."
             )
           }
-          common.runReleasesPullRequestWorkflow("origin/master", "HEAD", "RE", "CIT/release")
+          common.runReleasesPullRequestWorkflow("origin/master", "HEAD", "RE", "CIT/release", ":shipit: skip validation")
         } // dir
       } // globalWraps
 


### PR DESCRIPTION
Sometimes projects choose to release with failed tests. While this is
not ideal, to cater for this requirement, this pull request adds the
ability to skip code validation. Normally what happens is that if a
project has tests that have not been performed for the specified hash,
the release process will look to run those tests to ensure the code
works. With this change the status of any existing builds are ignored
and no new builds are started. All tests are skipped and the rest of the
release is completed as if the code was validated.

To skip validation a release should be triggered with the phrase
`:shipit: skip validation`.

JIRA: RE-1948

Issue: [RE-1948](https://rpc-openstack.atlassian.net/browse/RE-1948)

Tested with and without skipping:
https://github.com/rcbops/releases/pull/71
https://rpc.jenkins.cit.rackspace.net/job/Component-Release-Trigger-gh/1/console
https://rpc.jenkins.cit.rackspace.net/job/Component-Release-Trigger-gh/2/console