### PR TITLE
RE-1229 Fix confluence wiki page update

### DIFF
--- a/scripts/confluence_release_page.j2
+++ b/scripts/confluence_release_page.j2
@@ -6,7 +6,7 @@
 <tbody>
 <tr><th>Product</th><th>Version</th><th>Release Notes</th><th>Comments</th></tr>
 {% for row in rows %}
-<tr><td>{{ row.product }}</td><td>{{ row.version }}</td><td>{{ row.release_notes | urlize }}</td><td>{{ row.comments | wordwrap(width=79, break_long_words=False, wrapstring="<br/>") }}</td></tr>
+<tr><td>{{ row.product }}</td><td>{{ row.version }}</td><td>{{ row.release_notes | urlize }}</td><td>{{ row.comments | urlize}}</td></tr>
 {% endfor %}
 </tbody>
 </table>


### PR DESCRIPTION
Previously only the release notes column was run through the
urlize filter, this meant that a stray ampersand could make it into
the comments filter, and cause confluence to return 400.