### PR TITLE
ASC-1042 Rename asc staging image

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -616,14 +616,14 @@
     CRON: "{CRON_MONTHLY}"
     jira_project_key: ""
     image:
-      - staging_asc_bionic_mnaio_no_artifacts:
+      - bionic_mnaio_no_artifacts:
           SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
-      - staging_asc_xenial_mnaio_no_artifacts:
+      - xenial_mnaio_no_artifacts:
           SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
       - swift
     action:
-      - system
+      - system_staging
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 


### PR DESCRIPTION
This commit removes the specialized naming convention for the images
used for the asc staging job. The non-standard name prevents the images
cached in the CDN from being detected.

In order to allow the job to remain discrete from the production system
testing job, the action is renamed to 'system_staging'.

Issue: [ASC-1042](https://rpc-openstack.atlassian.net/browse/ASC-1042)