### PR TITLE
Add test node set for phobos ironic nodes and add Phobos into Grafana

### DIFF
--- a/grafana/grafyaml/dashboard-nodepool.yaml
+++ b/grafana/grafyaml/dashboard-nodepool.yaml
@@ -137,6 +137,7 @@ dashboard:
             - target: alias(stats.timers.nodepool.task.pubcloud-iad.ComputePostServers.mean, 'IAD')
             - target: alias(stats.timers.nodepool.task.pubcloud-lon.ComputePostServers.mean, 'LON')
             - target: alias(stats.timers.nodepool.task.pubcloud-ord.ComputePostServers.mean, 'ORD')
+            - target: alias(stats.timers.nodepool.task.phobos-nodepool.ComputePostServers.mean, 'Phobos')
         - title: Get Server
           type: graph
           lines: true
@@ -151,6 +152,7 @@ dashboard:
             - target: alias(stats.timers.nodepool.task.pubcloud-iad.ComputeGetServersDetail.mean, 'IAD')
             - target: alias(stats.timers.nodepool.task.pubcloud-lon.ComputeGetServersDetail.mean, 'LON')
             - target: alias(stats.timers.nodepool.task.pubcloud-ord.ComputeGetServersDetail.mean, 'ORD')
+            - target: alias(stats.timers.nodepool.task.phobos-nodepool.ComputeGetServersDetail.mean, 'Phobos')
         - title: Delete Server
           type: graph
           lines: true
@@ -165,6 +167,7 @@ dashboard:
             - target: alias(stats.timers.nodepool.task.pubcloud-iad.ComputeDeleteServers.mean, 'IAD')
             - target: alias(stats.timers.nodepool.task.pubcloud-lon.ComputeDeleteServers.mean, 'LON')
             - target: alias(stats.timers.nodepool.task.pubcloud-ord.ComputeDeleteServers.mean, 'ORD')
+            - target: alias(stats.timers.nodepool.task.phobos-nodepool.ComputeDeleteServers.mean, 'Phobos')
         - title: List Servers
           type: graph
           lines: true
@@ -179,6 +182,7 @@ dashboard:
             - target: alias(scale(stats.timers.nodepool.task.pubcloud-iad.ComputeGetServers.mean, '0.001'), 'IAD')
             - target: alias(scale(stats.timers.nodepool.task.pubcloud-lon.ComputeGetServers.mean, '0.001'), 'LON')
             - target: alias(scale(stats.timers.nodepool.task.pubcloud-ord.ComputeGetServers.mean, '0.001'), 'ORD')
+            - target: alias(scale(stats.timers.nodepool.task.phobos-nodepool.ComputeGetServers.mean, '0.001'), 'Phobos')
         - title: Get Limits
           type: graph
           lines: true
@@ -193,6 +197,7 @@ dashboard:
             - target: alias(scale(stats.timers.nodepool.task.pubcloud-iad.ComputeGetLimits.mean, '0.001'), 'IAD')
             - target: alias(scale(stats.timers.nodepool.task.pubcloud-lon.ComputeGetLimits.mean, '0.001'), 'LON')
             - target: alias(scale(stats.timers.nodepool.task.pubcloud-ord.ComputeGetLimits.mean, '0.001'), 'ORD')
+            - target: alias(scale(stats.timers.nodepool.task.phobos-nodepool.ComputeGetLimits.mean, '0.001'), 'Phobos')
     - title: Node Launches
       showTitle: true
       height: 250px
@@ -210,6 +215,7 @@ dashboard:
             - target: alias(consolidateBy(smartSummarize(stats_counts.nodepool.launch.provider.pubcloud-iad.ready, '1m'), 'sum'), 'IAD')
             - target: alias(consolidateBy(smartSummarize(stats_counts.nodepool.launch.provider.pubcloud-lon.ready, '1m'), 'sum'), 'LON')
             - target: alias(consolidateBy(smartSummarize(stats_counts.nodepool.launch.provider.pubcloud-ord.ready, '1m'), 'sum'), 'ORD')
+            - target: alias(consolidateBy(smartSummarize(stats_counts.nodepool.launch.provider.phobos-nodepool.ready, '1m'), 'sum'), 'Phobos')
         - title: Error Node Launch Attempts
           type: graph
           span: 4
@@ -223,6 +229,7 @@ dashboard:
             - target: alias(consolidateBy(smartSummarize(sumSeries(stats_counts.nodepool.launch.provider.pubcloud-iad.error.*), '1m'), 'sum'), 'IAD')
             - target: alias(consolidateBy(smartSummarize(sumSeries(stats_counts.nodepool.launch.provider.pubcloud-lon.error.*), '1m'), 'sum'), 'LON')
             - target: alias(consolidateBy(smartSummarize(sumSeries(stats_counts.nodepool.launch.provider.pubcloud-ord.error.*), '1m'), 'sum'), 'ORD')
+            - target: alias(consolidateBy(smartSummarize(sumSeries(stats_counts.nodepool.launch.provider.phobos-nodepool.error.*), '1m'), 'sum'), 'Phobos')
         - title: Time to Ready
           type: graph
           span: 4
@@ -236,9 +243,10 @@ dashboard:
             - target: alias(stats.timers.nodepool.launch.provider.pubcloud-iad.ready.mean, 'IAD')
             - target: alias(stats.timers.nodepool.launch.provider.pubcloud-lon.ready.mean, 'LON')
             - target: alias(stats.timers.nodepool.launch.provider.pubcloud-ord.ready.mean, 'ORD')
+            - target: alias(stats.timers.nodepool.launch.provider.phobos-nodepool.ready.mean, 'Phobos')
         - title: Test Nodes (DFW)
           type: graph
-          span: 3
+          span: 2
           stack: true
           tooltip:
             value_type: individual
@@ -255,7 +263,7 @@ dashboard:
               stack: False
         - title: Test Nodes (IAD)
           type: graph
-          span: 3
+          span: 2
           stack: true
           tooltip:
             value_type: individual
@@ -272,7 +280,7 @@ dashboard:
               stack: False
         - title: Test Nodes (LON)
           type: graph
-          span: 3
+          span: 2
           stack: true
           tooltip:
             value_type: individual
@@ -289,7 +297,7 @@ dashboard:
               stack: False
         - title: Test Nodes (ORD)
           type: graph
-          span: 3
+          span: 2
           stack: true
           tooltip:
             value_type: individual
@@ -301,6 +309,23 @@ dashboard:
             - target: alias(stats.gauges.nodepool.provider.pubcloud-ord.nodes.used, 'Used')
             - target: alias(stats.gauges.nodepool.provider.pubcloud-ord.nodes.deleting, 'Deleting')
             - target: alias(stats.gauges.nodepool.provider.pubcloud-ord.max_servers, 'Max')
+          seriesOverrides:
+            - alias: Max
+              stack: False
+        - title: Test Nodes (Phobos)
+          type: graph
+          span: 2
+          stack: true
+          tooltip:
+            value_type: individual
+          leftYAxisLabel: "nodes"
+          targets:
+            - target: alias(stats.gauges.nodepool.provider.phobos-nodepool.nodes.building, 'Building')
+            - target: alias(stats.gauges.nodepool.provider.phobos-nodepool.nodes.ready, 'Available')
+            - target: alias(stats.gauges.nodepool.provider.phobos-nodepool.nodes.in-use, 'In Use')
+            - target: alias(stats.gauges.nodepool.provider.phobos-nodepool.nodes.used, 'Used')
+            - target: alias(stats.gauges.nodepool.provider.phobos-nodepool.nodes.deleting, 'Deleting')
+            - target: alias(stats.gauges.nodepool.provider.phobos-nodepool.max_servers, 'Max')
           seriesOverrides:
             - alias: Max
               stack: False

--- a/nodepool/templates/nodepool.yml.j2
+++ b/nodepool/templates/nodepool.yml.j2
@@ -81,12 +81,25 @@ labels:
     min-ready: 1
     max-ready-age: 86400
 
+  # onmetal io2
+  - name: diag-ubuntu-bionic-om-io2
+    min-ready: 0
+    max-ready-age: 86400
+  - name: diag-ubuntu-xenial-om-io2
+    min-ready: 0
+    max-ready-age: 86400
+
 providers:
   - name: phobos-nodepool
     region-name: "RegionOne"
     cloud: phobos_nodepool
-    boot-timeout: 120
+    boot-timeout: 600
     hostname-format: nodepool-{label.name}-{provider.name}-{node.id}
+    cloud-images:
+      - name: baremetal-ubuntu-bionic
+        image-name: baremetal-ubuntu-bionic
+      - name: baremetal-ubuntu-bionic
+        image-name: baremetal-ubuntu-bionic
     image-name-format: nodepool-phobos-{image_name}-{timestamp}
     diskimages:
       - name: ubuntu-bionic
@@ -157,6 +170,22 @@ providers:
           - name: rpco-14.2-trusty-base
             diskimage: rpco-14.2-trusty-artifacts
             flavor-name: releng-7
+            key-name: jenkins
+            console-log: true
+      - name: onmetal
+        max-servers: 10
+        availability-zones: []
+        networks:
+          - rpc-releng-private
+        labels:
+          - name: diag-ubuntu-bionic-om-io2
+            cloud-image: baremetal-ubuntu-bionic
+            flavor-name: ironic-storage-perf
+            key-name: jenkins
+            console-log: true
+          - name: diag-ubuntu-xenial-om-io2
+            cloud-image: baremetal-ubuntu-xenial
+            flavor-name: ironic-storage-perf
             key-name: jenkins
             console-log: true
 


### PR DESCRIPTION
In order to verify the capability to use Ironic nodes
in Phobos, we add a new set of labels for them. Once
it's verified that they work we can add them to the
general pool of ubuntu-*-om-io2 nodes.

To provide visibility into what's happening in Phobos
we add the appropriate dashboard configuration.

To accommodate the new graph on the bottom row we
reduce the span size to ensure it still fits in.

Issue: [RE-2051](https://rpc-openstack.atlassian.net/browse/RE-2051)