### PR TITLE
Dropping rpc-upgrades Kilo version jobs

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -141,17 +141,6 @@
       - "r12.2.5_to_r14.current_leap"
       - "r12.2.8_to_r14.current_leap"
       - "kilo_to_r14.current_leap"
-      - "r11.0.0_to_r14.current_leap"
-      - "r11.0.1_to_r14.current_leap"
-      - "r11.0.4_to_r14.current_leap"
-      - "r11.1.3_to_r14.current_leap"
-      - "r11.1.4_to_r14.current_leap"
-      - "r11.1.5_to_r14.current_leap"
-      - "r11.1.6_to_r14.current_leap"
-      - "r11.1.9_to_r14.current_leap"
-      - "r11.1.10_to_r14.current_leap"
-      - "r11.1.15_to_r14.current_leap"
-      - "r11.1.18_to_r14.current_leap"
     jira_project_key: "RLM"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'


### PR DESCRIPTION
Jobs have never been successful as deployment of the older
versions is broken so removing them as to not eat up
unnecessary resources.