### PR TITLE
Reset python in rpc-gating venv at run time

### DIFF
--- a/Dockerfile.standard_job
+++ b/Dockerfile.standard_job
@@ -1,10 +1,16 @@
 ARG BASE_IMAGE=ubuntu:16.04
 FROM ${BASE_IMAGE}
-RUN apt-get update && apt-get install -y groovy2 python-pip build-essential python-dev libssl-dev curl libffi-dev sudo git-core libxml2-utils python3
-COPY requirements.txt /requirements.txt
-COPY test-requirements.txt /test-requirements.txt
-COPY constraints.txt /constraints.txt
-RUN pip install -c /constraints.txt -r /requirements.txt
-RUN pip install -c /constraints.txt -r /test-requirements.txt
-RUN useradd jenkins --shell /bin/bash --create-home --uid 500
-RUN echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+COPY scripts/reconfigure_apt_sources.sh /reconfigure_apt_sources.sh
+RUN chmod +x /reconfigure_apt_sources.sh
+RUN /reconfigure_apt_sources.sh
+# Packages required:
+#   bzip2: for log artifact compression
+#   curl: for downloading the rpc-gating venv
+#   git-core: for git cloning
+#   libxml2-utils: for lint checking junit xml results before uploading them
+#   openssh-client: for running ssh-keyscan against the repo
+#   python-minimal: for replacing the python in the rpc-gating venv
+#   python-virtualenv: required in order to prepare the rpc-gating virtualenv
+#   python-yaml: required by ansible when running rpc-gating playbooks
+#   virtualenv: required in order to prepare the rpc-gating virtualenv
+RUN apt-get update && apt-get install -y bzip2 curl git-core libxml2-utils openssh-client python-minimal python-virtualenv python-yaml virtualenv

--- a/rpc_jobs/unit/artefact_publish.yml
+++ b/rpc_jobs/unit/artefact_publish.yml
@@ -7,11 +7,22 @@
           num-to-keep: 30
     parameters:
       - rpc_gating_params
+      - standard_job_params:
+          SLAVE_TYPE: "container"
+          SLAVE_CONTAINER_DOCKERFILE_REPO: "RE"
+          SLAVE_CONTAINER_DOCKERFILE_PATH: "./Dockerfile.standard_job"
+          SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS: "BASE_IMAGE=ubuntu:16.04"
+          hold_on_error: "0"
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
       common.globalWraps(){
-        // Do something that creates an artifact
-        stage("Build"){
+        // NOTE(mattt): These vars are required in common.standard_job_slave()
+        // when this job is testing a custom dockerfile.
+        env.REPO_URL = "https://github.com/rcbops/rpc-gating"
+        env.BRANCH = "${RPC_GATING_BRANCH}"
+        env.RE_JOB_REPO_NAME = "rpc-gating"
+
+        common.standard_job_slave(env.SLAVE_TYPE){
           // ARA placeholder included to test that an ARA
           // link is added to the sidebar of the index page
           // when an ARA report is present.
@@ -30,9 +41,6 @@
             cp -r artifacts file_artifacts_no_dest
           """
 
-          // Set the RE_JOB_REPO_NAME (normally done by standard jobs)
-          env.RE_JOB_REPO_NAME = "rpc-gating"
-
           // Create a temporary component_metadata file
           def artifacts_data = [
             artifacts: [
@@ -50,6 +58,6 @@
             ]
           ]
           writeYaml file: "${env.WORKSPACE}/${env.RE_JOB_REPO_NAME}/component_metadata.yml", data: artifacts_data
-        }
+        } // standard_job_slave
         common.archive_artifacts(artifact_types: "all")
-      }
+      } // globalWraps

--- a/rpc_jobs/unit/re_unit_tests.yml
+++ b/rpc_jobs/unit/re_unit_tests.yml
@@ -55,7 +55,7 @@
             ]
           )
         },
-        "Artefact Publication": {
+        "Artefact Publication (Ubuntu Bionic Container)": {
           build(
             job: "RE-unit-test-artefact-publication",
             wait: true,
@@ -64,6 +64,103 @@
                 $class: 'StringParameterValue',
                 name: 'RPC_GATING_BRANCH',
                 value: env.RPC_GATING_BRANCH
+              ],
+              [
+                $class: 'StringParameterValue',
+                name: 'SLAVE_TYPE',
+                value: 'container'
+              ],
+              [
+                $class: 'StringParameterValue',
+                name: 'SLAVE_CONTAINER_DOCKERFILE_PATH',
+                value: './Dockerfile.standard_job'
+              ],
+              [
+                $class: 'StringParameterValue',
+                name: 'SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS',
+                value: 'BASE_IMAGE=ubuntu:18.04'
+              ]
+            ]
+          )
+        },
+        "Artefact Publication (Ubuntu Xenial Container)": {
+          build(
+            job: "RE-unit-test-artefact-publication",
+            wait: true,
+            parameters: [
+              [
+                $class: 'StringParameterValue',
+                name: 'RPC_GATING_BRANCH',
+                value: env.RPC_GATING_BRANCH
+              ],
+              [
+                $class: 'StringParameterValue',
+                name: 'SLAVE_TYPE',
+                value: 'container'
+              ],
+              [
+                $class: 'StringParameterValue',
+                name: 'SLAVE_CONTAINER_DOCKERFILE_PATH',
+                value: './Dockerfile.standard_job'
+              ],
+              [
+                $class: 'StringParameterValue',
+                name: 'SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS',
+                value: 'BASE_IMAGE=ubuntu:16.04'
+              ]
+            ]
+          )
+        },
+        "Artefact Publication (Ubuntu Bionic Nodepool)": {
+          build(
+            job: "RE-unit-test-artefact-publication",
+            wait: true,
+            parameters: [
+              [
+                $class: 'StringParameterValue',
+                name: 'RPC_GATING_BRANCH',
+                value: env.RPC_GATING_BRANCH
+              ],
+              [
+                $class: 'StringParameterValue',
+                name: 'SLAVE_TYPE',
+                value: 'nodepool-ubuntu-bionic-g1-8'
+              ]
+            ]
+          )
+        },
+        "Artefact Publication (Ubuntu Xenial Nodepool)": {
+          build(
+            job: "RE-unit-test-artefact-publication",
+            wait: true,
+            parameters: [
+              [
+                $class: 'StringParameterValue',
+                name: 'RPC_GATING_BRANCH',
+                value: env.RPC_GATING_BRANCH
+              ],
+              [
+                $class: 'StringParameterValue',
+                name: 'SLAVE_TYPE',
+                value: 'nodepool-ubuntu-xenial-g1-8'
+              ]
+            ]
+          )
+        },
+        "nodepool-ubuntu-bionic-g1-8 Instance": {
+          build(
+            job: "RE-unit-test-slave-types",
+            wait: true,
+            parameters: [
+              [
+                $class: 'StringParameterValue',
+                name: 'RPC_GATING_BRANCH',
+                value: env.RPC_GATING_BRANCH
+              ],
+              [
+                $class: 'StringParameterValue',
+                name: 'SLAVE_TYPE',
+                value: 'nodepool-ubuntu-bionic-g1-8'
               ]
             ]
           )
@@ -158,7 +255,7 @@
               [
                 $class: 'StringParameterValue',
                 name: 'SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS',
-                value: 'BASE_IMAGE=ubuntu:17.10'
+                value: 'BASE_IMAGE=ubuntu:16.04'
               ]
             ]
           )

--- a/rpc_jobs/unit/single_use_slave.yml
+++ b/rpc_jobs/unit/single_use_slave.yml
@@ -68,14 +68,28 @@
             if (env.SLAVE_TYPE == "container" && env.SLAVE_CONTAINER_DOCKERFILE_REPO == "RE") {
               if (env.SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS == "BASE_IMAGE=ubuntu:16.04") {
                 assert distro == "16.04"
-              } else if (env.SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS == "BASE_IMAGE=ubuntu:17.10") {
-                assert distro == "17.10"
               } else {
-                throw new Exception("Unexpected env.SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS passed into test")
+                String exceptionString = """
+                  Expected env.SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS of 'BASE_IMAGE=ubuntu:16.04'
+                  but got '${env.SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS}' instead.
+                """
+                throw new Exception(exceptionString)
               }
             } else {
               print 'Skipped as env.SLAVE_TYPE != "container" or env.SLAVE_CONTAINER_DOCKERFILE_REPO != "RE"'
             } // if
+          } // stage
+
+          stage("Ensure that venv is working correctly") {
+            sh """#!/bin/bash -x
+              set +x; . ${env.WORKSPACE}/.venv/bin/activate; set -x
+              if ${env.WORKSPACE}/rpc-gating/scripts/jirautils.py --help; then
+                echo -e "\n### rpc-gating venv is working ###\n"
+              else
+                echo -e "\n### rpc-gating venv is broken ###\n"
+                exit 1
+              fi
+            """
           } // stage
         } // standard_job_slave
       } // globalWraps


### PR DESCRIPTION
After extracting the venv on a target host, the python version
on the host may be different enough to cause the scripts used
in the venv to fail. This patch ensures that the python version
in the venv is replaced with whatever is on the host at runtime.

Resetting python in the venv cannot be done by simply doing a
python binary copy - it results in a broken venv which is missing
some of the standard libraries. Due to that, we need to use the
'virtualenv' tool for the reset. Given the range of options
available over time, we have to do a fair amount of logic to
figure out the options available to use.

To help prove that this works, unit tests are added for the
following:

1. Get a nodepool bionic node.
2. Publish artifacts using a xenial container (instead of using
   the long-lived slave), and a xenial nodepool node.
3. Publish artifacts using a bionic container, and a bionic
   nodepool node.
4. Verify that at least one script is working using the venv when
   building any single-use slaves (container, nodepool, and
   jenkins-built).

The current standard job Dockerfile installs a lot of content into
it, so the environment is not pristine. The package 'groovy2' is
also not available in Ubuntu Bionic. As part of this patch, we
reduce what the Dockerfile installs to a minimal set to support
running tests and executing the rpc-gating artifact uploading.

Note that the use of the rpc-gating scripts in a container is not
guaranteed to work. The artifact uploads work, but the jira-utils
script does not. The issue is that the venv python replacement is
done on the long-running-slave (Xenial), but then trying to use it
in the Bionic (or other) platform in the container fails because
the standard libraries aren't right for that distro. As such, I've
switched the Container Custom Args test to just use Xenial.

Issue: [RE-1977](https://rpc-openstack.atlassian.net/browse/RE-1977)