### PR TITLE
Include sudo/pip in container image

### DIFF
--- a/Dockerfile.standard_job
+++ b/Dockerfile.standard_job
@@ -10,7 +10,9 @@ RUN /reconfigure_apt_sources.sh
 #   libxml2-utils: for lint checking junit xml results before uploading them
 #   openssh-client: for running ssh-keyscan against the repo
 #   python-minimal: for replacing the python in the rpc-gating venv
+#   python-pip: used commonly by tests
 #   python-virtualenv: required in order to prepare the rpc-gating virtualenv
 #   python-yaml: required by ansible when running rpc-gating playbooks
+#   sudo: used commonly by tests
 #   virtualenv: required in order to prepare the rpc-gating virtualenv
-RUN apt-get update && apt-get install -y bzip2 curl git-core libxml2-utils openssh-client python-minimal python-virtualenv python-yaml virtualenv
+RUN apt-get update && apt-get install -y bzip2 curl git-core libxml2-utils openssh-client python-minimal python-pip python-virtualenv python-yaml sudo virtualenv


### PR DESCRIPTION
It seems that tests using the container image commonly use pip
and sudo, so we need to include it in the base dockerfile.

JIRA: RE-1977

Issue: [RE-1977](https://rpc-openstack.atlassian.net/browse/RE-1977)