### PR TITLE
Reduce retention and leave logs uncompressed for 5 days

### DIFF
--- a/rpc_jobs/build_summary.yml
+++ b/rpc_jobs/build_summary.yml
@@ -11,7 +11,7 @@
       - rpc_gating_params
     properties:
       - build-discarder:
-          days-to-keep: 30
+          days-to-keep: 10
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
       common.globalWraps(){

--- a/rpc_jobs/bump_snapshots.yml
+++ b/rpc_jobs/bump_snapshots.yml
@@ -4,7 +4,7 @@
     concurrent: false
     properties:
       - build-discarder:
-          days-to-keep: 30
+          days-to-keep: 10
     parameters:
       - rpc_gating_params
     triggers:

--- a/rpc_jobs/influx.yml
+++ b/rpc_jobs/influx.yml
@@ -4,7 +4,7 @@
     concurrent: false
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 10
     parameters:
       # See params.yml
       - rpc_gating_params

--- a/rpc_jobs/jjb_setup.yml
+++ b/rpc_jobs/jjb_setup.yml
@@ -10,7 +10,7 @@
     description: Creates and updates jobs with Jenkins Job Builder.
     properties:
       - build-discarder:
-          days-to-keep: 20
+          days-to-keep: 7
     parameters:
         - rpc_gating_params
         - jjb_params:

--- a/rpc_jobs/long_running_slave.yml
+++ b/rpc_jobs/long_running_slave.yml
@@ -4,7 +4,7 @@
     concurrent: true
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 10
     parameters:
       # See params.yml
       - rpc_gating_params

--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -109,7 +109,10 @@
             // Note that already compressed logs will be skipped as they
             // get renamed .gz .
             // Logs newer than 1 day are skipped to prevent compressing
-            // the logs from running builds.
+            // the logs from running builds. Unfortunately the core code
+            // which enables jenkins to read compressed logs has a bug,
+            // so we've had to set compression to only happen after 5
+            // days. ref RE-2215
             sh """#!/bin/bash
               cd /var/lib/jenkins/jobs
               while read stagelog; do
@@ -126,7 +129,7 @@
                     echo "gzip file \$stagelog failed with a non-zero response code of: \$_rc. Setting job stage response code to: \$_rc. This will fail the stage."
                     rc=\$_rc
                   fi
-              done < <(find . -regex '.+/builds/[0-9]+/\\([0-9]+\\.\\)?log' -mtime +1)
+              done < <(find . -regex '.+/builds/[0-9]+/\\([0-9]+\\.\\)?log' -mtime +5)
               exit \${rc:-0}
             """
           }

--- a/rpc_jobs/phobos.yml
+++ b/rpc_jobs/phobos.yml
@@ -4,7 +4,7 @@
     concurrent: false
     properties:
       - build-discarder:
-          num-to-keep: 60
+          num-to-keep: 10
     triggers:
       # Starting between 04:00-05:00 UTC every Monday and Thursday
       - timed: "H 4 * * 1,4"

--- a/rpc_jobs/pull_request_whisperer.yml
+++ b/rpc_jobs/pull_request_whisperer.yml
@@ -27,7 +27,7 @@
       - github:
           url: "{repo_url}"
       - build-discarder:
-          days-to-keep: 7
+          days-to-keep: 2
     parameters:
       - rpc_gating_params
       - text:

--- a/rpc_jobs/re_maintenance_window.yml
+++ b/rpc_jobs/re_maintenance_window.yml
@@ -5,7 +5,7 @@
       - rpc_gating_params
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 10
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
       common.globalWraps(){
@@ -55,7 +55,7 @@
       - maintenance_params
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 10
     sandbox: false
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
@@ -101,7 +101,7 @@
             job aborted due to the maintenance.
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 10
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"
       common.globalWraps(){

--- a/rpc_jobs/re_release_manual.yml
+++ b/rpc_jobs/re_release_manual.yml
@@ -12,7 +12,7 @@
     concurrent: false
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 10
     parameters:
       - rpc_gating_params
       - standard_job_params:

--- a/rpc_jobs/repo_server.yml
+++ b/rpc_jobs/repo_server.yml
@@ -4,7 +4,7 @@
     concurrent: false
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 10
     parameters:
       - rpc_gating_params
     triggers:

--- a/rpc_jobs/rpc_artifact_build.yml
+++ b/rpc_jobs/rpc_artifact_build.yml
@@ -12,7 +12,7 @@
     concurrent: true
     properties:
       - build-discarder:
-          num-to-keep: "30"
+          num-to-keep: 10
       - rpc-openstack-github
     parameters:
       # See params.yml

--- a/rpc_jobs/rpc_gating.yml
+++ b/rpc_jobs/rpc_gating.yml
@@ -5,7 +5,7 @@
     properties:
       - rpc-gating-github
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 10
     triggers:
         - github
     parameters:

--- a/rpc_jobs/setup_infra.yml
+++ b/rpc_jobs/setup_infra.yml
@@ -4,7 +4,7 @@
     concurrent: false
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 10
     parameters:
       - rpc_gating_params
     triggers:

--- a/rpc_jobs/snapshot.yml
+++ b/rpc_jobs/snapshot.yml
@@ -4,7 +4,7 @@
     concurrent: true
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 10
     parameters:
       # Default params are provided by macro, add any extra params, or
       # params you want to override the defaults for.

--- a/rpc_jobs/standard_job_checkmarx.yml
+++ b/rpc_jobs/standard_job_checkmarx.yml
@@ -1,7 +1,7 @@
 - job-template:
     CRON: "{CRON_WEEKLY}"
     RPC_GATING_BRANCH: master
-    NUM_TO_KEEP: 30
+    NUM_TO_KEEP: 14
     SLAVE_TYPE: "shared"
     name: '{trigger}-Checkmarx_{scan_type}-{repo_name}'
     project-type: pipeline

--- a/rpc_jobs/standard_job_dep_update.yml
+++ b/rpc_jobs/standard_job_dep_update.yml
@@ -1,7 +1,7 @@
 - job-template:
     CRON: "{CRON_WEEKLY}"
     RPC_GATING_BRANCH: master
-    NUM_TO_KEEP: 30
+    NUM_TO_KEEP: 14
     READ_ONLY_TEST: true
     SLAVE_TYPE: "container"
     component_dependencies_update: "false"

--- a/rpc_jobs/standard_job_gate.yml
+++ b/rpc_jobs/standard_job_gate.yml
@@ -18,7 +18,7 @@
       - github:
           url: "{repo_url}"
       - build-discarder:
-          days-to-keep: 30
+          days-to-keep: 14
     parameters:
       - rpc_gating_params
     dsl: |
@@ -47,7 +47,7 @@
     skip_pattern: ""
     properties:
       - build-discarder:
-          num-to-keep: "30"
+          num-to-keep: 14
       - github:
           url: "{repo_url}"
       - inject:

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -25,7 +25,7 @@
            - "{branch}"
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 14
     triggers:
         - github
     builders:

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -33,7 +33,7 @@
     status_context_prefix: "CIT"
     properties:
       - build-discarder:
-          num-to-keep: "30"
+          num-to-keep: 14
       - github:
           url: "{repo_url}"
       - inject:

--- a/rpc_jobs/standard_job_release.yml
+++ b/rpc_jobs/standard_job_release.yml
@@ -16,7 +16,7 @@
       - github:
           url: "https://github.com/rcbops/releases"
       - build-discarder:
-          days-to-keep: 30
+          days-to-keep: 14
     parameters:
       - rpc_gating_params
     dsl: |
@@ -40,7 +40,7 @@
     concurrent: false
     properties:
       - build-discarder:
-          days-to-keep: 30
+          days-to-keep: 14
     parameters:
       - rpc_gating_params
       - text:

--- a/rpc_jobs/sync_credential_store.yml
+++ b/rpc_jobs/sync_credential_store.yml
@@ -4,7 +4,7 @@
     concurrent: false
     properties:
       - build-discarder:
-          days-to-keep: 360
+          num-to-keep: 10
     parameters:
       - rpc_gating_params
       - string:

--- a/rpc_jobs/unit/artefact_publish.yml
+++ b/rpc_jobs/unit/artefact_publish.yml
@@ -4,7 +4,7 @@
     concurrent: true
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 10
     parameters:
       - rpc_gating_params
       - standard_job_params:

--- a/rpc_jobs/unit/globalwraps.yml
+++ b/rpc_jobs/unit/globalwraps.yml
@@ -4,7 +4,7 @@
     concurrent: true
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 10
     parameters:
       - rpc_gating_params
     dsl: |

--- a/rpc_jobs/unit/jira.yml
+++ b/rpc_jobs/unit/jira.yml
@@ -4,7 +4,7 @@
     concurrent: true
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 10
     parameters:
       - rpc_gating_params
     dsl: |

--- a/rpc_jobs/unit/phobos_vpn.yml
+++ b/rpc_jobs/unit/phobos_vpn.yml
@@ -4,7 +4,7 @@
     concurrent: true
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 10
     parameters:
       # Default params are provided by macro, add any extra params, or
       # params you want to override the defaults for.

--- a/rpc_jobs/unit/re_unit_tests.yml
+++ b/rpc_jobs/unit/re_unit_tests.yml
@@ -15,7 +15,7 @@
     properties:
       - rpc-gating-github
       - build-discarder:
-          days-to-keep: 30
+          num-to-keep: 10
     parameters:
       - rpc_gating_params
     dsl: |

--- a/rpc_jobs/unit/single_use_slave.yml
+++ b/rpc_jobs/unit/single_use_slave.yml
@@ -4,7 +4,7 @@
     concurrent: true
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 10
     parameters:
       # Default params are provided by macro, add any extra params, or
       # params you want to override the defaults for.

--- a/rpc_jobs/unit/skip_build_check.yml
+++ b/rpc_jobs/unit/skip_build_check.yml
@@ -4,7 +4,7 @@
     concurrent: true
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 10
     parameters:
       - rpc_gating_params
       - string:

--- a/rpc_jobs/unit/venvconstraintleak.yml
+++ b/rpc_jobs/unit/venvconstraintleak.yml
@@ -4,7 +4,7 @@
     concurrent: true
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 10
     parameters:
       - rpc_gating_params
     dsl: |

--- a/rpc_jobs/unit/with_requested_credentials.yml
+++ b/rpc_jobs/unit/with_requested_credentials.yml
@@ -4,7 +4,7 @@
     concurrent: true
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 10
     parameters:
       - rpc_gating_params
     dsl: |

--- a/rpc_jobs/unit/wrappers.yml
+++ b/rpc_jobs/unit/wrappers.yml
@@ -4,7 +4,7 @@
     concurrent: true
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 10
     parameters:
       - rpc_gating_params
       - standard_job_params:

--- a/rpc_jobs/webhook.yml
+++ b/rpc_jobs/webhook.yml
@@ -4,7 +4,7 @@
     concurrent: false
     properties:
       - build-discarder:
-          num-to-keep: 30
+          num-to-keep: 10
     parameters:
       # See params.yml
       - rpc_gating_params


### PR DESCRIPTION
A change [1] in the workflow-job-plugin has resulted in jenkins
no longer being able to render compressed job logs. As such, we
need to disable compression. We are not able to expand our
available disk space for logs and cannot meet our current retention
without compression, so we have to reduce the retention and disable
the compression for anything younger than 5 days.

[1] https://github.com/jenkinsci/workflow-job-plugin/commit/46bf528f5965ecb94180d2a01d91bf7cb05da9f5
JIRA: RE-2215

Issue: [RE-2215](https://rpc-openstack.atlassian.net/browse/RE-2215)