### PR TITLE
RE-1980 Fix the Grafana time range issue

### DIFF
--- a/grafana/grafyaml/dashboard-nodepool.yaml
+++ b/grafana/grafyaml/dashboard-nodepool.yaml
@@ -199,6 +199,7 @@ dashboard:
           yaxes:
             - format: short
               label: "Events / Min"
+            - show: True
           targets:
             - target: alias(consolidateBy(smartSummarize(stats_counts.nodepool.launch.provider.pubcloud-dfw.ready, '1m'), 'sum'), 'DFW')
             - target: alias(consolidateBy(smartSummarize(stats_counts.nodepool.launch.provider.pubcloud-iad.ready, '1m'), 'sum'), 'IAD')
@@ -210,6 +211,7 @@ dashboard:
           yaxes:
             - format: short
               label: "Events / Min"
+            - show: True
           targets:
             - target: alias(consolidateBy(smartSummarize(sumSeries(stats_counts.nodepool.launch.provider.pubcloud-dfw.error.*), '1m'), 'sum'), 'DFW')
             - target: alias(consolidateBy(smartSummarize(sumSeries(stats_counts.nodepool.launch.provider.pubcloud-iad.error.*), '1m'), 'sum'), 'IAD')


### PR DESCRIPTION
Some of the Grafana graphs show inaccurate data points if the graph
is zoomed out, or the time range is larger than about 6-12 hours.
For more an example, see the notes file attached to the RE-1980 card.
This task attempts to resolve the time range issue and includes a
minor adjustment to fix the units (scale) in the "Time to Ready" panel.

Revision: Added the missing "- show: True" to "yaxes" to fix the
previous PR

JIRA: RE-1980

Issue: [RE-1980](https://rpc-openstack.atlassian.net/browse/RE-1980)