### PR TITLE
JJB Lint fixes

### DIFF
--- a/job_dsl/standard_job_lint_jenkins.groovy
+++ b/job_dsl/standard_job_lint_jenkins.groovy
@@ -2,11 +2,7 @@ library "rpc-gating-master"
 common.globalWraps(){
   common.standard_job_slave(env.SLAVE_TYPE) {
     try {
-      stage("Configure Git"){
-        common.configure_git()
-      }
-
-      String repoDir = "${env.WORKSPACE}/${env.RE_JOB_REPO_NAME}"
+      String repoDir = "${WORKSPACE}/${env.RE_JOB_REPO_NAME}"
       String repoURL
       String repoBranch
       stage("Checkout"){
@@ -21,9 +17,13 @@ common.globalWraps(){
         print("Repo: ${repoURL} Branch: ${repoBranch}")
         common.clone_with_pr_refs(repoDir, repoURL, repoBranch)
       }
-
       def jobSources = readYaml text: JOB_SOURCES
-      String sourcesArgs = jobSources.collect {"--job-source ${it.repo};${it.commitish}"}.join(' ')
+      // Remove the repo being tested, because it will be added as a local source, so doesn't need to be cloned
+      // by path setup
+      // Remove rpc-gating because it's already been cloned.
+      String git_repo_url = common.https_to_ssh_github_url(env.REPO_URL)
+      jobSources.removeAll { it.repo == git_repo_url || it.repo == "git@github.com:rcbops/rpc-gating"}
+      String sourcesArgs = jobSources.collect {"--job-source \"${it.repo};${it.commitish}\""}.join(' ')
       stage("Lint Jenkins"){
         withCredentials([
           string(
@@ -38,8 +38,16 @@ common.globalWraps(){
           ){
             sshagent (credentials:['rpc-jenkins-svc-github-ssh-key']){
               sh """#!/bin/bash -xe
-                export JJB_PATHS_OVERRIDE=\$(rpc-gating/scripts/jjb-path-setup.py ${sourcesArgs} ---job-source '${repoDir}')
-                rpc-gating/lint.sh
+                # venv needed for click lib used by jjb-path-setup
+                source .venv/bin/activate
+                  export JJB_PATHS_OVERRIDE=\$(rpc-gating/scripts/jjb-path-setup.py \
+                    ${sourcesArgs} \
+                    --job-source '${repoDir}'\
+                    --job-source '${WORKSPACE}/rpc-gating')
+                deactivate
+                pushd rpc-gating
+                  ./lint.sh
+                popd
               """
             }
           }

--- a/lint.sh
+++ b/lint.sh
@@ -17,7 +17,7 @@ install(){
   which virtualenv >/dev/null \
     || { echo "virtualenv not available, please install via pip"; return; }
   if [ ! -d ${venv}_${python} ]; then
-    $python -m virtualenv ${venv}_${python}
+    $python -m virtualenv --python=${python} ${venv}_${python}
   fi
   . ${venv}_${python}/bin/activate
 

--- a/rpc_jobs/defaults.yml
+++ b/rpc_jobs/defaults.yml
@@ -30,7 +30,7 @@
     CRON_WEEKLY: "H H * * H(2-7)"
     CRON_MONTHLY: "H H H * 2-7"
     JOB_SOURCES: |
-      - repo: git@github.com:rcbops/rpc-gating.git
+      - repo: git@github.com:rcbops/rpc-gating
         commitish: master
-      - repo: git@github.com:rcbops/mk8s.git
+      - repo: git@github.com:rcbops/mk8s
         commitish: master

--- a/rpc_jobs/standard_job_release.yml
+++ b/rpc_jobs/standard_job_release.yml
@@ -61,7 +61,7 @@
       common.globalWraps(){
         dir("${env.WORKSPACE}/releases"){
           common.clone_with_pr_refs(
-            ".", "git@github.com:${pr_repo}.git", "origin/pr/${pr_number}/merge",
+            ".", "git@github.com:${pr_repo}", "origin/pr/${pr_number}/merge",
           )
           sh """#!/bin/bash -xe
             virtualenv --python python3 .venv3

--- a/rpc_jobs/sync_credential_store.yml
+++ b/rpc_jobs/sync_credential_store.yml
@@ -23,7 +23,7 @@
           name: "PIP_PWSAFE_LOCATION"
           description: |
             pip location to install pwsafe library from,
-            eg. git+ssh://git@repo_url/user/pwsafe.git
+            eg. git+ssh://git@repo_url/user/pwsafe
 
     dsl: |
       library "rpc-gating@${RPC_GATING_BRANCH}"

--- a/scripts/jjb-path-setup.py
+++ b/scripts/jjb-path-setup.py
@@ -59,10 +59,12 @@ def setup(job_sources):
                 )
 
         try:
-            with open("{d}/component_metadata.yml".format(d=directory)) as f:
+            metadata_file = "{d}/component_metadata.yml".format(d=directory)
+            with open(metadata_file) as f:
                 metadata = yaml.load(f)
-        except IOError:
-            pass
+        except IOError as e:
+            sys.stderr.write("Failed to load component metadata file: "
+                             "{}, error: {}".format(metadata_file, e))
         else:
             paths = metadata.get("jenkins", {}).get("jjb_paths", [])
             paths_by_source[name] = [


### PR DESCRIPTION
* Remove unnecessary call to configure_git
* Prevent jjb-path-setup from cloning job source repos that
  are cloned by other mechanisms. This includes rpc-gating
  which is provided by common.use_node and the repo currently
  being tested, as we want to use the version under test.
* Source venv before calling jjb-path-setup as it requires library
  from the venv
* Call the lint script from within the rpc-gating directory, as
  it expects paths relative to rpc-gating.
* Add the --python command to lint.sh when creating venvs to ensure
  the correct interpreter is installed in each venv
* Remove .git from the end of any ssh urls found in config. The suffix
  is not necessary and consistency is required.
* Add error message for when a componenet metdata file can't be found
  in a job source repo.