### PR TITLE
Upgrade pip in the base container image

### DIFF
--- a/Dockerfile.standard_job
+++ b/Dockerfile.standard_job
@@ -16,3 +16,4 @@ RUN /reconfigure_apt_sources.sh
 #   sudo: used commonly by tests
 #   virtualenv: required in order to prepare the rpc-gating virtualenv
 RUN apt-get update && apt-get install -y bzip2 curl git-core libxml2-utils openssh-client python-minimal python-pip python-virtualenv python-yaml sudo virtualenv
+RUN pip install --upgrade pip


### PR DESCRIPTION
Some tests are using options that are only available in more
recent versions of pip than are available in the distro package.

Issue: [RE-1977](https://rpc-openstack.atlassian.net/browse/RE-1977)