### PR TITLE
RE-2064 Run install_ansible in containers

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1100,6 +1100,7 @@ void standard_job_slave(String slave_type, Closure body){
       }
       container.inside {
         configure_git()
+        install_ansible()
         body()
       }
     } else {


### PR DESCRIPTION
In standard_job_slave we call use_node for all node types apart from
containers. This means that install_ansible is not run on containers,
which means the rpc-gating venv is not adjusted for the current os.

This commit adds a call to install_ansible within each container before
its used.

Issue: [RE-2064](https://rpc-openstack.atlassian.net/browse/RE-2064)