### PR TITLE
RE-1976 Fix dual schedules

### DIFF
--- a/rpc_jobs/build_summary.yml
+++ b/rpc_jobs/build_summary.yml
@@ -49,8 +49,9 @@
             Hours. Instances older than this will be removed.
       - rpc_gating_params
     triggers:
-      - timed: "H * * * 2-7"
-      - timed: "H 13-23 * * 1"
+      - timed: |
+          H * * * 2-7
+          H 13-23 * * 1
     properties:
       - build-discarder:
           days-to-keep: 3

--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -19,8 +19,9 @@
             Only instances in the specified region will be cleaned up.
       - rpc_gating_params
     triggers:
-      - timed: "H * * * 2-7"
-      - timed: "H 13-23 * * 1"
+      - timed: |
+          H * * * 2-7
+          H 13-23 * * 1
     properties:
       - build-discarder:
           days-to-keep: 3

--- a/scripts/extract_dsl.py
+++ b/scripts/extract_dsl.py
@@ -29,7 +29,6 @@ def extract_dsl(jjbfile, outdir):
                 item=item[key]['name'])
             with open(outfile, "w") as outf:
                 outf.write(dsl)
-            print("Written {outfile}".format(outfile=outfile))
 
 
 if __name__ == "__main__":

--- a/scripts/lint_jjb.py
+++ b/scripts/lint_jjb.py
@@ -400,12 +400,17 @@ def check_timed_trigger(data, in_file):
         "timed_triggers": "triggers[*].timed"
     }
 
+    # Each jmes expression can return one of more schedules
+    # Each schedule can be single or multi-line string.
     schedules = []
     for jmes_expression in jmes_expressions.values():
-        result = jmespath.search(jmes_expression, data) or []
-        if not isinstance(result, list):
-            result = [result]
-        schedules += [r for r in result if r not in ["{CRON}", ""]]
+        results = jmespath.search(jmes_expression, data) or []
+        if not isinstance(results, list):
+            results = [results]
+        for result in results:
+            for line in result.split("\n"):
+                if line not in ["{CRON}", ""]:
+                    schedules.append(line)
 
     for schedule in schedules:
         failures += check_timed_trigger_value(schedule, data)


### PR DESCRIPTION
Two timer triggers were added to some jobs in order to avoid
the maintenance window. However only one makes it into the
Jenkins configuration. This commit switches from two timer
triggers to a single timer trigger that contains two cron
expressions.

Issue: [RE-1976](https://rpc-openstack.atlassian.net/browse/RE-1976)