### PR TITLE
RE-2062 Provide ssh key for lint

### DIFF
--- a/gating/common/run_lint.sh
+++ b/gating/common/run_lint.sh
@@ -8,4 +8,14 @@ pip install -c constraints.txt -r requirements.txt
 pip install -c constraints.txt -r test-requirements.txt
 
 export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+
+# JJB definitions can be stored in project repos, some of which are private.
+# An ssh-agent is provided to the lint script so it can clone all the
+# necessary repos for testing JJB definitions.
+
+# Check if an agent is available, start one if not.
+# This check prevents us from loosing access to an agent supplied by Jenkins.
+ssh-add -l &>/dev/null || eval $(ssh-agent)
+# Safe to re-add keys that are in the agent.
+ssh-add $JENKINS_GITHUB_SSH_PRIVKEY
 ./lint.sh

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1373,6 +1373,10 @@ List build_creds_array(String list_of_cred_ids){
         credentialsId: 'id_rsa_cloud10_jenkins_file',
         variable: 'JENKINS_SSH_PRIVKEY'
       ),
+      "rpc_jenkins_svc_github_key_file": sshUserPrivateKey(
+        credentialsId: 'rpc-jenkins-svc-github-key',
+        keyFileVariable: 'JENKINS_GITHUB_SSH_PRIVKEY'
+      ),
       "RPC_REPO_IP": string(
         credentialsId: "RPC_REPO_IP",
         variable: "REPO_HOST"

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -13,6 +13,7 @@
     scenario:
       - "lint":
           SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+          credentials: "rpc_jenkins_svc_github_key_file"
       - "standard_job_pre_merge":
           SLAVE_TYPE: "container"
     action:


### PR DESCRIPTION
JJB definitions can be stored in project repos, some of which are private. An
ssh-agent is provided to the lint script so it can clone all the necessary
repos for testing JJB definitions.

Issue: [RE-2062](https://rpc-openstack.atlassian.net/browse/RE-2062)