### PR TITLE
Ensure hardening job image names match RPC-O jobs

### DIFF
--- a/rpc_jobs/hardening.yml
+++ b/rpc_jobs/hardening.yml
@@ -5,7 +5,7 @@
     branch: "master"
     jira_project_key: "RQE"
     image:
-      - bionic_mnaio:
+      - bionic_mnaio_no_artifacts:
           SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
       - "swift"
@@ -23,7 +23,7 @@
     branch: "master"
     jira_project_key: "RQE"
     image:
-      - xenial_mnaio:
+      - xenial_mnaio_no_artifacts:
           SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
       - "swift"


### PR DESCRIPTION
To allow the hardening jobs to simply use the RPc-O MNAIO
images, the 'image' axis names need to match. This patch
ensures that is the case.

Issue: [RE-2053](https://rpc-openstack.atlassian.net/browse/RE-2053)