### PR TITLE
Improve github known_hosts key addition

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -779,12 +779,14 @@ void configure_git(){
               git config --global "\$k" "\$v"
             fi
           }
-          if grep -q github.com ~/.ssh/known_hosts; then
-            echo "Github.com key already in known hosts"
-          else
-            echo "Adding github.com key to known hosts"
-            ssh-keyscan github.com >> ~/.ssh/known_hosts
-          fi
+          ssh-keyscan github.com 2>/dev/null | while read ssh_key; do
+            if grep -q "\${ssh_key}" ~/.ssh/known_hosts; then
+              echo "Github.com key already in known hosts: \${ssh_key}"
+            else
+              echo "Adding github.com key to known hosts: \${ssh_key}"
+              echo "\${ssh_key}" >> ~/.ssh/known_hosts
+            fi
+          done
           i_git_set user.email "rpc-jenkins-svc@github.com"
           i_git_set user.name "rpc.jenkins.cit.rackspace.net"
         """


### PR DESCRIPTION
If github changes their public key, the current implementation
will not replace the key for any existing host. Also, if github
implements multiple keys, the current implementation will not
add any new ones for existing hosts.

This patch ensures that both of these situations are catered for.

Issue: [RE-2231](https://rpc-openstack.atlassian.net/browse/RE-2231)