### PR TITLE
RE-2298 Accomodate restructured wiki

### DIFF
--- a/rpc_jobs/re_release_manual.yml
+++ b/rpc_jobs/re_release_manual.yml
@@ -162,7 +162,7 @@
                 --username TEXT                Confluence username.  [required]<br>
                 --password TEXT                Confluence password.  [required]<br>
                 --base-url TEXT                Confluence instance.<br>
-                --scheduled-release-page TEXT<br>
+                --product-release-page TEXT<br>
                 --async-release-page TEXT<br>
                 --component TEXT               Component name, e.g. rpc-foo.  [required]<br>
                 --version TEXT                 Component release version, e.g. 1.0.4.<br>


### PR DESCRIPTION
Previously the monthly release pages were directly under Product Releases
Now they are under annual pages. This commit updates the code to match
the new structure of the wiki.

Issue: [RE-2298](https://rpc-openstack.atlassian.net/browse/RE-2298)