### PR TITLE
Shortens incremental action to fit char limit

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -46,7 +46,7 @@
     scenario:
       - "swift"
     action:
-      - "pike_to_queens_incremental"
+      - "pike_to_queens_inc"
     jira_project_key: "RLM"
     jobs:
       - 'PR_{repo_name}-{series}-{image}-{scenario}-{action}'
@@ -223,10 +223,9 @@
     scenario:
       - "swift"
     action:
-      - "newton_to_queens_incremental"
-      - "pike_to_queens_incremental"
+      - "newton_to_queens_inc"
+      - "pike_to_queens_inc"
     jira_project_key: "RLM"
-    hold_on_error: 4h
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
     CRON: "{CRON_WEEKLY}"
@@ -241,10 +240,13 @@
     scenario:
       - "swift"
     action:
-      - "newton_to_queens_incremental"
-      - "pike_to_queens_incremental"
+      - "newton_to_queens_inc"
+      - "newton_to_rocky_inc"
+      - "pike_to_queens_inc"
+      - "pike_to_rocky_inc"
+      - "queens_to_rocky_inc"
+      - "r16.0.0-beta.1_to_queens_inc"
     jira_project_key: "RLM"
-    hold_on_error: 4h
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
     CRON: "{CRON_WEEKLY}"
@@ -258,12 +260,11 @@
     scenario:
       - swift
     action:
-      - newton_to_queens_incremental:
+      - newton_to_queens_inc:
           SLAVE_TYPE: "nodepool-rpc-r14-xenial_loose_artifacts-swift"
-      - pike_to_queens_incremental:
+      - pike_to_queens_inc:
           SLAVE_TYPE: "nodepool-rpc-r16-xenial_no_artifacts-swift"
     jira_project_key: "RLM"
-    hold_on_error: 4h
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
     CRON: "{CRON_WEEKLY}"
@@ -278,10 +279,9 @@
     scenario:
       - swift
     action:
-      - newton_to_queens_incremental
-      - pike_to_queens_incremental
+      - newton_to_queens_inc
+      - pike_to_queens_inc
     jira_project_key: "RLM"
-    hold_on_error: 4h
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
     CRON: "{CRON_WEEKLY}"


### PR DESCRIPTION
* Shortens the incremental action to give a bit more breathing room
  on the job character limit.
* Adds 16.0.0-beta.1 for customer upgrade test
* Adds Newton to Rocky, Pike to R, Queens to R for initial testing
* Removes hold_on_error until things are more stable

Depends on https://github.com/rcbops/rpc-upgrades/pull/291