### PR TITLE
Add RE_JOB_PROJECT_NAME environment variable

### DIFF
--- a/gating/check/run
+++ b/gating/check/run
@@ -1,3 +1,3 @@
 #!/bin/bash -xeu
 
-gating/common/run_${RE_JOB_SCENARIO}.sh
+gating/common/run_${RE_JOB_SCENARIO}.*

--- a/gating/common/run_standard_job_pre_merge.py
+++ b/gating/common/run_standard_job_pre_merge.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+from os import environ
+import unittest
+
+
+class TestREJobEnv(unittest.TestCase):
+    def setUp(self):
+        self.expected_env_vars = {
+            "RE_JOB_ACTION": "test",
+            "RE_JOB_FLAVOR": "performance1-1",
+            "RE_JOB_IMAGE": "xenial",
+            "RE_JOB_NAME": "gating-pre-merge",
+            "RE_JOB_PROJECT_NAME": "gating-pre-merge",
+            "RE_JOB_REPO_NAME": "rpc-gating",
+            "RE_JOB_SCENARIO": "standard_job_pre_merge",
+            "RE_JOB_TRIGGER": "PULL",
+            "RE_JOB_TRIGGER_DETAIL": "{title}/{pull_id}".format(
+                title=environ.get("ghprbPullTitle"),
+                pull_id=environ.get("ghprbPullId"),
+            ),
+        }
+        self.system_env_vars = {k: v for k, v in environ.items()}
+
+    def test_all_env_vars_expected(self):
+        self.assertSetEqual(
+            set(self.expected_env_vars),
+            set(v for v in self.system_env_vars if v.startswith("RE_JOB_"))
+        )
+
+    def test_env_vars_values(self):
+        for name, expected_value in self.expected_env_vars.items():
+            self.assertEqual(expected_value, self.system_env_vars[name])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -9,10 +9,12 @@
     branches:
       - "master"
     image:
-      - "xenial":
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+      - "xenial"
     scenario:
-      - "lint"
+      - "lint":
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+      - "standard_job_pre_merge":
+          SLAVE_TYPE: "container"
     action:
       - "test"
     jobs:
@@ -39,6 +41,7 @@
             STAGES="Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
             BOOT_TIMEOUT={BOOT_TIMEOUT}
             RE_JOB_NAME={name}
+            RE_JOB_PROJECT_NAME={name}
             RE_JOB_IMAGE={image}
             RE_JOB_SCENARIO={scenario}
             RE_JOB_ACTION={action}


### PR DESCRIPTION
RE_JOB_NAME currently binds to the name of the JJB project and not the
name of the job. To enable this to be correct, this change adds the new
variable RE_JOB_PROJECT_NAME to allow existing uses of RE_JOB_NAME to be
switched to using RE_JOB_PROJECT_NAME before updating RE_JOB_NAME to the
correct value.

This change adds a new pre-merge test job for rpc-gating to test that
the `RE_JOB_.*` environment variables are defined as expected.

Issue: [RE-2031](https://rpc-openstack.atlassian.net/browse/RE-2031)