### PR TITLE
Move rpc-designate snapshot jobs to use nodepool

### DIFF
--- a/rpc_jobs/rpc_designate.yml
+++ b/rpc_jobs/rpc_designate.yml
@@ -10,21 +10,17 @@
 
     # Use image for RPC-O install
     image:
-      - xenial_snapshot:
-          REGIONS: "DFW"
-          FALLBACK_REGIONS: "DFW"
-          FLAVOR: "7"
-          BOOT_TIMEOUT: 1500
+      - xenial_snapshot
 
     hold_on_error: "4h"
 
     scenario:
       - newton:
-          IMAGE: "rpc-r14.18.0-xenial_loose_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r14-xenial_loose_artifacts-swift"
       - pike:
-          IMAGE: "rpc-r16.2.5-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r16-xenial_no_artifacts-swift"
       - queens:
-          IMAGE: "rpc-r17.1.1-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r17-xenial_no_artifacts-swift"
     action:
       - "deploy"
 
@@ -43,22 +39,18 @@
 
     # Use image for RPC-O install
     image:
-      - xenial_snapshot:
-          REGIONS: "DFW"
-          FALLBACK_REGIONS: "DFW"
-          FLAVOR: "7"
-          BOOT_TIMEOUT: 1500
+      - xenial_snapshot
 
     # Add Hold on error incase we have a failure
     hold_on_error: "4h"
- 
+
     scenario:
       - newton:
-          IMAGE: "rpc-r14.18.0-xenial_loose_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r14-xenial_loose_artifacts-swift"
       - pike:
-          IMAGE: "rpc-r16.2.5-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r16-xenial_no_artifacts-swift"
       - queens:
-          IMAGE: "rpc-r17.1.1-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r17-xenial_no_artifacts-swift"
     action:
       - "deploy"
 


### PR DESCRIPTION
Nodepool now provides nodes based on the most recent
snapshot image of a working RPC-O deployment. With
this implemented, we can switch the designate jobs
over to using them.

Testing:
https://rpc.jenkins.cit.rackspace.net/job/PM_rpc-designate-master-xenial_snapshot-newton-deploy/227/
https://rpc.jenkins.cit.rackspace.net/job/PM_rpc-designate-master-xenial_snapshot-pike-deploy/229/
https://rpc.jenkins.cit.rackspace.net/job/PM_rpc-designate-master-xenial_snapshot-queens-deploy/168/

Issue: [RE-1592](https://rpc-openstack.atlassian.net/browse/RE-1592)
Issue: [RE-1593](https://rpc-openstack.atlassian.net/browse/RE-1593)