### PR TITLE
Correct global wrap timeout

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1686,7 +1686,7 @@ void globalWraps(Closure body){
   // global timeout is long, so individual jobs can set shorter timeouts and
   // still have to cleanup, archive atefacts etc.
   timestamps{
-    timeout(time: env.BUILD_TIMEOUT_HRS ?: 3, unit: 'HOURS'){
+    timeout(time: env.BUILD_TIMEOUT_HRS ?: 10, unit: 'HOURS'){
       shared_slave(){
         wrap([$class: 'LogfilesizecheckerWrapper', 'maxLogSize': 200, 'failBuild': true, 'setOwn': true]) {
           setTriggerVars()


### PR DESCRIPTION
In [1] the job timeout was set to 10 hours globally, but mistakenly
set to 3 hrs in the global wrap. This is causing job timeouts for
some of the longer running jobs (like MNAIO builds).

This patch just sets the global wrap timeout to the same value.

[1] https://github.com/rcbops/rpc-gating/pull/1275

JIRA: RE-2307

Issue: [RE-2307](https://rpc-openstack.atlassian.net/browse/RE-2307)