### PR TITLE
Fix Nodepool holding

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1019,6 +1019,10 @@ Boolean isNodepoolNode(String node){
   return node =~ /^nodepool-/
 }
 
+Boolean isNodepoolHoldRequired(String holdOnError){
+  return holdOnError && holdOnError != "0"
+}
+
 // initialisation steps for nodes
 void use_node(String label=null, body){
   node(label){
@@ -1039,7 +1043,7 @@ void use_node(String label=null, body){
       errString = "Caught exception on ${env.NODE_NAME}: ${e} Build: ${env.BUILD_URL}"
       print errString
 
-      if (isNodepoolNode(env.NODE_NAME) && env.HOLD_ON_ERROR != "0"){
+      if (isNodepoolNode(env.NODE_NAME) && isNodepoolHoldRequired(env.HOLD_ON_ERROR)){
         nodePoolHold(duration: env.HOLD_ON_ERROR, reason: errString)
       }
       throw e

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -46,6 +46,7 @@
     IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
     CRON: "{CRON_DAILY}"
     BOOT_TIMEOUT: 900
+    hold_on_error: "3h"
     properties:
       - build-discarder:
           num-to-keep: 14
@@ -82,7 +83,7 @@
           SLAVE_CONTAINER_DOCKERFILE_REPO: "{SLAVE_CONTAINER_DOCKERFILE_REPO}"
           SLAVE_CONTAINER_DOCKERFILE_PATH: "{SLAVE_CONTAINER_DOCKERFILE_PATH}"
           SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS: "{SLAVE_CONTAINER_DOCKERFILE_BUILD_ARGS}"
-          hold_on_error: "3h"
+          hold_on_error: "{hold_on_error}"
     triggers:
       - timed: "{CRON}"
 


### PR DESCRIPTION
This change fixes some issues with the implementation of the
functionality to hold Nodepool nodes:
- ensures a node is not held if `env.HOLD_ON_ERROR` is unset.
- ensures a post-merge project can override the default value.

JIRA: RE-2016

Issue: [RE-2016](https://rpc-openstack.atlassian.net/browse/RE-2016)

[Failure when HOLD_ON_ERROR unset](https://rpc.jenkins.cit.rackspace.net/job/scratchpipeline/1206/console)
[Failure when HOLD_ON_ERROR set](https://rpc.jenkins.cit.rackspace.net/job/scratchpipeline/1207/console)