### PR TITLE
RE-2267 Fix sources param default in std lint job

### DIFF
--- a/rpc_jobs/standard_job_lint_jenkins.yml
+++ b/rpc_jobs/standard_job_lint_jenkins.yml
@@ -41,7 +41,8 @@
           cancel-builds-on-update: true
     parameters:
       - rpc_gating_params
-      - jjb_params
+      - jjb_params:
+          JOB_SOURCES: "{JOB_SOURCES}"
       - string:
           name: "REPO_URL"
           description: URL of the repo to be updated


### PR DESCRIPTION
The jjb_params parameter macro requires an argument to set the default
value, however no argument was passed. Consequently the rendered
job contained the text "{JOB_SOURCES}" as the default value of that
paramater, rather than the expected value from defaults.
This commit fixes that by passing the appropriate argument.

Issue: [RE-2267](https://rpc-openstack.atlassian.net/browse/RE-2267)