### PR TITLE
MAINT - Add back RE_JOB_PROJECT_NAME to post merge

### DIFF
--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -63,6 +63,7 @@
             RE_JOB_FLAVOR={FLAVOR}
             RE_JOB_REPO_NAME={repo_name}
             RE_JOB_BRANCH={branch}
+            RE_JOB_PROJECT_NAME={name}
     parameters:
       - rpc_gating_params
       - instance_params:


### PR DESCRIPTION
This commit adds back the `RE_JOB_PROJECT_NAME` variable to the post
merge template.