### PR TITLE
RE-2000 Quote JQL terms that may contain - or _

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -960,7 +960,8 @@ String get_or_create_jira_issue(String project,
                                 String status = "BACKLOG",
                                 String summary,
                                 String description,
-                                List labels = []){
+                                List labels = [],
+                                Boolean debug=false){
   withCredentials([
     usernamePassword(
       credentialsId: "jira_user_pass",
@@ -968,12 +969,13 @@ String get_or_create_jira_issue(String project,
       passwordVariable: "JIRA_PASS"
     )
   ]){
+    String debugString = debug ? "--debug" : ""
     return sh (script: """#!/bin/bash -xe
       cd ${env.WORKSPACE}
       set +x; . .venv/bin/activate; set -x
       python rpc-gating/scripts/jirautils.py \
         --user '$JIRA_USER' \
-        --password '$JIRA_PASS' \
+        --password '$JIRA_PASS' ${debugString} \
         get_or_create_issue \
           --status "${status}" \
           --summary "${summary}" \

--- a/scripts/jirautils.py
+++ b/scripts/jirautils.py
@@ -52,8 +52,8 @@ def _get_or_create_issue(project, status, labels, description, summary):
     issue = None
 
     # Check for existing issues
-    query = ("{label_terms} AND project = \"{p}\" AND status = {s}"
-             " AND summary ~\"{summary}\""
+    query = (r'{label_terms} AND project = "{p}" AND status = {s}'
+             r' AND summary ~"\"{summary}\""'
              .format(label_terms=get_label_query_terms(labels),
                      p=project, s=status, summary=summary))
     issues = issues_for_query(query)
@@ -70,6 +70,9 @@ def _get_or_create_issue(project, status, labels, description, summary):
                          il=",".join(i.key for i in issues),
                          i=issue))
     else:
+        LOGGER.debug("Query: {q} Returned 0 issues. "
+                     .format(q=query))
+
         issue = _create_issue(
             summary=summary,
             description=description,


### PR DESCRIPTION
Jira processes string search terms including translating underscores
to spaces. To prevent this, much quoting is required.

Issue: [RE-2000](https://rpc-openstack.atlassian.net/browse/RE-2000)