### PR TITLE
RE-2231 Mitigate git config races

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -767,11 +767,26 @@ void configure_git(){
       // can be cloned when specified as https:// urls.
       // Ssh auth is handled in clone_with_pr_refs
       try {
-        sh """#!/bin/bash -xe
+        sh """#!/bin/bash -e
           mkdir -p ~/.ssh
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git config --global user.email "rpc-jenkins-svc@github.com"
-          git config --global user.name "rpc.jenkins.cit.rackspace.net"
+          i_git_set(){
+            k="\$1"
+            v="\$2"
+            if [[ "\$(git config --global \$k)" == "\$v" ]]; then
+              echo "Git config key \$k already set to \$v"
+            else
+              echo "Setting git config value \$k: \$v"
+              git config --global "\$k" "\$v"
+            fi
+          }
+          if grep -q github.com ~/.ssh/known_hosts; then
+            echo "Github.com key already in known hosts"
+          else
+            echo "Adding github.com key to known hosts"
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
+          fi
+          i_git_set user.email "rpc-jenkins-svc@github.com"
+          i_git_set user.name "rpc.jenkins.cit.rackspace.net"
         """
       } catch (Exception e){
         sleep(5)


### PR DESCRIPTION
We've had some jobs fail on git configuration because git can't
lock its own config files to modify them. This commit adds a lock
to ensure jenkins is only trying to configure git in one build at
a time. It also adds sleep+retry incase its a non-jenkins process
thats got the git config locked.

Issue: [RE-2231](https://rpc-openstack.atlassian.net/browse/RE-2231)