### PR TITLE
RE-2265 Overrideable default for folder excludes

### DIFF
--- a/rpc_jobs/defaults.yml
+++ b/rpc_jobs/defaults.yml
@@ -34,3 +34,4 @@
         commitish: master
       - repo: git@github.com:rcbops/mk8s
         commitish: master
+    checkmarx_exclude_folders: ""

--- a/rpc_jobs/standard_job_checkmarx.yml
+++ b/rpc_jobs/standard_job_checkmarx.yml
@@ -55,6 +55,6 @@
             status for a repo.
       - string:
           name: "exclude_folders"
-          default: ""
+          default: "{checkmarx_exclude_folders}"
           description: |
             An optional comma separated list of folders to exclude from the scan.


### PR DESCRIPTION
Previously a param was added to allow checkmarx jobs to exclude folders.
However that param didn't have a default value that used a jjb macro
so couldn't be overidden from a jjb project. This commit adds the
required macro and a default value.

Issue: [RE-2265](https://rpc-openstack.atlassian.net/browse/RE-2265)