### PR TITLE
RE-2083 Allow constraints leak test during maint

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -2353,7 +2353,7 @@ Boolean issueExistsForNextMaintenanceWindow(project="RE"){
 Boolean allowBuildDuringMaintenanceWindow(){
   patterns = [
     /RE-Maintenance/,
-    /RE-unit-test/,
+    /RE-unit/,
     /RPC-Gating-Unit-Tests/,
     /scratchpipeline/
   ]


### PR DESCRIPTION
A prefix match is used to determine which jobs can run during
a maintenance window. One of the existing prefixes is
RE-unit-test, which was designed to cover all the unit tests,
however the constraints leak job name starts RE-unit-venv.
This commit reduces the prefix match to RE-unit to ensure that the
constraints leak job is allowed.

Issue: [RE-2083](https://rpc-openstack.atlassian.net/browse/RE-2083)