### PR TITLE
Move rpc-octavia snapshot jobs to use nodepool

### DIFF
--- a/rpc_jobs/rpc_octavia.yml
+++ b/rpc_jobs/rpc_octavia.yml
@@ -16,11 +16,7 @@
     # Use image for RPC-O install
     image:
       - xenial_snapshot:
-          IMAGE: "rpc-r14.18.0-xenial_loose_artifacts-swift"
-          REGIONS: "DFW"
-          FALLBACK_REGIONS: "DFW"
-          FLAVOR: "7"
-          BOOT_TIMEOUT: 1500
+          SLAVE_TYPE: "nodepool-rpc-r14-xenial_loose_artifacts-swift"
 
     # Octavia ignores that setting for now
     scenario:
@@ -54,11 +50,7 @@
     # Use image for RPC-O install
     image:
       - xenial_snapshot:
-          IMAGE: "rpc-r16.2.5-xenial_no_artifacts-swift"
-          REGIONS: "DFW"
-          FALLBACK_REGIONS: "DFW"
-          FLAVOR: "7"
-          BOOT_TIMEOUT: 1500
+          SLAVE_TYPE: "nodepool-rpc-r16-xenial_no_artifacts-swift"
 
     # Octavia ignores that setting for now
     scenario:
@@ -86,17 +78,13 @@
     # upstream installer
     branch:
       - "master":
-          IMAGE: "rpc-r14.18.0-xenial_loose_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r14-xenial_loose_artifacts-swift"
       - "pike":
-          IMAGE: "rpc-r16.2.5-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r16-xenial_no_artifacts-swift"
 
     # Use image for RPC-O install
     image:
-      - xenial_snapshot:
-          REGIONS: "DFW"
-          FALLBACK_REGIONS: "DFW"
-          FLAVOR: "7"
-          BOOT_TIMEOUT: 1500
+      - xenial_snapshot
 
     # Octavia ignores that setting for now
     scenario:


### PR DESCRIPTION
Nodepool now provides nodes based on the most recent
snapshot image of a working RPC-O deployment. With
this implemented, we can switch the octavia jobs
over to using them.

Testing:
https://rpc.jenkins.cit.rackspace.net/job/PM_rpc-octavia-master-xenial_snapshot-functional-test/37/
https://rpc.jenkins.cit.rackspace.net/job/PM_rpc-octavia-pike-xenial_snapshot-functional-test/23/

Issue: [RE-1594](https://rpc-openstack.atlassian.net/browse/RE-1594)
Issue: [RE-1595](https://rpc-openstack.atlassian.net/browse/RE-1595)