### PR TITLE
Correct Phobos ironic network name

### DIFF
--- a/nodepool/templates/nodepool.yml.j2
+++ b/nodepool/templates/nodepool.yml.j2
@@ -176,7 +176,7 @@ providers:
         max-servers: 10
         availability-zones: []
         networks:
-          - rpc-releng-private
+          - ironic
         labels:
           - name: diag-ubuntu-bionic-om-io2
             cloud-image: baremetal-ubuntu-bionic


### PR DESCRIPTION
The previously used name was for VM's, not ironic
nodes. This corrects it to the right name.

Issue: [RE-2152](https://rpc-openstack.atlassian.net/browse/RE-2152)