### PR TITLE
RE-1965 Disable Maintenance aborts

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1409,11 +1409,11 @@ void globalWraps(Closure body){
           setTriggerVars()
           // This test must be outside a function so that return can be used to abort the job
           // Alternatively we could throw a custom exception and abort when catching it here.
-          if (issueExistsForNextMaintenanceWindow() && willOverlapMaintenanceWindow()){
-            recordAbortDueToMaintenance()
-            currentBuild.result == "ABORTED"
-            return
-          }
+          //if (issueExistsForNextMaintenanceWindow() && willOverlapMaintenanceWindow()){
+          //  recordAbortDueToMaintenance()
+          //  currentBuild.result == "ABORTED"
+          //  return
+          //}
           print("common.globalWraps pre body")
           body()
           print("common.globalWraps post body")


### PR DESCRIPTION
This process needs improvement and the abort line should
be removed so that jobs can continue. This will be reenabled
after making improvements such as allowing a maitnenance to
end early.

Issue: [RE-1965](https://rpc-openstack.atlassian.net/browse/RE-1965)