### PR TITLE
RE-2194 exapnd build summary timeout regex

### DIFF
--- a/scripts/build_summary/failure.py
+++ b/scripts/build_summary/failure.py
@@ -377,7 +377,11 @@ class BuildTimeoutFailure(Failure):
 
     def scan(self):
         match_re = ('Build timed out \(after [0-9]* minutes\). '
-                    'Marking the build as aborted.')
+                    'Marking the build as aborted.'
+                    '|Timeout has been exceeded'
+                    '|Cancelling nested steps due to timeout'
+                    '|Timeout waiting for NodePool ZNode '
+                    '/requests/.* to reach state fulfilled')
         pattern = re.compile(match_re)
         for i, line in enumerate(self.build.log_lines):
             if pattern.search(line):


### PR DESCRIPTION
Additional timeout messages have been encountered since the original
regex was written. This is useful now as I want to track the occurence
of timeouts in order to know where to focus attention on RE-2194.

Issue: [RE-2194](https://rpc-openstack.atlassian.net/browse/RE-2194)