### PR TITLE
Fix release job so it skips metadata verification

### DIFF
--- a/job_dsl/release.groovy
+++ b/job_dsl/release.groovy
@@ -5,25 +5,28 @@ common.globalWraps(){
       common.configure_git()
     }
     stage("Verify component metadata"){
-      common.clone_with_pr_refs(
-        "${env.WORKSPACE}/${env.RE_JOB_REPO_NAME}",
-      )
-      venv = "${WORKSPACE}/.componentvenv"
-      sh """#!/bin/bash -xe
-          virtualenv --python python3 ${venv}
-          set +x; . ${venv}/bin/activate; set -x
-          pip install -c '${env.WORKSPACE}/rpc-gating/constraints_rpc_component.txt' rpc_component
-      """
-      component_text = sh(
-        script: """#!/bin/bash -xe
-          set +x; . ${venv}/bin/activate; set -x
-          cd "${env.WORKSPACE}/${env.RE_JOB_REPO_NAME}"
-          component metadata get
-        """,
-        returnStdout: true
-      )
-      println "=== component CLI standard out ==="
-      println component_text
+      // This stage is used by component pre-merge release tests only
+      if ( env.ghprbPullId != null ) {
+        common.clone_with_pr_refs(
+          "${env.WORKSPACE}/${env.RE_JOB_REPO_NAME}",
+        )
+        venv = "${WORKSPACE}/.componentvenv"
+        sh """#!/bin/bash -xe
+            virtualenv --python python3 ${venv}
+            set +x; . ${venv}/bin/activate; set -x
+            pip install -c '${env.WORKSPACE}/rpc-gating/constraints_rpc_component.txt' rpc_component
+        """
+        component_text = sh(
+          script: """#!/bin/bash -xe
+            set +x; . ${venv}/bin/activate; set -x
+            cd "${env.WORKSPACE}/${env.RE_JOB_REPO_NAME}"
+            component metadata get
+          """,
+          returnStdout: true
+        )
+        println "=== component CLI standard out ==="
+        println component_text
+      }
     }
     stage("Release"){
       // If this is a PR test, then we need to set some


### PR DESCRIPTION
The metadata verification step was added by
bec68cab3f994280a2109a1f29df3d1397df0d1a for use by
'RE-Release-PR_{repo}-{BRANCH}' jobs however because this code is also
shared by 'RE-Release' it is causing failures when releasing components.
This change ensures the verification is only performed on a pull
request.

JIRA: RE-2033

Issue: [RE-2033](https://rpc-openstack.atlassian.net/browse/RE-2033)