### PR TITLE
Replace the systemd-resolved symlink

### DIFF
--- a/nodepool/files/elements/jenkins-slave/install.d/20-jenkins-slave
+++ b/nodepool/files/elements/jenkins-slave/install.d/20-jenkins-slave
@@ -20,6 +20,14 @@ set -o pipefail
 source /etc/lsb-release
 if [[ "${DISTRIB_CODENAME}" != "trusty" ]] && [[ "${DISTRIB_CODENAME}" != "xenial" ]]; then
     systemctl disable systemd-resolved
+    # Remove the systemd-resolved stub file
+    # symlink. glean will put a normal file
+    # in its place on boot.
+    rm -f /etc/resolv.conf
+    # To allow the image build to complete,
+    # we add a replacement file with a public
+    # resolver.
+    echo 'nameserver 8.8.8.8' > /etc/resolv.conf
 fi
 
 ##


### PR DESCRIPTION
systemd-resolved adds a symlink which glean does not
seem to replace on boot. To ensure that the boot can
complete, and the image build is unaffected by this
change, we replace /etc/resolv.conf with a normal
file and a public resolver.

Glean fails with the symlink in place with:

```
Oct 12 15:55:59 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[417]: Traceback (most recent call last):
Oct 12 15:55:59 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[417]:   File "/usr/local/bin/glean", line 11, in <module>
Oct 12 15:55:59 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[417]:     sys.exit(main())
Oct 12 15:55:59 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[417]:   File "/usr/local/lib/python2.7/dist-packages/glean/cmd.
py", line 1481, in main
Oct 12 15:55:59 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[417]:     write_network_info_from_config_drive(args)
Oct 12 15:55:59 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[417]:   File "/usr/local/lib/python2.7/dist-packages/glean/cmd.
py", line 1318, in write_network_info_from_config_drive
Oct 12 15:55:59 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[417]:     write_static_network_info(interfaces, sys_interfaces,
 dns, args)
Oct 12 15:55:59 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[417]:   File "/usr/local/lib/python2.7/dist-packages/glean/cmd.
py", line 1068, in write_static_network_info
Oct 12 15:55:59 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[417]:     finish_files(files_to_write, args)
Oct 12 15:55:59 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[417]:   File "/usr/local/lib/python2.7/dist-packages/glean/cmd.
py", line 1102, in finish_files
Oct 12 15:55:59 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[417]:     elif e.errno == errno.EACCESS:
Oct 12 15:55:59 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[417]: AttributeError: 'module' object has no attribute 'EACCESS
'
Oct 12 15:55:59 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[419]: Traceback (most recent call last):
Oct 12 15:55:59 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[419]:   File "/usr/local/bin/glean", line 11, in <module>
Oct 12 15:55:59 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[419]:     sys.exit(main())
Oct 12 15:55:59 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[419]:   File "/usr/local/lib/python2.7/dist-packages/glean/cmd.
py", line 1481, in main
Oct 12 15:55:59 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[419]:     write_network_info_from_config_drive(args)
Oct 12 15:55:59 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[419]:   File "/usr/local/lib/python2.7/dist-packages/glean/cmd.
py", line 1318, in write_network_info_from_config_drive
Oct 12 15:56:00 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[419]:     write_static_network_info(interfaces, sys_interfaces,
 dns, args)
Oct 12 15:56:00 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[419]:   File "/usr/local/lib/python2.7/dist-packages/glean/cmd.
py", line 1068, in write_static_network_info
Oct 12 15:56:00 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[419]:     finish_files(files_to_write, args)
Oct 12 15:56:00 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[419]:   File "/usr/local/lib/python2.7/dist-packages/glean/cmd.
py", line 1102, in finish_files
Oct 12 15:56:00 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[419]:     elif e.errno == errno.EACCESS:
Oct 12 15:56:00 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 glean.sh[419]: AttributeError: 'module' object has no attribute 'EACCESS
'
Oct 12 15:56:00 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 ifup[461]: /sbin/ifup: interface lo already configured
Oct 12 15:56:00 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 systemd[1]: Started Glean for interface lo.
Oct 12 15:56:00 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 systemd[1]: glean@eth0.service: Control process
exited, code=exited status=1
Oct 12 15:56:00 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 systemd[1]: glean@eth0.service: Failed with resu
lt 'exit-code'.
Oct 12 15:56:00 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 systemd[1]: Failed to start Glean for interface
eth0.
Oct 12 15:56:00 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 systemd[1]: glean@eth1.service: Control process
exited, code=exited status=1
Oct 12 15:56:00 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 systemd[1]: glean@eth1.service: Failed with resu
lt 'exit-code'.
Oct 12 15:56:00 nodepool-ubuntu-bionic-g1-8-pubcloud-dfw-0000116762 systemd[1]: Failed to start Glean for interface
eth1.
```

Issue: [RI-514](https://rpc-openstack.atlassian.net/browse/RI-514)