### PR TITLE
Only configure fallback DNS for systemd-resolved

### DIFF
--- a/nodepool/files/elements/jenkins-slave/install.d/20-jenkins-slave
+++ b/nodepool/files/elements/jenkins-slave/install.d/20-jenkins-slave
@@ -23,8 +23,7 @@ set -o pipefail
 #
 source /etc/lsb-release
 if [[ "${DISTRIB_CODENAME}" != "trusty" ]] && [[ "${DISTRIB_CODENAME}" != "xenial" ]]; then
-    sed -i 's/^#DNS=.*/DNS=8.8.8.8/' /etc/systemd/resolved.conf
-    sed -i 's/^#FallbackDNS=.*/FallbackDNS=8.8.4.4/' /etc/systemd/resolved.conf
+    sed -i 's/^#FallbackDNS=.*/FallbackDNS=8.8.8.8 8.8.4.4/' /etc/systemd/resolved.conf
 fi
 
 ##


### PR DESCRIPTION
In https://github.com/rcbops/rpc-gating/pull/1135 we configured
systemd-resolved in nodepool bionic images to ensure that they
are able to resolve DNS until glean is fixed to configured the
systemd-networkd interfaces with DNS as well.

To ensure that the glean configuration will take preference when
a fix is included in the release, we switch the DNS configuration
here to be a fallback only. Any systemd-networkd will then take
preference, but fall back to this configuration if that does not
work.

Issue: [RI-514](https://rpc-openstack.atlassian.net/browse/RI-514)