### PR TITLE
Gihub Pull Request Builder Cannot Use SSH Repo URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ runjenkins.yml
 # Ignore IDE project files
 *.iml
 .idea/
+.vscode/
 
 # Ignore Visual Studio Code project files
 .venv/

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -674,7 +674,7 @@ String clone_repo(String directory, String ssh_key, String repo, String ref, Str
   if (ref.startsWith("https://")) {
     beforeConversion = ref
     ref = ref.replaceAll("https://", "git@")
-    ref = ref.replaceAll("github.com:", "github.com/")
+    ref = ref.replaceAll("github.com/", "github.com:")
     println("Updated repo from ${beforeConversion} to ${ref}")
   }
   print "Cloning Repo: ${repo}@${ref}"

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -670,6 +670,13 @@ String clone_with_pr_refs(
 
 
 String clone_repo(String directory, String ssh_key, String repo, String ref, String refspec) {
+  // Need to clone/fetch with ssh@ protocol
+  if (ref.startsWith("https://")) {
+    beforeConversion = ref
+    ref = ref.replaceAll("https://", "git@")
+    ref = ref.replaceAll("github.com:", "github.com/")
+    println("Updated repo from ${beforeConversion} to ${ref}")
+  }
   print "Cloning Repo: ${repo}@${ref}"
   sshagent (credentials:[ssh_key]){
     sh """#!/bin/bash -xe

--- a/rpc_jobs/mk8s.yml
+++ b/rpc_jobs/mk8s.yml
@@ -8,13 +8,13 @@
       - PM
     repo_name:
       - mk8s:
-          repo_url: "git@github.com:rcbops/mk8s"
+          repo_url: "https://github.com/rcbops/mk8s"
           branch: master
       - kubernetes-harbor:
-          repo_url: "git@github.com:rcbops/kubernetes-harbor"
+          repo_url: "https://github.com/rcbops/kubernetes-harbor"
           branch: master
       - rackspace-monitoring-agent-coreos:
-          repo_url: "git@github.com:rcbops/rackspace-monitoring-agent-coreos"
+          repo_url: "https://github.com/rcbops/rackspace-monitoring-agent-coreos"
           branch: master
     jobs:
       - '{trigger}-Checkmarx_{scan_type}-{repo_name}'

--- a/rpc_jobs/rpc_appformix.yml
+++ b/rpc_jobs/rpc_appformix.yml
@@ -3,7 +3,7 @@
 
     repo_name: "rpc-appformix"
     # URL of the rpc-appformix repository
-    repo_url: "git@github.com:rcbops/rpc-appformix"
+    repo_url: "https://github.com/rcbops/rpc-appformix"
 
     branches:
       - "master"
@@ -35,7 +35,7 @@
 
     repo_name: "rpc-appformix"
     # URL of the rpc-appformix repository
-    repo_url: "git@github.com:rcbops/rpc-appformix"
+    repo_url: "https://github.com/rcbops/rpc-appformix"
 
     branches:
       - "master"
@@ -61,7 +61,7 @@
 
     repo_name: "rpc-appformix"
     # URL of the rpc-designate repository
-    repo_url: "git@github.com:rcbops/rpc-appformix"
+    repo_url: "https://github.com/rcbops/rpc-appformix"
 
     # Use image for RPC-O install
     image:
@@ -92,7 +92,7 @@
           branches: '.*'
     repo:
       - rpc-appformix:
-          repo_url: 'git@github.com/rcbops/rpc-appformix'
+          repo_url: 'https://github.com/rcbops/rpc-appformix'
     jobs:
       - 'Pull-Request-Whisperer_{repo}'
 
@@ -106,7 +106,7 @@
       - pci
     repo_name:
       - rpc-appformix:
-          repo_url: "git@github.com:rcbops/rpc-appformix.git"
+          repo_url: "https://github.com/rcbops/rpc-appformix"
           branch: master
     jobs:
       - '{trigger}-Checkmarx_{scan_type}-{repo_name}'

--- a/rpc_jobs/rpc_asc.yml
+++ b/rpc_jobs/rpc_asc.yml
@@ -8,28 +8,28 @@
       - PM
     repo_name:
       - zigzag:
-          repo_url: "git@github.com:rcbops/zigzag"
+          repo_url: "https://github.com/rcbops/zigzag"
           branch: master
       - pytest-zigzag:
-          repo_url: "git@github.com:rcbops/pytest-zigzag"
+          repo_url: "https://github.com/rcbops/pytest-zigzag"
           branch: master
       - pytest-rpc:
-          repo_url: "git@github.com:rcbops/pytest-rpc"
+          repo_url: "https://github.com/rcbops/pytest-rpc"
           branch: master
       - molecule-rpc-openstack-post-deploy:
-          repo_url: "git@github.com:rcbops/molecule-rpc-openstack-post-deploy"
+          repo_url: "https://github.com/rcbops/molecule-rpc-openstack-post-deploy"
           branch: master
       - magic-marker:
-          repo_url: "git@github.com:rcbops/magic-marker"
+          repo_url: "https://github.com/rcbops/magic-marker"
           branch: master
       - flake8-pytest-mark:
-          repo_url: "git@github.com:rcbops/flake8-pytest-mark"
+          repo_url: "https://github.com/rcbops/flake8-pytest-mark"
           branch: master
       - flake8-filename:
-          repo_url: "git@github.com:rcbops/flake8-filename"
+          repo_url: "https://github.com/rcbops/flake8-filename"
           branch: master
       - moleculerize:
-          repo_url: "git@github.com:rcbops/moleculerize"
+          repo_url: "https://github.com/rcbops/moleculerize"
           branch: master
     jobs:
       - '{trigger}-Checkmarx_{scan_type}-{repo_name}'

--- a/rpc_jobs/rpc_ceph.yml
+++ b/rpc_jobs/rpc_ceph.yml
@@ -187,7 +187,7 @@
       - pci
     repo_name:
       - rpc-ceph:
-          repo_url: "git@github.com:rcbops/rpc-ceph"
+          repo_url: "https://github.com/rcbops/rpc-ceph"
           branch: master
     jobs:
       - '{trigger}-Checkmarx_{scan_type}-{repo_name}'

--- a/rpc_jobs/rpc_eng_ops.yml
+++ b/rpc_jobs/rpc_eng_ops.yml
@@ -1,7 +1,7 @@
 - project:
     name: "rpc-eng-ops-jobs"
     repo_name:  "rpc-eng-ops"
-    repo_url:   "git@github.com:rcbops/rpc-eng-ops"
+    repo_url:   "https://github.com/rcbops/rpc-eng-ops"
     branch: "master"
     image:
       - "xenial":

--- a/rpc_jobs/rpc_jenkins_etl.yml
+++ b/rpc_jobs/rpc_jenkins_etl.yml
@@ -2,7 +2,7 @@
 - project:
     name: rpc-jenkins-etl-gate-trigger
     repo_name: rpc-jenkins-etl
-    repo_url: git@github.com:rcbops/rpc-jenkins-etl.git
+    repo_url: https://github.com/rcbops/rpc-jenkins-etl.git
     jobs:
       - 'Component-Gate-Trigger_{repo_name}'
 
@@ -10,7 +10,7 @@
     name: rpc-jenkins-etl-re-release-pr
     repo:
       - rpc-jenkins-etl:
-          URL: git@github.com:rcbops/rpc-jenkins-etl.git
+          URL: https://github.com/rcbops/rpc-jenkins-etl.git
           BRANCH: master
     jobs:
       - 'RE-Release-PR_{repo}-{BRANCH}'
@@ -22,14 +22,14 @@
           branches: '.*'
     repo:
       - rpc-jenkins-etl:
-          repo_url: 'git@github.com:rcbops/rpc-jenkins-etl.git'
+          repo_url: 'https://github.com/rcbops/rpc-jenkins-etl'
     jobs:
       - 'Pull-Request-Whisperer_{repo}'
 
 - project:
     name: "rpc-jenkins-etl-dev-premerge"
     repo_name: "rpc-jenkins-etl"
-    repo_url: 'git@github.com:rcbops/rpc-jenkins-etl.git'
+    repo_url: 'https://github.com/rcbops/rpc-jenkins-etl'
     series: "dev"
     branches:
       - "dev"
@@ -47,7 +47,7 @@
 - project:
     name: "rpc-jenkins-etl-master-periodic"
     repo_name: "rpc-jenkins-etl"
-    repo_url: 'git@github.com:rcbops/rpc-jenkins-etl.git'
+    repo_url: 'https://github.com/rcbops/rpc-jenkins-etl'
     branch: "master"
     image:
       - xenial:

--- a/rpc_jobs/rpc_uam.yml
+++ b/rpc_jobs/rpc_uam.yml
@@ -9,7 +9,7 @@
       - pci
     repo_name:
       - rpc-uam:
-          repo_url: "git@github.com:rcbops/rpc-uam"
+          repo_url: "https://github.com/rcbops/rpc-uam"
           branch: master
     jobs:
       - '{trigger}-Checkmarx_{scan_type}-{repo_name}'


### PR DESCRIPTION
* Updated PM jobs to use https protocol
* Updated clone/fetch repo to convert from https to ssh protocol
* Added unit test for repo_url protocol

JIRA: RE-2233

Issue: [RE-2233](https://rpc-openstack.atlassian.net/browse/RE-2233)