### PR TITLE
Implement a common method for rpc-gating runtime requirements

### DIFF
--- a/nodepool/setup_nodepool.yml
+++ b/nodepool/setup_nodepool.yml
@@ -124,13 +124,17 @@
   user: root
   vars:
     nodepool_file_nodepool_yaml_src: "{{ lookup('env', 'WORKSPACE') }}/rpc-gating/nodepool/templates/nodepool.yml.j2"
-    nodepool_git_version: 67824d8e64250ede0cb4a3ebe344412f5cba2218 # HEAD of 'master' as of 25 July 2018
+    nodepool_git_version: 44ae87c3105b44e3c21aa6c4077e4792d9bcb2a0 # HEAD of 'master' as of 23 Jan 2019
     nodepool_pip_executable: pip3
     nodepool_file_nodepool_builder_service_config_src: systemd-service-override.conf.j2
     nodepool_file_nodepool_launcher_service_config_src: systemd-service-override.conf.j2
 
     diskimage_builder_git_version: "2.12.1" # Current release as of 22 Mar 2018
     diskimage_builder_elements_src: "elements"
+
+    rpc_gating_git_sha: "{{ lookup('pipe', 'cd ' ~ playbook_dir ~ '; git log --pretty=format:\"%H\" -n 1') }}"
+    user_data_script_url: "https://raw.githubusercontent.com/rcbops/rpc-gating/{{ rpc_gating_git_sha }}/scripts/user_data_pubcloud.sh"
+    user_data_command: "curl --silent --show-error --fail --connect-timeout 5 --retry 3 {{ user_data_script_url }} | /bin/bash -e"
 
     logrotate_configs:
       - name: nodepool-builder

--- a/nodepool/templates/nodepool.yml.j2
+++ b/nodepool/templates/nodepool.yml.j2
@@ -161,11 +161,17 @@ providers:
             flavor-name: ironic-storage-perf
             key-name: jenkins
             console-log: true
+            userdata: |
+              #!/bin/bash
+              {{ user_data_command }}
           - name: ubuntu-xenial-om-io2
             cloud-image: baremetal-ubuntu-xenial
             flavor-name: ironic-storage-perf
             key-name: jenkins
             console-log: true
+            userdata: |
+              #!/bin/bash
+              {{ user_data_command }}
 
   - name: pubcloud-lon
     region-name: 'LON'
@@ -256,11 +262,17 @@ providers:
             flavor-name: onmetal-io2
             key-name: jenkins
             console-log: true
+            userdata: |
+              #!/bin/bash
+              {{ user_data_command }}
           - name: ubuntu-xenial-om-io2
             cloud-image: ubuntu-xenial-onmetal
             flavor-name: onmetal-io2
             key-name: jenkins
             console-log: true
+            userdata: |
+              #!/bin/bash
+              {{ user_data_command }}
 
   - name: pubcloud-ord
     region-name: 'ORD'

--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -4,8 +4,7 @@
   gather_facts: False
   vars:
     keyname: "jenkins"
-    inventory_path: "{{ lookup('env', 'WORKSPACE') }}/rpc-gating/playbooks/inventory"
-    user_data_path: "{{ lookup('env', 'WORKSPACE') }}/rpc-gating/scripts/user_data_pubcloud.sh"
+    inventory_path: "{{ playbook_dir }}/inventory"
     cloud_name: "public_cloud"
     boot_timeout: "{{ lookup('env', 'BOOT_TIMEOUT') | default(900, true) }}"
   tasks:
@@ -75,7 +74,7 @@
             image: "{{ _image | default(image) }}"
             key_name: "{{ keyname }}"
             security_groups: []
-            userdata: "{{ lookup('file', user_data_path) }}"
+            userdata: "{{ lookup('file', playbook_dir ~ '/../scripts/user_data_pubcloud.sh') }}"
             config_drive: yes
             meta:
               build_config: core
@@ -173,87 +172,3 @@
     - name: Wait for host preparation to complete
       pause:
         minutes: 5
-
-# Note(odyssey4me):
-# We use the raw module for this Ansible play because
-# we do not know if python and python-yaml are on the
-# system yet, and Ansible requires those installed to
-# use any modules other than raw.
-- hosts: singleuseslave
-  remote_user: root
-  gather_facts: False
-  tasks:
-    # To assist with debugging any problems if there
-    # is an apt failure, we set enable debugging.
-    - name: Add apt debug configuration
-      raw: echo 'Debug::Acquire::http "true";' > /etc/apt/apt.conf.d/99debug
-      args:
-        executable: /bin/bash
-
-    - name: Check whether python is present on the host
-      raw: |
-        if [[ -e /usr/bin/python ]]; then
-          echo -n yes
-        else
-          echo -n no
-        fi
-      register: _python_check
-
-    - name: Show the results of the python check
-      debug:
-        var: _python_check
-
-    - name: Install python onto the host if it is not already present
-      when:
-        - "not (_python_check.stdout | trim) | bool"
-      block:
-        # The apt sources in the OnMetal builds uses
-        # archive.ubuntu.com which has turned out to
-        # be a bit unreliable in providing complete
-        # data back when doing apt updates/installs.
-        # We prefer our local mirror which provides
-        # us with reliable and quick responses.
-        # ref: RE-1758
-        - name: Reconfigure the host to use Rackspace Mirrors
-          script: "{{ playbook_dir }}/../scripts/reconfigure_apt_sources.sh"
-
-        - name: Check the resulting apt sources file
-          raw: cat /etc/apt/sources.list
-          args:
-            executable: /bin/bash
-          register: _apt_sources_result
-
-        - name: Show the resulting apt sources file
-          debug:
-            var: _apt_sources_result
-
-        - name: Update apt cache
-          raw: apt-get update
-          args:
-            executable: /bin/bash
-          register: _update_cache
-          until: _update_cache is success
-          retries: 3
-          delay: 15
-
-        # We check to see whether the packages are available
-        # and where they will come from.
-        # ref: RE-1758
-        - name: Check the package candidates
-          raw: apt-cache policy python-minimal python-yaml
-          args:
-            executable: /bin/bash
-          register: _package_candidates
-
-        - name: Show the package candidates
-          debug:
-            var: _package_candidates
-
-        - name: Install minimal Ansible requirements so that Ansible can be used to setup the slave
-          raw: apt-get install -y python-minimal python-yaml
-          args:
-            executable: /bin/bash
-          register: _install_packages
-          until: _install_packages is success
-          retries: 3
-          delay: 15

--- a/playbooks/setup_openstack_instances.yml
+++ b/playbooks/setup_openstack_instances.yml
@@ -70,7 +70,7 @@
         image: "{{ instance['image'] | default('Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)') }}"
         key_name: "{{ keyname | default('jenkins') }}"
         security_groups: []
-        userdata: "{{ instance['userdata'] | default(omit) }}"
+        userdata: "{{ instance['userdata'] | default(lookup('file', playbook_dir ~ '/../scripts/user_data_pubcloud.sh')) }}"
         config_drive: yes
         meta: "{{ default_metadata | combine(instance['metadata'] | default({})) }}"
         wait: yes
@@ -143,40 +143,3 @@
       loop: "{{ (instance_list | default([])) | flatten(levels=1) }}"
       loop_control:
         loop_var: instance
-
-    - name: Add new hosts to bootstrap group
-      add_host:
-        name: "{{ item }}"
-        groups: new_hosts_to_bootstrap
-      loop: >-
-        {{
-          (instance_list | selectattr('state', 'defined') | selectattr('state', 'equalto', 'present') | map(attribute='name') | list) +
-          (instance_list | selectattr('state', 'undefined') | map(attribute='name') | list)
-        }}
-
-# Note(odyssey4me):
-# At this stage, Ansible may not be able to gather facts
-# because python is not present on the target host. We
-# therefore do not gather facts and have to use the raw
-# or script module only to get the pre-requisites installed.
-- name: Install Ansible prerequisites
-  hosts: new_hosts_to_bootstrap
-  gather_facts: no
-  user: root
-  tasks:
-    - name: Ensure python is installed
-      raw: |
-        set -e
-        if which apt-get >/dev/null && ! which python >/dev/null ; then
-          apt-get update
-          apt-get -y install python
-          exit 2
-        else
-          exit 0
-        fi
-      args:
-        executable: /bin/bash
-        warn: no
-      register: result
-      changed_when: "result.rc == 2"
-      failed_when: "result.rc not in [0, 2]"

--- a/scripts/user_data_pubcloud.sh
+++ b/scripts/user_data_pubcloud.sh
@@ -1,23 +1,123 @@
-#!/bin/bash
+#!/bin/bash -e
 
-# This file is used when creating public
-# cloud instances.
-# See playbooks/allocate_pubcloud.yml
+# This script is used as a user data file when building
+# machines which use images that are not managed by
+# nodepool. See https://cloud-init.io for more information
+# about how cloud-init uses user-data files.
+#
+# This script tries to ensure that the machine is prepared
+# in a consistent way and it has all the required packages
+# installed on it for jenkins/ansible to access it. Any
+# further preparation should be done using jenkins/ansible.
 
-source /etc/lsb-release
-
-# Delete configuration which enables automatic upgrades
-# to prevent the instance packages being upgraded before
-# the correct apt repositories have been configured.
-# ref: RE-458 / RE-473
-if [[ "${DISTRIB_CODENAME}" == "trusty" ]]; then
-    # The 'unattended-upgrades' package cannot
-    # be purged on trusty as it is a dependency
-    # for cloud-init. So instead we just remove
-    # the configuration.
-    rm -f /etc/apt/apt.conf.d/*unattended-upgrades
+# Get the distribution name
+echo -e "\n### Getting the distribution name ###\n"
+if [[ -e /etc/lsb-release ]]; then
+  source /etc/lsb-release
+  DISTRO_RELEASE=${DISTRIB_CODENAME}
+elif [[ -e /etc/os-release ]]; then
+  source /etc/os-release
+  DISTRO_RELEASE=${UBUNTU_CODENAME}
 else
-    export DEBIAN_FRONTEND=noninteractive
-    apt-get purge -y unattended-upgrades
+  echo "Unable to determine distribution due to missing lsb/os-release files."
+  exit 1
 fi
+
+# Save a backup of the original apt sources
+if [[ ! -f "/etc/apt/sources.list.original" ]]; then
+  echo -e "\n### Saving a backup of the original apt sources ###\n"
+  mv /etc/apt/sources.list /etc/apt/sources.list.original
+  echo -e "\n###Rewriting the apt sources ###\n"
+  DISTRO_MIRROR="http://mirror.rackspace.com/ubuntu"
+  DISTRO_COMPONENTS="main,universe"
+  cat << EOF >/etc/apt/sources.list
+deb ${DISTRO_MIRROR} ${DISTRO_RELEASE} ${DISTRO_COMPONENTS//,/ }
+deb ${DISTRO_MIRROR} ${DISTRO_RELEASE}-updates ${DISTRO_COMPONENTS//,/ }
+deb ${DISTRO_MIRROR} ${DISTRO_RELEASE}-backports ${DISTRO_COMPONENTS//,/ }
+deb ${DISTRO_MIRROR} ${DISTRO_RELEASE}-security ${DISTRO_COMPONENTS//,/ }
+EOF
+fi
+
+# Enable debug logging for apt to make diagnosis of apt failures easier
+if [[ ! -f "/etc/apt/apt.conf.d/99debug" ]]; then
+  echo -e "\n### Enabling apt debug logging ###\n"
+  echo 'Debug::Acquire::http "true";' > /etc/apt/apt.conf.d/99debug
+fi
+
+# Add jenkins user and group
+JENKINS_HOME="/var/lib/jenkins"
+if ! getent group jenkins &> /dev/null; then
+  echo -e "\n### Adding the jenkins group ###\n"
+  groupadd jenkins
+fi
+if ! getent passwd jenkins &> /dev/null; then
+  echo -e "\n### Adding the jenkins user ###\n"
+  useradd --gid jenkins \
+          --shell /bin/bash \
+          --home-dir ${JENKINS_HOME} \
+          --create-home jenkins
+fi
+
+# Fetch the rcbops public keys and add them to authorized_keys
+echo -e "\n### Fetching the rcbops public keys ###\n"
+SSH_PUBLIC_KEYS_URL="https://raw.githubusercontent.com/rcbops/rpc-gating/master/keys/rcb.keys"
+curl --silent \
+     --show-error \
+     --fail \
+     --connect-timeout 5 \
+     --retry 3 \
+     ${SSH_PUBLIC_KEYS_URL} > /tmp/ssh-public-keys
+
+echo -e "\n### Configuring authorized_keys for jenkins and root ###\n"
+for usr_home in /root ${JENKINS_HOME}; do
+  mkdir -p ${usr_home}/.ssh
+  chmod 700 ${usr_home}/.ssh
+  cat /tmp/ssh-public-keys >> ${usr_home}/.ssh/authorized_keys
+  chmod 644 ${usr_home}/.ssh/authorized_keys
+done
+
+# Configure sudoers for the jenkins user
+echo -e "\n### Configuring sudoers for jenkins ###\n"
+cat > /etc/sudoers.d/jenkins << EOF
+jenkins ALL=(ALL) NOPASSWD:ALL
+EOF
+chmod 0440 /etc/sudoers.d/jenkins
+
+# Ensure everything has the right owner
+echo -e "\n### Ensuring jenkins owns all jenkins home files ###\n"
+chown -R jenkins:jenkins ${JENKINS_HOME}
+
+# For Ubuntu Trusty add the openjdk PPA for access
+# to the openjdk8 packages
+echo -e "\n### Adding openjdk PPA for Ubuntu Trusty hosts ###\n"
+if [[ "${DISTRO_RELEASE}" == "trusty" ]]; then
+  add-apt-repository -y ppa:openjdk-r/ppa
+fi
+
+# Prepare the list of packages to install
+echo -e "\n### Preparing a list of packages to install ###\n"
+pkgs_required=""
+pkgs_to_install=""
+pkgs_required+=" openjdk-8-jre-headless" # for the jenkins agent
+pkgs_required+=" python-minimal" # required by ansible
+pkgs_required+=" python-yaml" # required by ansible
+
+for pkg in ${pkgs_required}; do
+  if ! dpkg-query --list ${pkg} &>/dev/null; then
+    pkgs_to_install+=" ${pkg}"
+  fi
+done
+
+# Update the apt cache and installing the required packages
+if [[ "${pkgs_to_install}" != "" ]]; then
+  echo -e "\n### Updating the apt cache ###\n"
+  apt-get update
+  echo -e "\n### Installing the required packages ###\n"
+  export DEBIAN_FRONTEND="noninteractive"
+  apt-get install -y ${pkgs_to_install}
+fi
+
+# Regardless of the last command's return code, ensure that the script exits
+# with RC=0, otherwise cloud-init may fail the boot.
+echo -e "\n### Host preparation complete ###\n"
 exit 0


### PR DESCRIPTION
Currently there are multiple methods for preparing a host for
tests:

1. In the jenkins nodepool plugin configuration, there is a script
   which executes on all target nodes to prepare the node for use.
   This script is used to add the jenkins user, add the ssh keys,
   add the JDK, etc. This is used for preparing OnMetal/Ironic
   hosts where we do not control the image.

2. In the setup_openstack_instances playbook, we use the raw Ansible
   module to add python to the target host so that Ansible is able
   to execute other tasks and modules on that host.
   This is used for preparing VM's where we do not control the image.

3. In the allocate_pubcloud playbook we use the raw and script
   modules to ensure that the apt sources are configured, apt debug
   logging is enabled, and that python and python-yaml are installed
   on the target host.
   This is used for preparing VM's where we do not control the image.

In this patch, we combine these all into a single script which is
used as userdata provided to cloud-init [1], which is present in all
the images for public cloud and Phobos.

In order to use this for nodepool, we also need to update the nodepool
SHA we use to include the support for userdata.

As part of this, we also make the following minor adjustments:

1. In the allocate_pubcloud playbook we use the Ansible playbook_dir
   magic variable, rather than refer to the WORKSPACE environment
   variable. This makes the playbook executable for testing without
   having to set the WORKSPACE environment variable.

2. In the user_data_publoud script, we remove the unattended upgrade
   disabling. Now that all RPC-O tests make use of nodepool images
   the issue which brought that content there is no longer relevant.

[1] https://cloud-init.io
Issue: [RE-1523](https://rpc-openstack.atlassian.net/browse/RE-1523)