### PR TITLE
Allow commit_and_pull_request.sh to update branch

### DIFF
--- a/scripts/commit_and_pull_request.sh
+++ b/scripts/commit_and_pull_request.sh
@@ -26,7 +26,7 @@ git commit -m "${COMMIT_TITLE}" -m "${message}"
 
 echo "Pushing changes to repo branch"
 ssh_url="$(git remote get-url --push origin | sed 's|https://github.com/|git@github.com:|')"
-git push "$ssh_url" "${pr_branch}"
+git push -f "$ssh_url" "${pr_branch}"
 
 git checkout "${orig_branch}"
 


### PR DESCRIPTION
If the branch already exists, the `git push` command fails. This change
forces the push to ensure that the script can always update an existing
pull request.

JIRA: RE-2100

Issue: [RE-2100](https://rpc-openstack.atlassian.net/browse/RE-2100)