### PR TITLE
RE-2215 Disable periodic cleanup

### DIFF
--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -1,4 +1,5 @@
 - job:
+    disabled: true
     name: 'Periodic-Cleanup'
     project-type: workflow
     parameters:


### PR DESCRIPTION
Periodic cleanup is temporarily disabled to ensure that logs aren't
compressed while we are running a version of workflow-job that
prevents the jenkins ui from rendering compressed logs.

See Jira for details.

Issue: [RE-2215](https://rpc-openstack.atlassian.net/browse/RE-2215)