### PR TITLE
RE-2061 Ignore non pr failures on maint tickets

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -2502,7 +2502,9 @@ void restartAbortedPRBuilds(String maint_date="today"){
   for (comment in comments){
     try {
       Map pr_data = _parse_json_string(json_text: comment)
-      prsWithFailures[pr_data['link']] = pr_data
+      if (pr_data['link'] != null){
+        prsWithFailures[pr_data['link']] = pr_data
+      }
     } catch (groovy.json.JsonException e){
       print("Ignoring non-json comment: ${comment}")
     }


### PR DESCRIPTION
At the end of a maintenance the mainteance-end job attempts to recheck
all PR builds that were aborted due to the maintenance. This process
fails if any non-pr builds are reported, as the PR related fields are
null.

This PR ensures that non-pr failures are safely skipped when rechecking
PRs after a maintenance.

Issue: [RE-2061](https://rpc-openstack.atlassian.net/browse/RE-2061)