### PR TITLE
Update hardening tests to use MNAIO images

### DIFF
--- a/rpc_jobs/hardening.yml
+++ b/rpc_jobs/hardening.yml
@@ -1,20 +1,54 @@
 - project:
-    name: "hardening-repo-rpc-openstack-mnaio-postmerge"
+    name: "hardening-rpc-openstack-bionic"
+    repo_name: "hardening"
+    repo_url: "internal:hardening_repo_url"
+    branch: "master"
+    jira_project_key: "RQE"
+    image:
+      - bionic_mnaio:
+          SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
+    scenario:
+      - "swift"
+    action:
+      - "hardening_master"
+      - "hardening_rocky"
+    CRON: "{CRON_WEEKLY}"
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+- project:
+    name: "hardening-rpc-openstack-xenial"
+    repo_name: "hardening"
+    repo_url: "internal:hardening_repo_url"
+    branch: "master"
+    jira_project_key: "RQE"
+    image:
+      - xenial_mnaio:
+          SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
+    scenario:
+      - "swift"
+    action:
+      - "hardening_master"
+      - "hardening_rocky"
+      - "hardening_queens"
+      - "hardening_pike"
+    CRON: "{CRON_WEEKLY}"
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+
+- project:
+    name: "hardening-rpc-openstack-xenial-newton"
     repo_name: "hardening"
     repo_url: "internal:hardening_repo_url"
     branch: "master"
     jira_project_key: "RQE"
     image:
       - xenial_mnaio_loose_artifacts:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-om-io2"
+          SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
       - "swift"
     action:
-      - "deploy_master"
-      - "deploy_rocky"
-      - "deploy_queens"
-      - "deploy_pike"
-      - "deploy_newton"
+      - "hardening_newton"
     CRON: "{CRON_WEEKLY}"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'


### PR DESCRIPTION
In order to ensure that the hardening tests make use of
MNAIO images rather than do the deployment from scratch,
we rename the 'action' to 'hardening' rather than 'deploy'.

We also update the nodepool node to use bionic.

Finally we change the 'image' axis to be 'xenial_mnaio'
for pike, queens rocky and master rather than make mention
of 'loose_artifacts' given that these RPC-O branches do not
have any notion of artifacts. We restrict that naming to
only newton. We also add bionic VM tests for rocky and
master.

Issue: [RE-2053](https://rpc-openstack.atlassian.net/browse/RE-2053)