### PR TITLE
RI-648 Change Master PM jobs to weekly

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -265,6 +265,7 @@
     repo_url: "https://github.com/rcbops/rpc-openstack"
     branch: "master"
     jira_project_key: "RO"
+    CRON: "{CRON_WEEKLY}"
     image:
       - bionic_mnaio_no_artifacts:
           SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"


### PR DESCRIPTION
Master is unstable, so we want to reduce the frequency of the jobs.

Issue: [RI-648](https://rpc-openstack.atlassian.net/browse/RI-648)