### PR TITLE
Move rpc-upgrades to using nodepool

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -75,13 +75,9 @@
     name: "rpc-upgrades-aio-newton-head-pm"
     repo_name: "rpc-upgrades"
     repo_url: "https://github.com/rcbops/rpc-upgrades"
-    # NOTE(mattt): ORD doesn't have the custom RPC images in it
-    REGIONS: "DFW"
-    FALLBACK_REGIONS: "IAD"
     image:
       - trusty_aio:
-          FLAVOR: "performance2-15"
-          IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+          SLAVE_TYPE: "nodepool-rpco-14.2-trusty-base"
     scenario:
       - "swift"
     action:
@@ -97,13 +93,9 @@
     name: "rpc-upgrades-aio-newton-head-pm-minor"
     repo_name: "rpc-upgrades"
     repo_url: "https://github.com/rcbops/rpc-upgrades"
-    # NOTE(mattt): ORD doesn't have the custom RPC images in it
-    REGIONS: "DFW"
-    FALLBACK_REGIONS: "IAD"
     image:
       - xenial_aio:
-          FLAVOR: "performance2-15"
-          IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
+          SLAVE_TYPE: "nodepool-rpco-14.2-xenial-base"
     scenario:
       - "swift"
     action:
@@ -119,13 +111,9 @@
     name: "rpc-upgrades-aio-newton-release-pm"
     repo_name: "rpc-upgrades"
     repo_url: "https://github.com/rcbops/rpc-upgrades"
-    # NOTE(mattt): ORD doesn't have the custom RPC images in it
-    REGIONS: "DFW"
-    FALLBACK_REGIONS: "IAD"
     image:
       - trusty_aio:
-          FLAVOR: "performance2-15"
-          IMAGE: "Ubuntu 14.04.5 LTS prepared for RPC deployment"
+          SLAVE_TYPE: "nodepool-rpco-14.2-trusty-base"
     scenario:
       - "swift"
     action:
@@ -214,13 +202,9 @@
     name: "rpc-upgrades-aio-newton-head-incremental"
     repo_name: "rpc-upgrades"
     repo_url: "https://github.com/rcbops/rpc-upgrades"
-    # NOTE(mattt): ORD doesn't have the custom RPC images in it
-    REGIONS: "DFW"
-    FALLBACK_REGIONS: "IAD"
     image:
       - xenial_aio:
-          FLAVOR: "performance2-15"
-          IMAGE: "Ubuntu 16.04.2 LTS prepared for RPC deployment"
+          SLAVE_TYPE: "nodepool-rpco-14.2-xenial-base"
     scenario:
       - "swift"
     action:


### PR DESCRIPTION
The PR jobs have been using nodepool for some time. We can
now switch the PM jobs too. The region and flavor settings
are removed as they're not used by nodepool.

Issue: [RE-1589](https://rpc-openstack.atlassian.net/browse/RE-1589)
Issue: [RE-1591](https://rpc-openstack.atlassian.net/browse/RE-1591)