### PR TITLE
Add artefact store support to release workflow

### DIFF
--- a/constraints_rpc_component.txt
+++ b/constraints_rpc_component.txt
@@ -1,3 +1,3 @@
 GitPython==2.1.9
-git+https://github.com/rcbops/rpc_component@77f546270a6c5f01d9422c78fc4f722577c6f81d#egg=rpc_component
+git+https://github.com/rcbops/rpc_component@16dc9a0374f757016af132b441ca537a152119b6#egg=rpc_component
 schema==0.6.7

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1818,6 +1818,9 @@ void runReleasesPullRequestWorkflow(String baseBranch, String prBranch, String j
     }
   }else if (type == "registration"){
     registerComponent(componentText, jiraProjectKey)
+  }else if (type == "artifact-store"){
+    // Adding an artefact store does not activate any additional workflow and
+    // so this block only needs skipping so the pull request can be merged.
   }else{
     throw new Exception("The pull request type ${prType} is unsupported.")
   }
@@ -1845,7 +1848,7 @@ List getComponentChange(String baseBranch, String prBranch){
       set +x; . ${venv}/bin/activate; set -x
       pip install -c '${env.WORKSPACE}/rpc-gating/constraints_rpc_component.txt' rpc_component
   """
-  types = ["release", "registration"]
+  types = ["release", "registration", "artifact-store"]
   for (i=0; i < types.size(); i++){
     type = types[i]
     try{


### PR DESCRIPTION
When the release job is run, on an rcbops/releases pull request to add
an artefact store, the change must be recognised so that the automated
merge can be done. This change adds the necessary support. rpc_component
is updated to a version that supports the `artifact-store` subcommand.

JIRA: RE-2100

Issue: [RE-2100](https://rpc-openstack.atlassian.net/browse/RE-2100)