### PR TITLE
Use nodepool images for AIO snapshot builds

### DIFF
--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -39,6 +39,20 @@
           {%- set region_list = (fallback_regions | replace(',', ' ')).split() | map('trim') | map('upper') | select | shuffle %}
           {{- (region_list | length == 1) | ternary(region_list, region_list | difference([regions_shuff[0]])) }}
 
+    - name: Determine the latest image name when required
+      when:
+        - image | match('^nodepool-.*')
+      block:
+        - name: Get the list of images
+          os_image_facts:
+            cloud: "{{ cloud_name }}"
+            region_name: "{{ regions_shuff[0] }}"
+          register: _images
+
+        - name: Set the image name fact
+          set_fact:
+            _image: "{{ _images.ansible_facts.openstack_image | json_query('[*].name') | select('match', image ~ '*') | list | sort | last }}"
+
     - name: Provision a cloud instance
       block:
         - name: Output the primary region list
@@ -58,7 +72,7 @@
             state: present
             cloud: "{{ cloud_name }}"
             region_name: "{{ regions_shuff[0] }}"
-            image: "{{ image }}"
+            image: "{{ _image | default(image) }}"
             key_name: "{{ keyname }}"
             userdata: "{{ lookup('file', user_data_path) }}"
             config_drive: yes
@@ -113,7 +127,7 @@
             state: present
             cloud: "{{ cloud_name }}"
             region_name: "{{ fallback_regions_shuff[0] }}"
-            image: "{{ image }}"
+            image: "{{ _image | default(image) }}"
             key_name: "{{ keyname }}"
             userdata: "{{ lookup('file', user_data_path) }}"
             config_drive: yes

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -244,9 +244,9 @@
     CRON: "{CRON_MONTHLY}"
     image:
       - bionic_no_artifacts:
-          IMAGE: "Ubuntu 18.04 LTS (Bionic Beaver) (PVHVM)"
+          IMAGE: "nodepool-ubuntu-bionic-"
       - xenial_no_artifacts:
-          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+          IMAGE: "nodepool-ubuntu-xenial-"
     scenario:
       - "swift"
     action:
@@ -293,9 +293,9 @@
     CRON: "{CRON_MONTHLY}"
     image:
       - bionic_no_artifacts:
-          IMAGE: "Ubuntu 18.04 LTS (Bionic Beaver) (PVHVM)"
+          IMAGE: "nodepool-ubuntu-bionic-"
       - xenial_no_artifacts:
-          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+          IMAGE: "nodepool-ubuntu-xenial-"
     scenario:
       - "swift"
     action:
@@ -343,7 +343,7 @@
     CRON: "{CRON_MONTHLY}"
     image:
       - xenial_no_artifacts:
-          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+          IMAGE: "nodepool-ubuntu-xenial-"
     scenario:
       - "swift"
     action:
@@ -387,7 +387,7 @@
     CRON: "{CRON_MONTHLY}"
     image:
       - xenial_no_artifacts:
-          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+          IMAGE: "nodepool-ubuntu-xenial-"
     scenario:
       - "swift"
     action:
@@ -447,12 +447,12 @@
     jira_project_key: "RO"
     image:
       - xenial_loose_artifacts:
-          IMAGE: "Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)"
+          IMAGE: "nodepool-ubuntu-xenial-"
           # We have an MNAIO equivalent of this PM job, but we need to keep
           # this for the push triggering for snapshot building.
           CRON: "{CRON_MONTHLY}"
       - trusty_loose_artifacts:
-          IMAGE: "Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)"
+          IMAGE: "nodepool-ubuntu-trusty-"
     scenario:
       - "swift"
     action:


### PR DESCRIPTION
Rather than use public cloud images, which have proven to be unreliable
due to the nova-agent not starting properly, we enable the jenkins node
build to use the images built by nodepool instead.

The playbook fetches the list of available images, then uses the latest
available one for the build.

This brings the image build process closer to what is used for all tests
and should be more reliable given that nodepool does not use nova-agent.

Issue: [RE-2278](https://rpc-openstack.atlassian.net/browse/RE-2278)