### PR TITLE
RE-1906 Bump flask version

### DIFF
--- a/webhooktranslator/setup.py
+++ b/webhooktranslator/setup.py
@@ -10,7 +10,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'jira==1.0.10',
-        'flask==0.12.2',
+        'flask==0.12.3',
         'flup==1.0.2'
     ],
     entry_points={


### PR DESCRIPTION
The version of flask used in webhooktranslator is vulnerable
to a denial of service attack (CVE-2018-1000656).

This commit bumps flask to the oldest non-vulnerable version.

Issue: [RE-1906](https://rpc-openstack.atlassian.net/browse/RE-1906)