### PR TITLE
Upgrade from Newton release for Genentech gating job

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -245,7 +245,7 @@
       - "pike_to_queens_inc"
       - "pike_to_rocky_inc"
       - "queens_to_rocky_inc"
-      - "r16.0.0-beta.1_to_queens_inc"
+      - "r14.6.0_to_queens_inc"
     jira_project_key: "RLM"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'


### PR DESCRIPTION
This gate is intended to provide some testing that approximates the Genentech upgrade scenario.  Initially, the understanding was that they would be upgrading from r16.0.0-beta, but it turns out they are actually running r14.6.0.