### PR TITLE
Revert job frequency and correct nodepool config error

### DIFF
--- a/nodepool/templates/nodepool.yml.j2
+++ b/nodepool/templates/nodepool.yml.j2
@@ -98,8 +98,8 @@ providers:
     cloud-images:
       - name: baremetal-ubuntu-bionic
         image-name: baremetal-ubuntu-bionic
-      - name: baremetal-ubuntu-bionic
-        image-name: baremetal-ubuntu-bionic
+      - name: baremetal-ubuntu-xenial
+        image-name: baremetal-ubuntu-xenial
     image-name-format: nodepool-phobos-{image_name}-{timestamp}
     diskimages:
       - name: ubuntu-bionic

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -279,7 +279,6 @@
       - system
     # Required by RPC-ASC team to upload test results qTest
     credentials: "rpc_asc_creds"
-    CRON: "{CRON_WEEKLY}"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
@@ -329,7 +328,6 @@
       - system
     # Required by RPC-ASC team to upload test results qTest
     credentials: "rpc_asc_creds"
-    CRON: "{CRON_WEEKLY}"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
 
@@ -370,8 +368,7 @@
       - swift
     action:
       - deploy
-      - elk:
-          CRON: "{CRON_WEEKLY}"
+      - elk
       - sdqc
       - system
     # Required by RPC-ASC team to upload test results qTest
@@ -415,8 +412,7 @@
       - swift
     action:
       - deploy
-      - elk:
-          CRON: "{CRON_WEEKLY}"
+      - elk
       - system
     # Required by RPC-ASC team to upload test results qTest
     credentials: "rpc_asc_creds"


### PR DESCRIPTION
This reverts commit 3ec27fb.

Releases are now been processed and the resource crisis
is over, so we can revert this change.

A duplicated cloud image was put into the configuration
for Phobos, but it was supposed to be two different
images. This corrects the mistake.

Issue: [RE-2051](https://rpc-openstack.atlassian.net/browse/RE-2051)