### PR TITLE
Revert "RE-2215 Disable periodic cleanup"

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1521,7 +1521,7 @@ void setTriggerVars(){
       env.RE_JOB_TRIGGER_DETAIL = root_cause.getShortDescription()
   } else if (root_cause instanceof org.jenkinsci.plugins.ghprb.GhprbCause){
       env.RE_JOB_TRIGGER="PULL"
-      env.RE_JOB_TRIGGER_DETAIL = "${root_cause.title}/${root_cause.pullID}"
+      env.RE_JOB_TRIGGER_DETAIL = "${env.ghprbPullTitle}/${root_cause.pullID}"
   } else {
       env.RE_JOB_TRIGGER="OTHER"
   }

--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -1,5 +1,4 @@
 - job:
-    disabled: true
     name: 'Periodic-Cleanup'
     project-type: workflow
     parameters:


### PR DESCRIPTION
The workflow-job plugin has now been downgraded to 2.25 and the UI is rendering compressed logs. Its now safe to re-enable periodic cleanup. 

Reverts rcbops/rpc-gating#1203

Jira: RE-2215

Issue: [RE-2215](https://rpc-openstack.atlassian.net/browse/RE-2215)