### PR TITLE
Set jenkins password before saving the image

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -52,6 +52,7 @@ ordereddict==1.1
 os-service-types==1.4.0
 packaging==18.0
 paramiko==2.4.2
+passlib==1.7.1
 pbr==5.1.1
 pip==18.1
 pluggy==0.8.1

--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1534,6 +1534,10 @@ List build_creds_array(String list_of_cred_ids){
       "RPC_OSP_REDHAT_USERNAME": string(
         credentialsId: "RPC_OSP_REDHAT_USERNAME",
         variable: "RPC_OSP_REDHAT_USERNAME"
+      ),
+      "IMAGE_JENKINS_PASSWORD": string(
+        credentialsId: "IMAGE_JENKINS_PASSWORD",
+        variable: "IMAGE_JENKINS_PASSWORD"
       )
     ]
 

--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -46,7 +46,7 @@ def savePubCloudSlave(Map args){
     clouds_cfg = common.writeCloudsCfg()
     env.OS_CLIENT_CONFIG_FILE = clouds_cfg
     env.SAVE_IMAGE_NAME = args.image
-    common.withRequestedCredentials("jenkins_ssh_privkey") {
+    common.withRequestedCredentials("jenkins_ssh_privkey IMAGE_JENKINS_PASSWORD") {
       common.venvPlaybook(
         playbooks: ['save_pubcloud.yml'],
         args: [

--- a/playbooks/save_pubcloud.yml
+++ b/playbooks/save_pubcloud.yml
@@ -33,6 +33,14 @@
         instance: "{{ openstack_servers[0] }}"
       delegate_to: localhost
 
+    - name: Set the password to help troubleshooting boot failures
+      user:
+        name: jenkins
+        update_password: always
+        password: "{{ lookup('env', 'IMAGE_JENKINS_PASSWORD') | password_hash('sha512', (65534 | random(seed=inventory_hostname)) | string) }}"
+      when:
+        - lookup('env', 'IMAGE_JENKINS_PASSWORD') != ""
+
     - name: Execute public cloud instance cleanup script
       script: "{{ lookup('env', 'WORKSPACE') }}/rpc-gating/scripts/rax_instance_clean.sh"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ jira
 jmespath
 openstacksdk
 packaging
+passlib
 python-dateutil
 python-swiftclient
 python-subunit


### PR DESCRIPTION
The snapshot images, when booting up, often fail and are inaccessible
via SSH. In order to enable troubleshooting this situation, we set the
password for the jenkins user before snapshotting the instance.

Issue: [RE-2278](https://rpc-openstack.atlassian.net/browse/RE-2278)