### PR TITLE
Remove safe_jira_comment

### DIFF
--- a/job_dsl/rpc_artifact_build.groovy
+++ b/job_dsl/rpc_artifact_build.groovy
@@ -93,7 +93,5 @@ common.globalWraps(){
     print e
     currentBuild.result = "FAILURE"
     throw e
-  } finally {
-    common.safe_jira_comment("${currentBuild.result}: [${env.BUILD_TAG}|${env.BUILD_URL}]")
   }
 } // globalWraps

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -871,24 +871,6 @@ No JIRA Issue key were found in commits ${repo_path}:${ghprbSourceBranch}""")
   }
 }
 
-/* Attempt to add a jira comment, but don't fail if ghprb env vars are missing
- * or no Jira issue key is present in commit titles
- */
-def safe_jira_comment(body, String repo_path="rpc-openstack"){
-  if (env.ghprbTargetBranch == null){
-    print ("Not a PR job, so not attempting to add a Jira comment")
-    return
-  }
-  try{
-    String key = get_jira_issue_key(repo_path)
-    jiraComment(issueKey: key,
-                body: body)
-    print "Jira Comment Added: [${key}] ${body}"
-  } catch (e){
-    print ("Error while attempting to add a build result comment to a JIRA issue: ${e}")
-  }
-}
-
 // This function creates or updates issues related to build failures.
 // Should be used to report build failures by calling:
 //    common.build_failure_issue(project, labels)


### PR DESCRIPTION
Commenting on the status of pull request builds was not deemed to be
useful by teams, it simply created noise. This change removes the rest
of the code related to safe_jira_comment.

JIRA: RE-1124

Issue: [RE-1124](https://rpc-openstack.atlassian.net/browse/RE-1124)