### PR TITLE
RE-2070 Build jobs from MK8s repo

### DIFF
--- a/gating/common/run_lint.sh
+++ b/gating/common/run_lint.sh
@@ -18,4 +18,5 @@ export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
 ssh-add -l &>/dev/null || eval $(ssh-agent)
 # Safe to re-add keys that are in the agent.
 ssh-add $JENKINS_GITHUB_SSH_PRIVKEY
+ssh-add -l
 ./lint.sh

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1384,7 +1384,7 @@ List build_creds_array(String list_of_cred_ids){
         variable: 'JENKINS_SSH_PRIVKEY'
       ),
       "rpc_jenkins_svc_github_key_file": sshUserPrivateKey(
-        credentialsId: 'rpc-jenkins-svc-github-key',
+        credentialsId: 'rpc-jenkins-svc-github-ssh-key',
         keyFileVariable: 'JENKINS_GITHUB_SSH_PRIVKEY'
       ),
       "RPC_REPO_IP": string(

--- a/rpc_jobs/defaults.yml
+++ b/rpc_jobs/defaults.yml
@@ -32,3 +32,5 @@
     JOB_SOURCES: |
       - repo: git@github.com:rcbops/rpc-gating.git
         commitish: master
+      - repo: git@github.com:rcbops/mk8s.git
+        commitish: master

--- a/scripts/jjb-path-setup.py
+++ b/scripts/jjb-path-setup.py
@@ -2,6 +2,7 @@
 from itertools import chain
 import os.path
 import re
+import sys
 
 import click
 from sh import git, ErrorReturnCode_128
@@ -36,7 +37,7 @@ def setup(job_sources):
             name = match.group(1)
             js = {"commitish": commitish, "directory": name, "url": url}
         job_sources_by_name[name] = js
-
+    sys.stderr.write("Job Sources: {} \n".format(job_sources_by_name))
     paths_by_source = {}
     for name, job_source in job_sources_by_name.items():
         directory = job_source["directory"]
@@ -48,7 +49,10 @@ def setup(job_sources):
                     job_source["url"],
                     directory
                 )
-            except ErrorReturnCode_128:
+            except ErrorReturnCode_128 as e:
+                sys.stderr.write(
+                    "Clone Failure: {}, "
+                    "retrying checkout.\n".format(e))
                 git.checkout(
                     job_source["commitish"],
                     _env={"GIT_DIR": directory + "/.git"}


### PR DESCRIPTION
The relevant metadata has now been merged into the mk8s repo.
This commit updates defaults so that the Jenkins-Job-Builder job
will build jobs from the mk8s repo.

Issue: [RE-2070](https://rpc-openstack.atlassian.net/browse/RE-2070)