### PR TITLE
Correct Appformix action axis name

### DIFF
--- a/rpc_jobs/rpc_appformix.yml
+++ b/rpc_jobs/rpc_appformix.yml
@@ -83,7 +83,7 @@
       - queens:
           IMAGE: "rpc-r17.1.0-xenial_no_artifacts-swift"
     action:
-      - "deploy"
+      - "functional"
 
     jira_project_key: "RI"
 


### PR DESCRIPTION
The Appformix PM jobs are failing because the name of
the axis is incorrect. It is 'deploy' instead of
'functional', and there is no tox env for 'deploy'.

Issue: [RE-1985](https://rpc-openstack.atlassian.net/browse/RE-1985)