### PR TITLE
ASC-1414 Exclude zigzag/tests from checkmarx scan

### DIFF
--- a/rpc_jobs/rpc_asc.yml
+++ b/rpc_jobs/rpc_asc.yml
@@ -10,6 +10,7 @@
       - zigzag:
           repo_url: "https://github.com/rcbops/zigzag"
           branch: master
+          checkmarx_exclude_folders: "tests"
       - pytest-zigzag:
           repo_url: "https://github.com/rcbops/pytest-zigzag"
           branch: master


### PR DESCRIPTION
This commit adds the `tests` directory to the list of folders to exclude
from the checkmarx scan for the zigzag repository.

Issue: [ASC-1414](https://rpc-openstack.atlassian.net/browse/ASC-1414)