### PR TITLE
Remove MaaS Nodepool node types

### DIFF
--- a/nodepool/templates/nodepool.yml.j2
+++ b/nodepool/templates/nodepool.yml.j2
@@ -12,23 +12,6 @@ zookeeper-servers:
 {% endfor %}
 
 labels:
-  # MaaS jobs expect a MaaS entity to be provided for each node. Public cloud provides
-  # entities but phobos does not. Consequently MaaS jobs fail on phobos. (RE-1954)
-  # This was initially solved by disabling phobos. In order to re-enable phobos,
-  # maas specific labels are introduced that draw from all regions except phobos.
-  - name: maas-ubuntu-bionic-g1-8
-    min-ready: 0
-    max-ready-age: 86400
-  - name: maas-ubuntu-xenial-g1-8
-    min-ready: 0
-    max-ready-age: 86400
-  - name: maas-ubuntu-trusty-g1-8
-    min-ready: 0
-    max-ready-age: 86400
-  - name: maas-ubuntu-xenial-p2-15
-    min-ready: 0
-    max-ready-age: 86400
-
   # rpco snapshots
   - name: rpc-r14-xenial_loose_artifacts-swift
     min-ready: 1
@@ -216,28 +199,6 @@ providers:
         max-servers: 20
         availability-zones: []
         labels: &provider_pools_main_labels_block
-          #MaaS
-          - name: maas-ubuntu-bionic-g1-8
-            diskimage: ubuntu-bionic
-            flavor-name: general1-8
-            key-name: jenkins
-            console-log: true
-          - name: maas-ubuntu-xenial-g1-8
-            diskimage: ubuntu-xenial
-            flavor-name: general1-8
-            key-name: jenkins
-            console-log: true
-          - name: maas-ubuntu-trusty-g1-8
-            diskimage: ubuntu-trusty
-            flavor-name: general1-8
-            key-name: jenkins
-            console-log: true
-          - name: maas-ubuntu-xenial-p2-15
-            diskimage: ubuntu-xenial
-            flavor-name: performance2-15
-            key-name: jenkins
-            console-log: true
-
           #g1-8
           - name: ubuntu-bionic-g1-8
             diskimage: ubuntu-bionic

--- a/rpc_jobs/rpc_maas.yml
+++ b/rpc_jobs/rpc_maas.yml
@@ -43,7 +43,7 @@
       - "bionic"
     scenario:
       - rocky:
-          SLAVE_TYPE: "nodepool-maas-ubuntu-bionic-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-bionic-g1-8"
     action:
       - "deploy"
     credentials: "cloud_creds"
@@ -69,21 +69,21 @@
       - "xenial"
     scenario:
       - master:
-          SLAVE_TYPE: "nodepool-maas-ubuntu-xenial-p2-15"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-p2-15"
           TRIGGER_PR_PHRASE_ONLY: true
       - rocky:
-          SLAVE_TYPE: "nodepool-maas-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
       - queens:
-          SLAVE_TYPE: "nodepool-maas-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
       - pike:
-          SLAVE_TYPE: "nodepool-maas-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
       - ocata:
-          SLAVE_TYPE: "nodepool-maas-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
           TRIGGER_PR_PHRASE_ONLY: true
       - newton:
-          SLAVE_TYPE: "nodepool-maas-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
       - ceph:
-          SLAVE_TYPE: "nodepool-maas-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
     action:
       - "deploy"
     credentials: "cloud_creds"
@@ -107,7 +107,7 @@
       | ^gating/release/
     image:
       - trusty:
-          SLAVE_TYPE: "nodepool-maas-ubuntu-trusty-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-trusty-g1-8"
     scenario:
       - newton
       - mitaka
@@ -161,7 +161,7 @@
 #      | ^gating/release/
 #    image:
 #      - "xenial":
-#          SLAVE_TYPE: "nodepool-maas-ubuntu-xenial-g1-8"
+#          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
 #    scenario:
 #      - pike
 #      - newton
@@ -187,7 +187,7 @@
 #      | ^gating/release/
 #    image:
 #      - "trusty":
-#          SLAVE_TYPE: "nodepool-maas-ubuntu-trusty-g1-8"
+#          SLAVE_TYPE: "nodepool-ubuntu-trusty-g1-8"
 #    scenario:
 #      - newton
 #    action:
@@ -203,7 +203,7 @@
     branch: "master"
     image:
       - "xenial":
-          SLAVE_TYPE: "nodepool-maas-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
     scenario:
       - rocky
       - queens
@@ -223,7 +223,7 @@
     branch: "master"
     image:
       - "trusty":
-          SLAVE_TYPE: "nodepool-maas-ubuntu-trusty-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-trusty-g1-8"
     scenario:
       - newton
     action:
@@ -240,7 +240,7 @@
     CRON: "{CRON_DAILY}"
     image:
       - "xenial":
-          SLAVE_TYPE: "nodepool-maas-ubuntu-xenial-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
     scenario:
       - queens
       - pike
@@ -260,7 +260,7 @@
     CRON: "{CRON_DAILY}"
     image:
       - "trusty":
-          SLAVE_TYPE: "nodepool-maas-ubuntu-trusty-g1-8"
+          SLAVE_TYPE: "nodepool-ubuntu-trusty-g1-8"
     scenario:
       - newton
     action:


### PR DESCRIPTION
rpc-maas is now able to test the API on Phobos and so it is no longer
necessary to provide separate nodes to cater for its needs. This change
removes the node definitions and updates the projects using them to
instead use the original versions.

JIRA: RE-1782

Issue: [RE-1782](https://rpc-openstack.atlassian.net/browse/RE-1782)