### PR TITLE
Move RPC-O strict artifact builds to using nodepool

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -439,19 +439,15 @@
     repo_url: "https://github.com/rcbops/rpc-openstack"
     branch: "newton"
     jira_project_key: "RO"
-    # NOTE(mattt): ORD doesn't have the custom RPC images in it
-    REGIONS: "DFW"
-    FALLBACK_REGIONS: "IAD"
     image:
       - xenial:
-          IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
+          SLAVE_TYPE: "nodepool-rpco-14.2-xenial-base"
       - trusty:
-          IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+          SLAVE_TYPE: "nodepool-rpco-14.2-trusty-base"
     scenario:
       - "swift"
     action:
-      - deploy:
-          FLAVOR: "7"
+      - deploy
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 


### PR DESCRIPTION
The PR jobs have been using nodepool for some time. We can
now switch the PM jobs too. The region and flavor settings
are removed as they're not used by nodepool.

Confirmed to be working as normal via:
https://rpc.jenkins.cit.rackspace.net/job/PM_rpc-openstack-newton-xenial-swift-deploy/475/
https://rpc.jenkins.cit.rackspace.net/job/PM_rpc-openstack-newton-trusty-swift-deploy/427/

Issue: [RE-1586](https://rpc-openstack.atlassian.net/browse/RE-1586)
Issue: [RE-1587](https://rpc-openstack.atlassian.net/browse/RE-1587)