### PR TITLE
Fix use of status context for releases

### DIFF
--- a/rpc_jobs/standard_job_release.yml
+++ b/rpc_jobs/standard_job_release.yml
@@ -24,13 +24,13 @@
       common.globalWraps(){
         dir("${env.WORKSPACE}/releases") {
           common.clone_with_pr_refs()
-          if (! github.is_pr_approved(["CIT/release"])) {
+          if (! github.is_pr_approved(["release"])) {
             throw new Exception(
               "Release process cannot continue until the pull request is "
               + "approved by required reviewers and checks."
             )
           }
-          common.runReleasesPullRequestWorkflow("origin/master", "HEAD", "RE", "CIT/release", ":shipit: skip validation")
+          common.runReleasesPullRequestWorkflow("origin/master", "HEAD", "RE", "release", ":shipit: skip validation")
         } // dir
       } // globalWraps
 


### PR DESCRIPTION
The status context for Component-Release-Trigger was updated by
d179202fd710607dc1bf8e5915381a394703afd3 however the additional
occurrences of this value where not updated. This change updates the
other places where the status context is hard-coded for this job.

JIRA: RE-2032