### PR TITLE
Adding RE job for openstack-ops

### DIFF
--- a/rpc_jobs/rpc_openstack_ops.yml
+++ b/rpc_jobs/rpc_openstack_ops.yml
@@ -1,0 +1,15 @@
+### test checkmarx against openstack-ops
+- project:
+    name: 'openstack-ops-checkmarx'
+    jira_project_key: "FLEEK"
+    trigger:
+      - PM
+    scan_type:
+      - all
+      - pci
+    repo_name:
+      - openstack-ops:
+          repo_url: "https://github.com/rcbops/openstack-ops"
+          branch: master
+    jobs:
+      - '{trigger}-Checkmarx_{scan_type}-{repo_name}'


### PR DESCRIPTION
openstack-ops is added to RE jobs to run checkmarx
against the repository code