### PR TITLE
RE-1971 Add CIT Jenkins docker env

### DIFF
--- a/scripts/CIT_JM_Docker/Dockerfile
+++ b/scripts/CIT_JM_Docker/Dockerfile
@@ -1,0 +1,34 @@
+FROM centos:centos6.10
+RUN yum install -y java-1.8.0-openjdk perl
+RUN mkdir -p /var/log/jenkins /usr/lib/jenkins /var/lib/jenkins/tmp
+RUN curl -sO https://ssltool.rackspace.com/cli/ssltool-cli
+RUN chmod +x ./ssltool-cli
+RUN echo yes | ./ssltool-cli rscerts
+RUN mkdir -p /etc/pki/java
+COPY cacerts /etc/pki/java/
+COPY vlj.tar.gz /var/lib
+COPY jenkins.2.107.1.war /usr/lib/jenkins
+RUN cd /usr/lib/jenkins; ln -s jenkins.2.107.1.war  jenkins.war
+RUN cd /var/lib; tar xzf vlj.tar.gz; chown -R root:root /var/lib/jenkins
+RUN rm -rf /var/lib/jenkins/nodes/*
+EXPOSE 8080/tcp
+CMD /usr/bin/java \
+    -Dorg.apache.commons.jelly.tags.fmt.timeZone=America/Chicago \
+    -Xmx1g \
+    -Djava.awt.headless=true \
+    -Dhudson.model.DirectoryBrowserSupport.CSP= \
+    -Djava.io.tmpdir=/var/lib/jenkins/tmp \
+    -DJENKINS_HOME=/var/lib/jenkins \
+    -jar /usr/lib/jenkins/jenkins.war \
+    --webroot=/var/cache/jenkins/war \
+    --httpPort=8080 \
+    --debug=5 \
+    --handlerCountMax=200 \
+    --handlerCountMaxIdle=20
+
+# --logfile=/var/log/jenkins/jenkins.log \
+# Removed because its easier to use the console or docker logs.
+
+# See readme for where to get the files required by COPY instructions.
+
+#DO NOT PUSH images created from this dockerfile to a public repo as they contain secrets

--- a/scripts/CIT_JM_Docker/README.md
+++ b/scripts/CIT_JM_Docker/README.md
@@ -1,0 +1,23 @@
+# CIT Jenkins Testing Environment
+This dockerfile is for producing a docker container that mimics the current CIT/TES jenkins master environment.
+
+Before it can be run, three files must be obtained from the Jenkins master:
+
+1.  vlj.tar.gz. This is a tar of /var/lib/jenkins created in /var/lib and excluding a few patterns:
+    ```
+    cd /var/lib; tar cvzf vlj.tar.gz \
+        --exclude .git\
+        --exclude builds\
+        --exclude \*workspace\* \
+        --exclude reports \
+        --exclude .cache \
+        --exclude cache \
+        --exclude monitoring \
+        --exclude fingerprints \
+        --exclude tmp \
+        --exclude \*venv\*
+        --ignore-failed-read \
+        jenkins
+    ```
+1. cacerts: pull this from /etc/pki/java
+1. jenkins-$version.war: pull this from /usr/lib/jenkins, you may need to update the version in the dockerfile.


### PR DESCRIPTION
This dockerfile is for producing an environment that is very
similar to the running Jenkins master.

Useful for testing upgrades, reproducing errors etc.

Issue: [RE-1971](https://rpc-openstack.atlassian.net/browse/RE-1971)