### PR TITLE
RE-2211 Remove time triggers from mainteannce jobs

### DIFF
--- a/rpc_jobs/re_maintenance_window.yml
+++ b/rpc_jobs/re_maintenance_window.yml
@@ -56,8 +56,6 @@
     properties:
       - build-discarder:
           num-to-keep: 30
-    triggers:
-      - timed: "0 10 * * 1"
     sandbox: false
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
@@ -104,8 +102,6 @@
     properties:
       - build-discarder:
           num-to-keep: 30
-    triggers:
-      - timed: "0 12 * * 1"
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
       common.globalWraps(){


### PR DESCRIPTION
This gives more flexibility around mainteannce windows, they are unlikely
to take exactly the prescribed time.