### PR TITLE
Add component metadata file validation

### DIFF
--- a/Dockerfile.standard_job
+++ b/Dockerfile.standard_job
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=ubuntu:16.04
 FROM ${BASE_IMAGE}
-RUN apt-get update && apt-get install -y groovy2 python-pip build-essential python-dev libssl-dev curl libffi-dev sudo git-core libxml2-utils
+RUN apt-get update && apt-get install -y groovy2 python-pip build-essential python-dev libssl-dev curl libffi-dev sudo git-core libxml2-utils python3
 COPY requirements.txt /requirements.txt
 COPY test-requirements.txt /test-requirements.txt
 COPY constraints.txt /constraints.txt

--- a/rpc_jobs/standard_job_premerge_release.yml
+++ b/rpc_jobs/standard_job_premerge_release.yml
@@ -16,6 +16,9 @@
           num-to-keep: 10
       - github:
           url: "{URL}"
+      - inject:
+          properties-content: |
+            RE_JOB_REPO_NAME={repo}
     triggers:
       - github-pull-request:
           org-list:


### PR DESCRIPTION
component_metadata.yml can include information related to dependencies
and artefacts. To ensure this file is valid this change updates the
release pre-merge job, which is automatically added to new components,
to also test component metadata to ensure it is always in a valid
format.

The Docker file updated is used by the release job, python3 is installed
to support the component CLI tool.

[Success](https://rpc.jenkins.cit.rackspace.net/job/RE-Release-PR_rpc-product-1-master/2/console)
[Failure](https://rpc.jenkins.cit.rackspace.net/job/RE-Release-PR_rpc-product-1-master/6/console)

JIRA: RE-1811

Issue: [RE-1811](https://rpc-openstack.atlassian.net/browse/RE-1811)