### PR TITLE
Change PM MaaS Queens Deploy Job to Run Daily

### DIFF
--- a/rpc_jobs/rpc_maas.yml
+++ b/rpc_jobs/rpc_maas.yml
@@ -182,7 +182,7 @@
     repo_name: "rpc-maas"
     repo_url: "https://github.com/rcbops/rpc-maas"
     branch: "master"
-    CRON: "{CRON_WEEKLY}"
+    CRON: "{CRON_DAILY}"
     image:
       - "xenial":
           SLAVE_TYPE: "nodepool-maas-ubuntu-xenial-g1-8"


### PR DESCRIPTION
- Changed the periodic MaaS Post Merge deploy scenarios for queens, pike, newton, and ceph running on xenial from weekly to daily.

JIRA: RE-2054

Issue: [RE-2054](https://rpc-openstack.atlassian.net/browse/RE-2054)