### PR TITLE
Disable systemd-resolved in bionic+ images

### DIFF
--- a/nodepool/files/elements/jenkins-slave/install.d/20-jenkins-slave
+++ b/nodepool/files/elements/jenkins-slave/install.d/20-jenkins-slave
@@ -7,6 +7,22 @@ set -eu
 set -o pipefail
 
 ##
+## Disable systemd-resolved on bionic images
+##
+# We have glean to setup the interfaces and the resolvers
+# from config-drive. We do not want systemd-resolved to
+# interfere with that. It is enabled by default in Bionic,
+# so we need to disable and mask it to prevent it from
+# starting without any resolvers configured and breaking
+# DNS resolution on the host.
+# ref: RI-514
+#
+source /etc/lsb-release
+if [[ "${DISTRIB_CODENAME}" != "trusty" ]] && [[ "${DISTRIB_CODENAME}" != "xenial" ]]; then
+    systemctl disable systemd-resolved
+fi
+
+##
 ## Add jenkins user, group.
 ##
 JENKINS_HOME="/var/lib/jenkins"


### PR DESCRIPTION
Bionic images are failing to resolve DNS because glean
is not implementing any systemd-resolved configuration
to make it work. This results in the system initially
working OK, but failing if any changes are made to the
networking configuration which causes systemd-resolved
to restart (replacing the content of /etc/resolve.conf
which glean put there).

While this is currently only showing up in RPC-O tests,
the issue would happen on any nodepool nodes which make
adjustments to the network config. Given that we use
glean as part of the nodepool node setup, we need to do
this here to prevent test failures rather than expect
test implementations to do it.

We disable this on any image which is not trusty/xenial
so that this will happen for any images bionic onwards.

Issue: [RI-514](https://rpc-openstack.atlassian.net/browse/RI-514)