### PR TITLE
RE-2184 Switch MK8s Checkmarx jobs to ssh clones

### DIFF
--- a/job_dsl/standard_job_checkmarx.groovy
+++ b/job_dsl/standard_job_checkmarx.groovy
@@ -75,10 +75,10 @@ common.globalWraps(){
                   sourceEncoding: '1',
                   username: '',
                   vulnerabilityThresholdEnabled: true,
-                  highThreshold: 1,
+                  highThreshold: 0,
                   includeOpenSourceFolders: '',
-                  lowThreshold: 1,
-                  mediumThreshold: 1,
+                  lowThreshold: 0,
+                  mediumThreshold: 0,
                   vulnerabilityThresholdResult: 'FAILURE',
                   waitForResultsEnabled: true])
           } // dir

--- a/rpc_jobs/mk8s.yml
+++ b/rpc_jobs/mk8s.yml
@@ -8,13 +8,13 @@
       - PM
     repo_name:
       - mk8s:
-          repo_url: "https://github.com/rcbops/mk8s"
+          repo_url: "git@github.com:rcbops/mk8s"
           branch: master
-      - rackspace-harbor:
-          repo_url: "https://github.com/rcbops/rackspace-harbor"
+      - kubernetes-harbor:
+          repo_url: "git@github.com:rcbops/kubernetes-harbor"
           branch: master
       - rackspace-monitoring-agent-coreos:
-          repo_url: "https://github.com/rcbops/rackspace-monitoring-agent-coreos"
+          repo_url: "git@github.com:rcbops/rackspace-monitoring-agent-coreos"
           branch: master
     jobs:
       - '{trigger}-Checkmarx_{scan_type}-{repo_name}'


### PR DESCRIPTION
This allows keys to be used to access private repos.

Also set thresholds to 0 not 1, so that any vulnerability causes a scan to fail. 

Issue: [RE-2184](https://rpc-openstack.atlassian.net/browse/RE-2184)