### PR TITLE
Add RPCO snapshot support to Nodepool

### DIFF
--- a/nodepool/files/nodepool.yml
+++ b/nodepool/files/nodepool.yml
@@ -24,6 +24,17 @@ labels:
     min-ready: 0
     max-ready-age: 3600
 
+  # rpco snapshots
+  - name: rpc-r14-xenial_loose_artifacts-swift
+    min-ready: 5
+    max-ready-age: 86400
+  - name: rpc-r16-xenial_no_artifacts-swift
+    min-ready: 5
+    max-ready-age: 86400
+  - name: rpc-r17-xenial_no_artifacts-swift
+    min-ready: 5
+    max-ready-age: 86400
+
   #g1-8
   - name: ubuntu-bionic-g1-8
     min-ready: 3
@@ -174,9 +185,23 @@ providers:
   - name: pubcloud-dfw
     region-name: 'DFW'
     cloud: public_cloud
-    boot-timeout: 600
+    # Higher boot-timeout value that for other providers to support snapshots
+    boot-timeout: 1800
     hostname-format: nodepool-{label.name}-{provider.name}-{node.id}
-    cloud-images: *provider_cloudimage_block
+    cloud-images:
+      - name: ubuntu-bionic-onmetal
+        image-name: "OnMetal - Ubuntu 18.04 LTS (Bionic Beaver)"
+      - name: ubuntu-xenial-onmetal
+        image-name: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+      - name: rpc-r14-xenial_loose_artifacts-swift-image
+        image-name: rpc-r14.17.0-xenial_loose_artifacts-swift
+        config-drive: true
+      - name: rpc-r16-xenial_no_artifacts-swift-image
+        image-name: rpc-r16.2.4-xenial_no_artifacts-swift
+        config-drive: true
+      - name: rpc-r17-xenial_no_artifacts-swift-image
+        image-name: rpc-r17.1.0-xenial_no_artifacts-swift
+        config-drive: true
     image-name-format: nodepool-{image_name}-{timestamp}
     diskimages: *provider_diskimage_block
     pools:
@@ -192,6 +217,27 @@ providers:
         max-servers: 10
         availability-zones: []
         labels: *provider_pools_onmetal_labels_block
+      - name: snapshots
+        # Ignore the quota given by public cloud and only respect what we provide as max-servers
+        ignore-provider-quota: true
+        max-servers: 25
+        availability-zones: []
+        labels:
+          - name: rpc-r14-xenial_loose_artifacts-swift
+            cloud-image: rpc-r14-xenial_loose_artifacts-swift-image
+            flavor-name: "15GB Standard Instance"
+            key-name: jenkins
+            console-log: true
+          - name: rpc-r16-xenial_no_artifacts-swift
+            cloud-image: rpc-r16-xenial_no_artifacts-swift-image-image
+            flavor-name: "15GB Standard Instance"
+            key-name: jenkins
+            console-log: true
+          - name: rpc-r17-xenial_no_artifacts-swift
+            cloud-image: rpc-r17-xenial_no_artifacts-swift-image
+            flavor-name: "15GB Standard Instance"
+            key-name: jenkins
+            console-log: true
 
   - name: pubcloud-ord
     region-name: 'ORD'

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1465,6 +1465,7 @@ void stdJob(String hook_dir, String credentials, String jira_project_key, String
 
         currentBuild.result="SUCCESS"
 
+        runThawIfSnapshot()
         try {
           withRequestedCredentials(credentials) {
 
@@ -2240,4 +2241,21 @@ void restartAbortedPRBuilds(String maint_date="today"){
     github.add_comment_to_pr("recheck_all", true, pr_data['repo'], pr_data['prnum'])
   }
 
+}
+
+/**
+ * Run snapshot thaw file if it exists.
+ */
+void runThawIfSnapshot(){
+  String thawFileName = "/gating/thaw/run"
+  def thawFile = new File(thawFileName)
+  if (thawFile.exists()){
+    stage('Execute snapshot thaw'){
+      sh """#!/bin/bash -xeu
+            ${thawFileName}
+      """
+    }
+  } else{
+    println "No thaw file detected."
+  }
 }

--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -237,18 +237,3 @@
           until: _install_packages | success
           retries: 3
           delay: 15
-
-- hosts: singleuseslave
-  tasks:
-    - name: Check for thaw hook
-      stat:
-        path: /gating/thaw/run
-      register: thaw
-
-    - name: Execute thaw hook
-      shell: |
-        set -xeu
-        /gating/thaw/run
-      args:
-        executable: /bin/bash
-      when: thaw.stat.exists|bool

--- a/rpc_jobs/bump_snapshots.yml
+++ b/rpc_jobs/bump_snapshots.yml
@@ -112,6 +112,7 @@
             if (release['result'] == "SUCCESS") {
               sh """#!/bin/bash -xe
                 sed -i "s/rpc-${release['previous']}-${release['image']}/rpc-${release['latest']}-${release['image']}/g" rpc_jobs/*.yml
+                sed -i "s/rpc-${release['previous']}-${release['image']}/rpc-${release['latest']}-${release['image']}/g" nodepool/files/nodepool.yml
               """
             }
           } // for


### PR DESCRIPTION
nodepool.yml is updated to support three new types of node. Replicating
how the snapshots are currently used, each node type is flavour 7. The
nodes are labelled based on the major series to which they belong and
not the specific version, this simplifies the management of the
configuration but does mean if a project requires use of a specific
version it will need to be done manually.

bump_snapshots.yml has been updated so that Nodepool is automatically
updated when new snapshots become available.

JIRA: RE-1465

Issue: [RE-1465](https://rpc-openstack.atlassian.net/browse/RE-1465)