### PR TITLE
hold the node on error for RI-591

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -375,6 +375,7 @@
     credentials: "rpc_asc_creds"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
+    hold_on_error: "6h"
 
 - project:
     name: "rpc-openstack-pike-aio-postmerge"


### PR DESCRIPTION
PM_rpc-openstack-queens-xenial_mnaio_no_artifacts-swift-system
specifcally is what needs to be held (as mentioned in the issue).

Issue: [RI-591](https://rpc-openstack.atlassian.net/browse/RI-591)