### PR TITLE
Update snapshot image for RPC-O Pike

### DIFF
--- a/nodepool/templates/nodepool.yml.j2
+++ b/nodepool/templates/nodepool.yml.j2
@@ -316,7 +316,7 @@ providers:
         image-name: rpc-r14.20.0-xenial_loose_artifacts-swift
         config-drive: true
       - name: rpc-r16-xenial_no_artifacts-swift-image
-        image-name: rpc-r16.2.5-xenial_no_artifacts-swift
+        image-name: rpc-r16.2.7-xenial_no_artifacts-swift
         config-drive: true
       - name: rpc-r17-xenial_no_artifacts-swift-image
         image-name: rpc-r17.1.3-xenial_no_artifacts-swift


### PR DESCRIPTION
The bump snapshot job only does a search and replace for
N-1 to N where N is the most recent release. Due to the
fact that the last in-use images are N-2, the search and
replace is not working, even though the image is confirmed
to work.

As such, to get things back on track we handle this bump
manually.

Issue: [RI-538](https://rpc-openstack.atlassian.net/browse/RI-538)