### PR TITLE
Adjust nodepool settings to give more headroom to DFW

### DIFF
--- a/nodepool/files/nodepool.yml
+++ b/nodepool/files/nodepool.yml
@@ -37,10 +37,10 @@ labels:
 
   #g1-8
   - name: ubuntu-bionic-g1-8
-    min-ready: 3
+    min-ready: 1
     max-ready-age: 86400
   - name: ubuntu-xenial-g1-8
-    min-ready: 3
+    min-ready: 1
     max-ready-age: 86400
   - name: ubuntu-trusty-g1-8
     min-ready: 0
@@ -48,7 +48,7 @@ labels:
 
   #p2-15
   - name: ubuntu-bionic-p2-15
-    min-ready: 1
+    min-ready: 0
     max-ready-age: 86400
   - name: ubuntu-xenial-p2-15
     min-ready: 1
@@ -211,10 +211,10 @@ providers:
       - name: main
         # Ignore the quota given by public cloud and only respect what we provide as max-servers
         ignore-provider-quota: true
-        # Some node types (eg: p2-15) use 16GB RAM, so we set this value to ensure
-        # that we do not use more than half that quota to make room for the snapshot
-        # nodes.
-        max-servers: 15
+        # This region is used for snapshot building, and snapshot consumption.
+        # To ensure that there is headroom for these build jobs, we reduce this
+        # number to ensure that jenkins has the headroom to run them.
+        max-servers: 10
         availability-zones: []
         labels: *provider_pools_main_labels_block
       - name: onmetal
@@ -291,7 +291,7 @@ providers:
           hypervisor_type: qemu
     pools:
       - name: main
-        max-servers: 5
+        max-servers: 30
         availability-zones: []
         networks:
           - rpc-releng-private


### PR DESCRIPTION
The public cloud DFW region is exclusively used for snapshot
builds and snapshot consumption, both of which currently use
jenkins (not nodepool). In the 2018.10 release we'll be migrating
the snapshot consumption to use nodepool, so that will help us to
remain within a quota - but jenkins does not have quota awareness,
so we have the snapshot creation jobs failing unless we provide
some headroom for jenkins to use.

In this patch we do the following:

1. Reduce the DFW nodepool quota to ensure that there is headroom
   for jenkins.
2. Reduce the min-ready for ubuntu-xenial-g1-8 and ubuntu-bionic-g1-8
   because it seems that they are underutilised with the current
   setting. With min-ready at 1, there will be one available in each
   region which should be more than enough.
3. Reduce the min-ready for ubuntu-bionic-p2-15 because it is currently
   unused by any jobs.
4. Increase the max-servers for Phobos to be 30, which matches the
   setting for ORD.

Issue: [RE-2027](https://rpc-openstack.atlassian.net/browse/RE-2027)