### PR TITLE
Fix RE_JOB_NAME value

### DIFF
--- a/gating/common/run_standard_job_pre_merge.py
+++ b/gating/common/run_standard_job_pre_merge.py
@@ -10,7 +10,9 @@ class TestREJobEnv(unittest.TestCase):
             "RE_JOB_ACTION": "test",
             "RE_JOB_FLAVOR": "performance1-1",
             "RE_JOB_IMAGE": "xenial",
-            "RE_JOB_NAME": "gating-pre-merge",
+            "RE_JOB_NAME": (
+                "PR_rpc-gating-master-xenial-standard_job_pre_merge-test"
+            ),
             "RE_JOB_PROJECT_NAME": "gating-pre-merge",
             "RE_JOB_REPO_NAME": "rpc-gating",
             "RE_JOB_SCENARIO": "standard_job_pre_merge",

--- a/rpc_jobs/standard_job_checkmarx.yml
+++ b/rpc_jobs/standard_job_checkmarx.yml
@@ -22,7 +22,7 @@
       - inject:
           properties-content: |
             JIRA_PROJECT_KEY={jira_project_key}
-            RE_JOB_NAME={name}
+            RE_JOB_NAME=${{JOB_NAME}}
             RE_JOB_REPO_NAME={repo_name}
     triggers:
       - timed: "{CRON}"

--- a/rpc_jobs/standard_job_dep_update.yml
+++ b/rpc_jobs/standard_job_dep_update.yml
@@ -26,7 +26,7 @@
           properties-content: |
             BOOT_TIMEOUT=900
             JIRA_PROJECT_KEY={jira_project_key}
-            RE_JOB_NAME={name}
+            RE_JOB_NAME=${{JOB_NAME}}
             RE_JOB_REPO_NAME={repo_name}
             STAGES="Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
     triggers:

--- a/rpc_jobs/standard_job_gate.yml
+++ b/rpc_jobs/standard_job_gate.yml
@@ -54,7 +54,7 @@
           properties-content: |
             STAGES="Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
             BOOT_TIMEOUT={BOOT_TIMEOUT}
-            RE_JOB_NAME={name}
+            RE_JOB_NAME=${{JOB_NAME}}
             RE_JOB_IMAGE={image}
             RE_JOB_SCENARIO={scenario}
             RE_JOB_ACTION={action}

--- a/rpc_jobs/standard_job_lint_jenkins.yml
+++ b/rpc_jobs/standard_job_lint_jenkins.yml
@@ -23,7 +23,7 @@
           properties-content: |
             BOOT_TIMEOUT=900
             JIRA_PROJECT_KEY={jira_project_key}
-            RE_JOB_NAME={name}
+            RE_JOB_NAME=${{JOB_NAME}}
             RE_JOB_REPO_NAME={repo_name}
             STAGES="Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
     triggers:

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -56,7 +56,7 @@
           properties-content: |
             STAGES="Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
             BOOT_TIMEOUT={BOOT_TIMEOUT}
-            RE_JOB_NAME={name}
+            RE_JOB_NAME=${{JOB_NAME}}
             RE_JOB_IMAGE={image}
             RE_JOB_SCENARIO={scenario}
             RE_JOB_ACTION={action}

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -40,7 +40,7 @@
           properties-content: |
             STAGES="Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
             BOOT_TIMEOUT={BOOT_TIMEOUT}
-            RE_JOB_NAME={name}
+            RE_JOB_NAME=${{JOB_NAME}}
             RE_JOB_PROJECT_NAME={name}
             RE_JOB_IMAGE={image}
             RE_JOB_SCENARIO={scenario}

--- a/rpc_jobs/standard_job_release.yml
+++ b/rpc_jobs/standard_job_release.yml
@@ -196,7 +196,7 @@
           properties-content: |
             STAGES="Allocate Resources, Connect Slave, Cleanup, Destroy Slave"
             BOOT_TIMEOUT={BOOT_TIMEOUT}
-            RE_JOB_NAME={name}
+            RE_JOB_NAME=${{JOB_NAME}}
             RE_JOB_IMAGE={image}
             RE_JOB_SCENARIO={scenario}
             RE_JOB_ACTION={action}


### PR DESCRIPTION
This change fixes RE_JOB_NAME to ensure it is bound to the name of the
job and not the name of the project. The job name does not appear to be
available when using jenkins-jobs and so this change makes use of the
environment variable JOB_NAME to set RE_JOB_NAME to the correct value.

JIRA: RE-2031

Issue: [RE-2031](https://rpc-openstack.atlassian.net/browse/RE-2031)