### PR TITLE
Update snapshot image for RPC-O Queens

### DIFF
--- a/nodepool/templates/nodepool.yml.j2
+++ b/nodepool/templates/nodepool.yml.j2
@@ -319,7 +319,7 @@ providers:
         image-name: rpc-r16.2.5-xenial_no_artifacts-swift
         config-drive: true
       - name: rpc-r17-xenial_no_artifacts-swift-image
-        image-name: rpc-r17.1.1-xenial_no_artifacts-swift
+        image-name: rpc-r17.1.3-xenial_no_artifacts-swift
         config-drive: true
       - name: rpc-r18-xenial_no_artifacts-swift-image
         image-name: rpc-r18.0.0-xenial_no_artifacts-swift

--- a/rpc_jobs/rpc_gating.yml
+++ b/rpc_jobs/rpc_gating.yml
@@ -28,7 +28,7 @@
     CRON: "{CRON_DAILY}"
     image:
       - snapshot:
-          IMAGE: "rpc-r17.1.1-xenial_no_artifacts-swift"
+          IMAGE: "rpc-r17.1.3-xenial_no_artifacts-swift"
           REGIONS: "DFW"
           FALLBACK_REGIONS: "DFW"
           FLAVOR: "7"


### PR DESCRIPTION
The bump snapshot job only does a search and replace for
N-1 to N where N is the most recent release. Due to the
fact that the last in-use images are N-2, the search and
replace is not working, even though the image is confirmed
to work.

As such, to get things back on track we handle this bump
manually.