### PR TITLE
Adds temporary job to capture older versions

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -261,6 +261,22 @@
     CRON: "{CRON_WEEKLY}"
 
 - project:
+    name: "rpc-upgrades-mnaio-snapcap-trusty"
+    repo_name: "rpc-upgrades"
+    repo_url: "https://github.com/rcbops/rpc-upgrades"
+    image:
+      - trusty_mnaio:
+          SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
+    scenario:
+      - swift
+    action:
+      - r13.1.3_to.r14.current_snapcap
+    jira_project_key: "RLM"
+    jobs:
+      - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+    CRON: "{CRON_WEEKLY}"
+
+- project:
     name: "rpc-upgrades"
     repo_name: "rpc-upgrades"
     repo_url: "https://github.com/rcbops/rpc-upgrades"


### PR DESCRIPTION
Captures MNAIO environment after the initial deployment of a
version has ran.  Leverages the workarounds to install an older
version so that we can create a library of older versions and
focus on just testing upgrades rather than deployment of an older
verision.

Uses snapcap as the action which skips the upgrade part of
the job and captures the image on success. Testing out with one
image to see how it works.  

The upgrade_to is ignored but the format is left as is to avoid making a lot of changes to the existing process.

Relies on https://github.com/rcbops/rpc-upgrades/pull/276