### PR TITLE
RE-1494 Fix recordAbortDueToMaintenance

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1406,7 +1406,7 @@ void globalWraps(Closure body){
           // This test must be outside a function so that return can be used to abort the job
           // Alternatively we could throw a custom exception and abort when catching it here.
           if (issueExistsForNextMaintenanceWindow() && willOverlapMaintenanceWindow()){
-            common.recordAbortDueToMaintenance()
+            recordAbortDueToMaintenance()
             currentBuild.result == "ABORTED"
             return
           }


### PR DESCRIPTION
The prefix common. should not be used to call common functions from within
common.

Issue: [RE-1494](https://rpc-openstack.atlassian.net/browse/RE-1494)