### PR TITLE
Change PM MaaS Newton Deploy Job to Run Daily

### DIFF
--- a/rpc_jobs/rpc_maas.yml
+++ b/rpc_jobs/rpc_maas.yml
@@ -202,7 +202,7 @@
     repo_name: "rpc-maas"
     repo_url: "https://github.com/rcbops/rpc-maas"
     branch: "master"
-    CRON: "{CRON_WEEKLY}"
+    CRON: "{CRON_DAILY}"
     image:
       - "trusty":
           SLAVE_TYPE: "nodepool-maas-ubuntu-trusty-g1-8"


### PR DESCRIPTION
- Changed the periodic MaaS Post Merge deploy scenarios for newton running on trusty from weekly to daily.

JIRA: RE-2054

Issue: [RE-2054](https://rpc-openstack.atlassian.net/browse/RE-2054)