### PR TITLE
Switch artifact uploads to use IAD instead of DFW

### DIFF
--- a/playbooks/artifact_upload.yml
+++ b/playbooks/artifact_upload.yml
@@ -4,7 +4,7 @@
   connection: local
   gather_facts: False
   vars:
-    region: "DFW"
+    region: "IAD"
     cloud_name: "public_cloud"
     component_metadata_file_path: "{{ lookup('env', 'WORKSPACE') }}/{{ lookup('env', 'RE_JOB_REPO_NAME') }}/component_metadata.yml"
     legacy_artifact_log_type:


### PR DESCRIPTION
Currently DFW is undergoing a data centre migration, resulting
in artifact uploads not synchronising quickly enough to provide
the download in time, and therefore producing inconsistencies
when downloading objects - especially large objects.

Testing has proven that IAD is much more reliable, so in this
PR we switch all artifact uploads to use IAD instead.