### PR TITLE
Jenkins Setup Grafana Repo Fix

### DIFF
--- a/grafana/role_requirements.yml
+++ b/grafana/role_requirements.yml
@@ -2,7 +2,7 @@
 - name: cloudalchemy.grafana
   scm: git
   src: https://github.com/cloudalchemy/ansible-grafana
-  version: "0.8.1"
+  version: "0.13.0"
 - name: openstack.grafyaml
   scm: git
   src: https://github.com/openstack/ansible-role-grafyaml


### PR DESCRIPTION
* Bump ansible-grafana role version to 0.13.0 to pick up the upstream
  repo/gpg key fix.

JIRA: RE-2296

Issue: [RE-2296](https://rpc-openstack.atlassian.net/browse/RE-2296)