### PR TITLE
Remove 'ironic' RPC-O jobs and switch newton MNAIO to bionic hosts

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -22,8 +22,6 @@
       - xenial_no_artifacts:
           SLAVE_TYPE: "nodepool-ubuntu-xenial-p2-15"
     scenario:
-      - ironic:
-          TRIGGER_PR_PHRASE_ONLY: true
       - "swift"
     action:
       - "deploy"
@@ -71,8 +69,6 @@
       - xenial_no_artifacts:
           SLAVE_TYPE: "nodepool-ubuntu-xenial-p2-15"
     scenario:
-      - ironic:
-          TRIGGER_PR_PHRASE_ONLY: true
       - "swift"
     action:
       - "deploy"
@@ -119,8 +115,6 @@
       - xenial_no_artifacts:
           SLAVE_TYPE: "nodepool-ubuntu-xenial-p2-15"
     scenario:
-      - ironic:
-          TRIGGER_PR_PHRASE_ONLY: true
       - "swift"
     action:
       - "deploy"
@@ -166,8 +160,6 @@
       - xenial_no_artifacts:
           SLAVE_TYPE: "nodepool-ubuntu-xenial-p2-15"
     scenario:
-      - ironic:
-          TRIGGER_PR_PHRASE_ONLY: true
       - "swift"
     action:
       - "deploy"
@@ -279,17 +271,11 @@
       - xenial_mnaio_no_artifacts:
           SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
-      - ironic
       - swift
     action:
       - system
       - sdqc
       - deploy
-    exclude:
-      - action: system
-        scenario: ironic
-      - action: sdqc
-        scenario: ironic
     # Required by RPC-ASC team to upload test results qTest
     credentials: "rpc_asc_creds"
     jobs:
@@ -333,17 +319,11 @@
       - xenial_mnaio_no_artifacts:
           SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
-      - ironic
       - swift
     action:
       - system
       - sdqc
       - deploy
-    exclude:
-      - action: system
-        scenario: ironic
-      - action: sdqc
-        scenario: ironic
     # Required by RPC-ASC team to upload test results qTest
     credentials: "rpc_asc_creds"
     jobs:
@@ -383,17 +363,11 @@
       - xenial_mnaio_no_artifacts:
           SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
-      - ironic
       - swift
     action:
       - system
       - sdqc
       - deploy
-    exclude:
-      - action: system
-        scenario: ironic
-      - action: sdqc
-        scenario: ironic
     # Required by RPC-ASC team to upload test results qTest
     credentials: "rpc_asc_creds"
     jobs:
@@ -432,14 +406,10 @@
       - xenial_mnaio_no_artifacts:
           SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
-      - ironic
       - swift
     action:
       - system
       - deploy
-    exclude:
-      - action: system
-        scenario: ironic
     # Required by RPC-ASC team to upload test results qTest
     credentials: "rpc_asc_creds"
     jobs:

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -468,7 +468,7 @@
     jira_project_key: "RO"
     image:
       - xenial_mnaio_loose_artifacts:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
       - swift
     action:
@@ -537,7 +537,7 @@
     jira_project_key: "RO"
     image:
       - xenial_mnaio_loose_artifacts:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
       - swift
     action:


### PR DESCRIPTION
The 'ironic' scenario in RPC-O does not do anything different
to the 'deploy' scenario. This means that CI resources are being
wasted on executing them. This PR removes the ironic jobs so that
this no longer happens.

Also, in order to prepare for using the MNAIO images, we need to
switch to using bionic hosts. They're required to support
the use of the later virt-tools which perform the magic
in the images prior to booting the VM's to ensure that they
work when starting up without having to run any extra
playbooks.

Issue: [RI-513](https://rpc-openstack.atlassian.net/browse/RI-513)
Issue: [RE-2030](https://rpc-openstack.atlassian.net/browse/RE-2030)