### PR TITLE
RI-547 RPC-Openstack rocky checkmarx

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -644,8 +644,11 @@
       - all
       - pci
     repo_name:
-      - rpc-openstack:
+      - rpc-openstack-master:
           repo_url: "https://github.com/rcbops/rpc-openstack"
           branch: master
+      - rpc-openstack-rocky:
+          repo_url: "https://github.com/rcbops/rpc-openstack"
+          branch: rocky
     jobs:
       - '{trigger}-Checkmarx_{scan_type}-{repo_name}'


### PR DESCRIPTION
Marked out known false alarm and changed the rule based on
master check. Adding rocky check.

Issue: [RI-547](https://rpc-openstack.atlassian.net/browse/RI-547)