### PR TITLE
Update releases jobs to give clearer information

### DIFF
--- a/rpc_jobs/releases.yml
+++ b/rpc_jobs/releases.yml
@@ -18,7 +18,7 @@
       - 'test'
 
     jira_project_key: 'RE'
-
+    status_context_prefix: "check"
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
 
@@ -32,17 +32,19 @@
           repo_url: "https://github.com/rcbops/releases"
           run_issue_linker: true
           comment_body: |
-            Thank you for pull request to `rcbops/releases`!
+            Thank you for your pull request to `rcbops/releases`!
 
-            Once all `check` jobs have passed and the pull request has received a
-            sufficient number of reviews, the repository's `release` jobs can be triggered by
-            adding a comment of `:shipit:` to this pull request.
+            Once all required `check` jobs, prefixed with `check/`, have passed and the pull
+            request has received a sufficient number of reviews, the repository's `release` job
+            can be triggered by adding a comment of `:shipit:` to this pull request.
 
-            If the requested release has one or more failing tests and there are valid reasons
-            to ignore the failure, a release can be forced through by triggering the process
-            a with comment of `:shipit: skip validation`.
+            If the requested release has one or more failing project tests and there are valid
+            reasons to ignore the failure(s), a release can be forced through by triggering the
+            process with a comment of `:shipit: skip validation`. This option should only be used
+            in exceptional circumstances. The first course of action should always be to fix the
+            failing job(s).
 
-            When the `release` jobs have completed successfully and the release itself has been
-            completed, this pull request will get merged automatically.
+            When the `release` job has completed successfully the release will have been created
+            and this pull request will get merged automatically.
     jobs:
       - 'Pull-Request-Whisperer_{repo}'

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -28,6 +28,7 @@
     TRIGGER_PR_PHRASE_ONLY: false
     BOOT_TIMEOUT: 900
     skip_pattern: ""
+    status_context_prefix: "CIT"
     properties:
       - build-discarder:
           num-to-keep: "30"
@@ -72,7 +73,7 @@
           only-trigger-phrase: "{obj:TRIGGER_PR_PHRASE_ONLY}"
           white-list-target-branches: "{branches}"
           auth-id: "github_account_rpc_jenkins_svc"
-          status-context: 'CIT/{image}_{scenario}_{action}'
+          status-context: '{status_context_prefix}/{image}_{scenario}_{action}'
           failure-status: 'To recheck, add comment with "recheck_{image}_{scenario}_{action}"'
           cancel-builds-on-update: true
 

--- a/rpc_jobs/standard_job_release.yml
+++ b/rpc_jobs/standard_job_release.yml
@@ -10,7 +10,7 @@
           trigger-phrase: ":shipit:|:shipit: skip validation"
           only-trigger-phrase: true
           auth-id: "github_account_rpc_jenkins_svc"
-          status-context: 'CIT/release'
+          status-context: 'release'
           cancel-builds-on-update: true
     properties:
       - github:


### PR DESCRIPTION
To improve the clarity of the information provided by whisperer in
rcbops/releases this change:
- updates the status context prefix used by the check job to be prefixed
  with `check` to make it easier to reference by whisperer
- removes the use of CIT from the status context for the release job
- modifies the whisperer comment body to better explain and reference
  the check and release jobs.

JIRA RE-1945

Issue: [RE-1945](https://rpc-openstack.atlassian.net/browse/RE-1945)