### PR TITLE
Switch release/experimental MNAIO jobs to use bionic hosts

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -505,7 +505,7 @@
     jira_project_key: "RO"
     image:
       - xenial_mnaio_no_artifacts:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
       - swift
     action:
@@ -521,7 +521,7 @@
     jira_project_key: "RO"
     image:
       - xenial_mnaio_no_artifacts:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
       - swift
     action:
@@ -537,7 +537,7 @@
     jira_project_key: "RO"
     image:
       - xenial_mnaio_no_artifacts:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
       - swift
     action:
@@ -603,7 +603,7 @@
     jira_project_key: ""
     image:
       - staging_asc_xenial_mnaio_no_artifacts:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
       - swift
     action:


### PR DESCRIPTION
In recent PR's the MNAIO host was switched to using bionic, but
the same was not done for the release and the ASC experimental
job. This patch ensures those jobs are also switched over.

Issue: [RE-1562](https://rpc-openstack.atlassian.net/browse/RE-1562)
Issue: [RE-1996](https://rpc-openstack.atlassian.net/browse/RE-1996)
Issue: [RE-1997](https://rpc-openstack.atlassian.net/browse/RE-1997)
Issue: [RE-1998](https://rpc-openstack.atlassian.net/browse/RE-1998)