### PR TITLE
Switch to using bionic hosts for RPC-O MNAIO queens jobs

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -369,7 +369,7 @@
     jira_project_key: "RO"
     image:
       - xenial_mnaio_no_artifacts:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
       - ironic
       - swift


### PR DESCRIPTION
In order to prepare for using the MNAIO images, we need to
switch to using bionic hosts. They're required to support
the use of the later virt-tools which perform the magic
in the images prior to booting the VM's to ensure that they
work when starting up without having to run any extra
playbooks.