### PR TITLE
Add the whisperer job to rpc-appformix

### DIFF
--- a/rpc_jobs/rpc_appformix.yml
+++ b/rpc_jobs/rpc_appformix.yml
@@ -90,3 +90,15 @@
     # Link to the standard post-merge-template
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+- project:
+    name: 'rpc-appformix-whisperer'
+    series:
+      - all_branches:
+          branches: '.*'
+    repo:
+      - rpc-appformix:
+          repo_url: 'git@github.com/rcbops/rpc-appformix'
+    jobs:
+      - 'Pull-Request-Whisperer_{repo}'
+


### PR DESCRIPTION
Without the whisperer, no PR's can be rechecked and none
of the helper comments are added to PR's.

Issue: [RE-1985](https://rpc-openstack.atlassian.net/browse/RE-1985)