### PR TITLE
RI-498 Upgrade rpc-upgrades/osp-mnaio hypervisor to Bionic

### DIFF
--- a/rpc_jobs/osp_mnaio.yml
+++ b/rpc_jobs/osp_mnaio.yml
@@ -29,7 +29,7 @@
       | ^gating/release/
     image:
       - xenial_mnaio:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
       - "3ctlr_2comp_3ceph"
     action:
@@ -46,7 +46,7 @@
     repo_url: "https://github.com/rcbops/osp-mnaio"
     image:
       - xenial_mnaio:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
       - "3ctlr_2comp_3ceph"
     action:
@@ -63,7 +63,7 @@
     repo_url: "https://github.com/rcbops/osp-mnaio"
     image:
       - xenial_mnaio:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
       - "3ctlr_2comp_3ceph"
     action:

--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -164,7 +164,7 @@
     image:
       # in mnaio builds, the OS equals the VMs OS
       - trusty_mnaio:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
       - "swift"
     action:
@@ -186,7 +186,7 @@
     image:
       # in mnaio builds, the OS equals the VMs OS
       - trusty_mnaio:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
       - "swift"
     action:
@@ -237,7 +237,7 @@
     repo_url: "https://github.com/rcbops/rpc-upgrades"
     image:
       - xenial_mnaio:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
       - "swift"
     action:


### PR DESCRIPTION
Assuming we have enough Bionic nodes in the queue, I'd like to move from Xenial to Bionic for rpc-upgrades and osp-mnaio builds.

Issue: [RI-498](https://rpc-openstack.atlassian.net/browse/RI-498)