### PR TITLE
Revert "hold the node on error for RI-591"

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -375,7 +375,6 @@
     credentials: "rpc_asc_creds"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
-    hold_on_error: "6h"
 
 - project:
     name: "rpc-openstack-pike-aio-postmerge"


### PR DESCRIPTION
This reverts commit 46b5a70ac5624183531e36925c1519e97daffda5.

Signed-off-by: Matthew Thode <mthode@mthode.org>

Issue: [RI-591](https://rpc-openstack.atlassian.net/browse/RI-591)