### PR TITLE
Reduce LON region OnMetal max-servers to 5

### DIFF
--- a/nodepool/templates/nodepool.yml.j2
+++ b/nodepool/templates/nodepool.yml.j2
@@ -287,7 +287,7 @@ providers:
       - name: onmetal
         # Ignore the quota given by public cloud and only respect what we provide as max-servers
         ignore-provider-quota: true
-        max-servers: 10
+        max-servers: 5
         availability-zones: []
         labels: &provider_pools_onmetal_labels_block
           - name: ubuntu-bionic-om-io2


### PR DESCRIPTION
As agreed with our public cloud friends, we reduce the
OnMetal max-servers for the LON region down to 5 now that
we have Phobos ironic nodes online.

Issue: [RE-2152](https://rpc-openstack.atlassian.net/browse/RE-2152)