### PR TITLE
Switch rpc-appformix repo URL to use git@

### DIFF
--- a/rpc_jobs/rpc_appformix.yml
+++ b/rpc_jobs/rpc_appformix.yml
@@ -3,7 +3,7 @@
 
     repo_name: "rpc-appformix"
     # URL of the rpc-appformix repository
-    repo_url: "https://github.com/rcbops/rpc-appformix"
+    repo_url: "git@github.com:rcbops/rpc-appformix"
 
     branches:
       - "master"
@@ -39,7 +39,7 @@
 
     repo_name: "rpc-appformix"
     # URL of the rpc-appformix repository
-    repo_url: "https://github.com/rcbops/rpc-appformix"
+    repo_url: "git@github.com:rcbops/rpc-appformix"
 
     branches:
       - "master"
@@ -65,7 +65,7 @@
 
     repo_name: "rpc-appformix"
     # URL of the rpc-designate repository
-    repo_url: "https://github.com/rcbops/rpc-appformix"
+    repo_url: "git@github.com:rcbops/rpc-appformix"
 
     # Use image for RPC-O install
     image:


### PR DESCRIPTION
The repo is private, so to allow jenkins to authenticate via
its key we need to use the URL git@github.com:rcbops/rpc-appformix
instead.

Issue: [RE-1985](https://rpc-openstack.atlassian.net/browse/RE-1985)