### PR TITLE
Adding RE job for RPC-UAM

### DIFF
--- a/rpc_jobs/rpc_uam.yml
+++ b/rpc_jobs/rpc_uam.yml
@@ -1,0 +1,15 @@
+### test checkmarx against UAM
+- project:
+    name: 'rpc-uam-checkmarx'
+    jira_project_key: "FLEEK"
+    trigger:
+      - PM
+    scan_type:
+      - all
+      - pci
+    repo_name:
+      - rpc-uam:
+          repo_url: "git@github.com:rcbops/rpc-uam"
+          branch: master
+    jobs:
+      - '{trigger}-Checkmarx_{scan_type}-{repo_name}'


### PR DESCRIPTION
rpc-uam is added to RE jobs to run checkmarx
against the repository code