### PR TITLE
Use Phobos ironic nodes for MNAIO tests

### DIFF
--- a/nodepool/templates/nodepool.yml.j2
+++ b/nodepool/templates/nodepool.yml.j2
@@ -84,14 +84,6 @@ labels:
     min-ready: 1
     max-ready-age: 86400
 
-  # onmetal io2
-  - name: diag-ubuntu-bionic-om-io2
-    min-ready: 0
-    max-ready-age: 86400
-  - name: diag-ubuntu-xenial-om-io2
-    min-ready: 0
-    max-ready-age: 86400
-
 providers:
   - name: phobos-nodepool
     region-name: "RegionOne"
@@ -181,12 +173,12 @@ providers:
         networks:
           - ironic
         labels:
-          - name: diag-ubuntu-bionic-om-io2
+          - name: ubuntu-bionic-om-io2
             cloud-image: baremetal-ubuntu-bionic
             flavor-name: ironic-storage-perf
             key-name: jenkins
             console-log: true
-          - name: diag-ubuntu-xenial-om-io2
+          - name: ubuntu-xenial-om-io2
             cloud-image: baremetal-ubuntu-xenial
             flavor-name: ironic-storage-perf
             key-name: jenkins


### PR DESCRIPTION
Now that we've verified that the Phobos ironic nodes are
usable in the same way as the public cloud OnMetal nodes,
we can add them to the same label.

Issue: [RE-2152](https://rpc-openstack.atlassian.net/browse/RE-2152)