### PR TITLE
RE-2298 Wiki update still failing

### DIFF
--- a/scripts/confluence_release_page.j2
+++ b/scripts/confluence_release_page.j2
@@ -6,7 +6,7 @@
 <tbody>
 <tr><th>Product</th><th>Version</th><th>Release Notes</th><th>Comments</th></tr>
 {% for row in rows %}
-<tr><td>{{ row.product }}</td><td>{{ row.version }}</td><td>{{ row.release_notes | urlize }}</td><td>{{ row.comments | urlize}}</td></tr>
+<tr><td>{{ row.product | urlize }}</td><td>{{ row.version | urlize }}</td><td>{{ row.release_notes | urlize }}</td><td>{{ row.comments | urlize}}</td></tr>
 {% endfor %}
 </tbody>
 </table>


### PR DESCRIPTION
#1233 added urlize to a second field, but left two unfiltered. This commit filters the remaining two.

Issue: [RE-2298](https://rpc-openstack.atlassian.net/browse/RE-2298)