### PR TITLE
Fix Jenkins-Job-Builder name

### DIFF
--- a/rpc_jobs/jjb_setup.yml
+++ b/rpc_jobs/jjb_setup.yml
@@ -1,12 +1,11 @@
 - project:
     name: "Jenkins-Job-Builder"
-    branch: "master"
     jobs:
-      - "Jenkins-Job-Builder-{branch}"
+      - "Jenkins-Job-Builder"
 
 # A template is required to allow rpc_jobs/defaults.yml to be used.
 - job-template:
-    name: "Jenkins-Job-Builder-{branch}"
+    name: "Jenkins-Job-Builder"
     project-type: workflow
     description: Creates and updates jobs with Jenkins Job Builder.
     properties:


### PR DESCRIPTION
Jenkins-Job-Builder was changed to Jenkins-Job-Builder-master, because
the job was changed to a template however the name to not need to be
parameterised for it to work. Changing this back because the name change
broke the merge trigger job and is unnecessary.

JIRA: RE-2069

Issue: [RE-2069](https://rpc-openstack.atlassian.net/browse/RE-2069)