### PR TITLE
Add 'elk' action to RPC-O MNAIO tests

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -273,9 +273,10 @@
     scenario:
       - swift
     action:
-      - system
-      - sdqc
       - deploy
+      - elk
+      - sdqc
+      - system
     # Required by RPC-ASC team to upload test results qTest
     credentials: "rpc_asc_creds"
     jobs:
@@ -321,9 +322,10 @@
     scenario:
       - swift
     action:
-      - system
-      - sdqc
       - deploy
+      - elk
+      - sdqc
+      - system
     # Required by RPC-ASC team to upload test results qTest
     credentials: "rpc_asc_creds"
     jobs:
@@ -365,9 +367,10 @@
     scenario:
       - swift
     action:
-      - system
-      - sdqc
       - deploy
+      - elk
+      - sdqc
+      - system
     # Required by RPC-ASC team to upload test results qTest
     credentials: "rpc_asc_creds"
     jobs:
@@ -408,8 +411,9 @@
     scenario:
       - swift
     action:
-      - system
       - deploy
+      - elk
+      - system
     # Required by RPC-ASC team to upload test results qTest
     credentials: "rpc_asc_creds"
     jobs:


### PR DESCRIPTION
In order to test the ELK add-on for RPC-O, we add an
extra 'action' which executes that option using the
MNAIO images. This also ensures that the 'deploy'
action remains focused on the base RPC-O deployment
without any extras.

The 'action' axis components are all re-ordered into
alphabetical order for easier maintenance.

Issue: [RI-263](https://rpc-openstack.atlassian.net/browse/RI-263)