### PR TITLE
ASC-1364 remove system tests from rpc-upgrades

### DIFF
--- a/rpc_jobs/rpc_upgrades.yml
+++ b/rpc_jobs/rpc_upgrades.yml
@@ -174,7 +174,6 @@
       - "mitaka_to_newton_leap"
       - "liberty_to_newton_leap"
       - "kilo_to_newton_leap"
-      - "liberty_to_newton_leap_system"
     jira_project_key: "RLM"
     # Required by RPC-ASC team to upload test results qTest
     credentials: "rpc_asc_creds"
@@ -205,7 +204,6 @@
       - "r12.2.2_to_r14.current_leap"
       - "r12.1.2_to_r14.current_leap"
       - "kilo_to_r14.current_leap"
-      - "liberty_to_r14.current_leap_system"
     jira_project_key: "RLM"
     # Required by RPC-ASC team to upload test results qTest
     credentials: "rpc_asc_creds"


### PR DESCRIPTION
The system tests have not run successfully against upgrades and other priorities are higher than resolving issues here. System tests for upgrade will be revisited later and remove the jobs for now to reduce CI noise.

Issue: [ASC-1364](https://rpc-openstack.atlassian.net/browse/ASC-1364)