### PR TITLE
Ensure /usr/bin/python is present on target hosts

### DIFF
--- a/playbooks/setup_openstack_instances.yml
+++ b/playbooks/setup_openstack_instances.yml
@@ -143,3 +143,40 @@
       loop: "{{ (instance_list | default([])) | flatten(levels=1) }}"
       loop_control:
         loop_var: instance
+
+    - name: Add new hosts to bootstrap group
+      add_host:
+        name: "{{ item }}"
+        groups: new_hosts_to_bootstrap
+      loop: >-
+        {{
+          (instance_list | selectattr('state', 'defined') | selectattr('state', 'equalto', 'present') | map(attribute='name') | list) +
+          (instance_list | selectattr('state', 'undefined') | map(attribute='name') | list)
+        }}
+
+# Note(odyssey4me):
+# At this stage, Ansible may not be able to gather facts
+# because python is not present on the target host. We
+# therefore do not gather facts and have to use the raw
+# or script module only to get the pre-requisites installed.
+- name: Install Ansible prerequisites
+  hosts: new_hosts_to_bootstrap
+  gather_facts: no
+  user: root
+  tasks:
+    - name: Ensure python is installed
+      raw: |
+        set -e
+        if which apt-get >/dev/null && ! which python >/dev/null ; then
+          apt-get update
+          apt-get -y install python
+          exit 2
+        else
+          exit 0
+        fi
+      args:
+        executable: /bin/bash
+        warn: no
+      register: result
+      changed_when: "result.rc == 2"
+      failed_when: "result.rc not in [0, 2]"


### PR DESCRIPTION
When using the setup_openstack_instances playbook, the target
hosts may not have /usr/bin/python present on them. This is
the case for Ubuntu Xenial in the new Public Cloud images.

Without /usr/bin/python present, Ansible cannot gather facts
from the target host, so we need to use the raw/script module
to get it there before any subsequent plays which use facts.

Issue: [RE-2323](https://rpc-openstack.atlassian.net/browse/RE-2323)