### PR TITLE
RE-2184 Make Checkmarx consumable from pipelines

### DIFF
--- a/job_dsl/standard_job_checkmarx.groovy
+++ b/job_dsl/standard_job_checkmarx.groovy
@@ -19,71 +19,12 @@ common.globalWraps(){
       }
 
       stage("Checkmarx Scan"){
-        withCredentials([
-          string(
-            credentialsId: 'CHECKMARX_RE_TEAM_ID',
-            variable: 'groupId'
-          ),
-          string(
-            credentialsId: 'CHECKMARX_SERVER',
-            variable: 'serverUrl'
-          )
-        ]){
-          // Switch to scan repo dir to avoid sending the gating venv to checkmarx
-          dir("repo"){
-            presets = [
-              // values generated using the snippet generator
-              // ${jenkins}/pipeline-syntax/
-              // sample step > step: general build step
-              //    Build Step > Execute Checkmarx Scan
-              "default": "36",
-              "pci": "5",
-              "all": "1"
-            ]
-            if (!presets.keySet().contains(SCAN_TYPE)){
-              throw new Exception("Invalid scan type: ${SCAN_TYPE}, should be default or pci")
-            }
-            step([$class: 'CxScanBuilder',
-                  avoidDuplicateProjectScans: false, // duplicate detection isn't great and kills scans of the same project with different parameters
-                  comment: '',
-                  credentialsId: '',
-                  excludeFolders: '',
-                  excludeOpenSourceFolders: '',
-                  exclusionsSetting: 'global',
-                  failBuildOnNewResults: true,
-                  failBuildOnNewSeverity: 'LOW',
-                  filterPattern: '''!**/_cvs/**/*, !**/.svn/**/*,   !**/.hg/**/*,   !**/.git/**/*,  !**/.bzr/**/*, !**/bin/**/*,
-                  !**/obj/**/*,  !**/backup/**/*, !**/.idea/**/*, !**/*.DS_Store, !**/*.ipr,     !**/*.iws,
-                  !**/*.bak,     !**/*.tmp,       !**/*.aac,      !**/*.aif,      !**/*.iff,     !**/*.m3u, !**/*.mid, !**/*.mp3,
-                  !**/*.mpa,     !**/*.ra,        !**/*.wav,      !**/*.wma,      !**/*.3g2,     !**/*.3gp, !**/*.asf, !**/*.asx,
-                  !**/*.avi,     !**/*.flv,       !**/*.mov,      !**/*.mp4,      !**/*.mpg,     !**/*.rm,  !**/*.swf, !**/*.vob,
-                  !**/*.wmv,     !**/*.bmp,       !**/*.gif,      !**/*.jpg,      !**/*.png,     !**/*.psd, !**/*.tif, !**/*.swf,
-                  !**/*.jar,     !**/*.zip,       !**/*.rar,      !**/*.exe,      !**/*.dll,     !**/*.pdb, !**/*.7z,  !**/*.gz,
-                  !**/*.tar.gz,  !**/*.tar,       !**/*.gz,       !**/*.ahtm,     !**/*.ahtml,   !**/*.fhtml, !**/*.hdm,
-                  !**/*.hdml,    !**/*.hsql,      !**/*.ht,       !**/*.hta,      !**/*.htc,     !**/*.htd, !**/*.war, !**/*.ear,
-                  !**/*.htmls,   !**/*.ihtml,     !**/*.mht,      !**/*.mhtm,     !**/*.mhtml,   !**/*.ssi, !**/*.stm,
-                  !**/*.stml,    !**/*.ttml,      !**/*.txn,      !**/*.xhtm,     !**/*.xhtml,   !**/*.class, !**/*.iml, !Checkmarx/Reports/*.*''',
-                  fullScanCycle: 10,
-                  generatePdfReport: true,
-                  groupId: groupId,
-                  includeOpenSourceFolders: '',
-                  osaArchiveIncludePatterns: '*.zip, *.war, *.ear, *.tgz',
-                  password: '',
-                  preset: presets[SCAN_TYPE],
-                  projectName: repo_name,
-                  serverUrl: serverUrl,
-                  sourceEncoding: '1',
-                  username: '',
-                  vulnerabilityThresholdEnabled: true,
-                  highThreshold: 0,
-                  includeOpenSourceFolders: '',
-                  lowThreshold: 0,
-                  mediumThreshold: 0,
-                  vulnerabilityThresholdResult: 'FAILURE',
-                  waitForResultsEnabled: true])
-          } // dir
-        } // withCredentials
+        // Switch to scan repo dir to avoid sending the gating venv to checkmarx
+        dir("repo"){
+          checkmarx.scan(scan_type, repo_name)
+        } // dir
       } // stage
+
     } catch(e) {
       print(e)
       // Only create failure card when run as a post-merge job

--- a/pipeline_steps/checkmarx.groovy
+++ b/pipeline_steps/checkmarx.groovy
@@ -1,0 +1,68 @@
+// Upload all folders in the current working directory to checkmarx and scan for vulnerabilities.
+// If you wish to scan a subdir of the working dir, call this function within dir("subdir"){}
+def scan(String scan_type, String repo_name){
+    withCredentials([
+        string(
+            credentialsId: 'CHECKMARX_RE_TEAM_ID',
+            variable: 'groupId'
+        ),
+        string(
+            credentialsId: 'CHECKMARX_SERVER',
+            variable: 'serverUrl'
+        )
+    ]){
+        presets = [
+        // values generated using the snippet generator
+        // ${jenkins}/pipeline-syntax/
+        // sample step > step: general build step
+        //    Build Step > Execute Checkmarx Scan
+        "default": "36",
+        "pci": "5",
+        "all": "1"
+        ]
+        if (!presets.keySet().contains(scan_type)){
+            throw new Exception("Invalid scan type: ${scan_type}, should be default or pci")
+        }
+        step([$class: 'CxScanBuilder',
+            avoidDuplicateProjectScans: false, // duplicate detection isn't great and kills scans of the same project with different parameters
+            comment: '',
+            credentialsId: '',
+            excludeFolders: '',
+            excludeOpenSourceFolders: '',
+            exclusionsSetting: 'global',
+            failBuildOnNewResults: true,
+            failBuildOnNewSeverity: 'LOW',
+            filterPattern: '''!**/_cvs/**/*, !**/.svn/**/*,   !**/.hg/**/*,   !**/.git/**/*,  !**/.bzr/**/*, !**/bin/**/*,
+            !**/obj/**/*,  !**/backup/**/*, !**/.idea/**/*, !**/*.DS_Store, !**/*.ipr,     !**/*.iws,
+            !**/*.bak,     !**/*.tmp,       !**/*.aac,      !**/*.aif,      !**/*.iff,     !**/*.m3u, !**/*.mid, !**/*.mp3,
+            !**/*.mpa,     !**/*.ra,        !**/*.wav,      !**/*.wma,      !**/*.3g2,     !**/*.3gp, !**/*.asf, !**/*.asx,
+            !**/*.avi,     !**/*.flv,       !**/*.mov,      !**/*.mp4,      !**/*.mpg,     !**/*.rm,  !**/*.swf, !**/*.vob,
+            !**/*.wmv,     !**/*.bmp,       !**/*.gif,      !**/*.jpg,      !**/*.png,     !**/*.psd, !**/*.tif, !**/*.swf,
+            !**/*.jar,     !**/*.zip,       !**/*.rar,      !**/*.exe,      !**/*.dll,     !**/*.pdb, !**/*.7z,  !**/*.gz,
+            !**/*.tar.gz,  !**/*.tar,       !**/*.gz,       !**/*.ahtm,     !**/*.ahtml,   !**/*.fhtml, !**/*.hdm,
+            !**/*.hdml,    !**/*.hsql,      !**/*.ht,       !**/*.hta,      !**/*.htc,     !**/*.htd, !**/*.war, !**/*.ear,
+            !**/*.htmls,   !**/*.ihtml,     !**/*.mht,      !**/*.mhtm,     !**/*.mhtml,   !**/*.ssi, !**/*.stm,
+            !**/*.stml,    !**/*.ttml,      !**/*.txn,      !**/*.xhtm,     !**/*.xhtml,   !**/*.class, !**/*.iml, !Checkmarx/Reports/*.*''',
+            fullScanCycle: 10,
+            generatePdfReport: true,
+            groupId: groupId,
+            includeOpenSourceFolders: '',
+            osaArchiveIncludePatterns: '*.zip, *.war, *.ear, *.tgz',
+            password: '',
+            preset: presets[scan_type],
+            projectName: repo_name,
+            serverUrl: serverUrl,
+            sourceEncoding: '1',
+            username: '',
+            vulnerabilityThresholdEnabled: true,
+            highThreshold: 0,
+            includeOpenSourceFolders: '',
+            lowThreshold: 0,
+            mediumThreshold: 0,
+            vulnerabilityThresholdResult: 'FAILURE',
+            waitForResultsEnabled: true]
+        )
+    } // withCredentials
+}
+
+return this

--- a/rpc_jobs/standard_job_checkmarx.yml
+++ b/rpc_jobs/standard_job_checkmarx.yml
@@ -47,7 +47,7 @@
           default: "{branch}"
           description: "Branch of repo to checkout before scanning"
       - string:
-          name: "SCAN_TYPE"
+          name: "scan_type"
           default: "{scan_type}"
           description: |
             default or pci


### PR DESCRIPTION
This commit moves the defaults and scan call out of the standard
Checkmarx job into a library function that can be used in any job.
This will allow teams such as MK8s to intergrate Checkmarx scans
with their existing pipelines.

Issue: [RE-2184](https://rpc-openstack.atlassian.net/browse/RE-2184)