### PR TITLE
RE-2085 Fix PR aborts post maintenance

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -2336,7 +2336,7 @@ Boolean willOverlapMaintenanceWindow(){
 Boolean issueExistsForNextMaintenanceWindow(project="RE"){
   LocalDateTime nextWindow = getNextMaintenanceWindowStart()
   String nextWindowDateString = nextWindow.format(DateTimeFormatter.ISO_LOCAL_DATE)
-  List issues = jira_query("project=\"${project}\" AND summary ~ '${nextWindowDateString} Maintenance Window'")
+  List issues = jira_query("project=\"${project}\" AND summary ~ '${nextWindowDateString} Maintenance Window' and STATUS not in (Finished)")
   Boolean issueExists = issues.size > 0
   if (issueExists){
     print("Issue exists for next maintenance window: ${issues[0]}")


### PR DESCRIPTION
Previously, there was no check for the status of the maintenance ticket,
so builds were still aborted even when the ticket was progressed
past doing. This commit adds a check so that once a maintenance
ticket is moved past doing it won't count towards future mainteanances.

Issue: [RE-2085](https://rpc-openstack.atlassian.net/browse/RE-2085)