### PR TITLE
RE-2082 Reorder maint start job

### DIFF
--- a/rpc_jobs/re_maintenance_window.yml
+++ b/rpc_jobs/re_maintenance_window.yml
@@ -72,9 +72,6 @@
           currentBuild.result = "ABORTED"
           return
         }
-        stage("Enable Quiet Down"){
-          Jenkins.get().doQuietDown()
-        }
         stage("Slack Notification"){
           if (env.SEND_SLACK_NOTIFICATIONS == "true"){
             slackSend(channel: env.SLACK_CHANNEL,
@@ -83,6 +80,9 @@
           }
         }
         println("Maintenance Window Started, go forth and betterate")
+        stage("Enable Quiet Down"){
+          Jenkins.get().doQuietDown()
+        }
       }
 
 - job:


### PR DESCRIPTION
Quiet down is moved to the end of the pipeline as nothing
can execute once quiet down is enabled.

Issue: [RE-2082](https://rpc-openstack.atlassian.net/browse/RE-2082)