### PR TITLE
RE-2087 Catch workspace cleanup failures

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1141,7 +1141,14 @@ void use_node(String label=null, body){
       }
       throw e
     } finally {
-      deleteDir()
+      try {
+        // This may fail if node has gone offline
+        // We've had a few jobs where the node goes offline during the post stage
+        // but that must not fail the job. RE-2087
+        deleteDir()
+      } catch (Exception e){
+        print("Failed to clean workspace on ${env.NODE_NAME}: ${e}")
+      }
     }
   }
 }


### PR DESCRIPTION
When we release a node, we clean the workspace by calling
deleteDir from common.use_node. If the node has gone offline
for any reason, that deleteDir will fail. If the node wen't offline
during the post phase, we don't want its disapperance to fail the
build so we enclose deleteDir in try/catch.

Issue: [RE-2087](https://rpc-openstack.atlassian.net/browse/RE-2087)