### PR TITLE
RI-499 Use snapshots on incremental upgrades

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -249,6 +249,24 @@
     CRON: "{CRON_WEEKLY}"
 
 - project:
+    name: "rpc-upgrades-aio-snapshot-incremental"
+    repo_name: "rpc-upgrades"
+    repo_url: "https://github.com/rcbops/rpc-upgrades"
+    image:
+      - xenial_snapshot
+    scenario:
+      - swift
+    action:
+      - newton_to_queens_incremental:
+          SLAVE_TYPE: "rpc-r14-xenial_loose_artifacts-swift"
+      - pike_to_queens_incremental:
+          SLAVE_TYPE: "rpc-r16-xenial_no_artifacts-swift"
+    jira_project_key: "RLM"
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+    CRON: "{CRON_WEEKLY}"
+
+- project:
     name: "rpc-upgrades"
     repo_name: "rpc-upgrades"
     repo_url: "https://github.com/rcbops/rpc-upgrades"


### PR DESCRIPTION
Use version snapshots to avoid inital deploy and
just focus on upgrading.

Issue: [RI-499](https://rpc-openstack.atlassian.net/browse/RI-499)