### PR TITLE
RE-2310 Add missing parameter name

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -2333,7 +2333,7 @@ void createRelease(String component_text, Boolean from_rc_branch, Boolean re_rel
       ],
       [
         $class: "BooleanParameterValue",
-        name: "",
+        name: "re_release",
         value: re_release,
       ],
     ]


### PR DESCRIPTION
The release job is a 3 level hierachy:
1. Component-Release-Trigger
2. Component-Release
3. RE-Release

1. Checks the comment to determine if "re-release" was specified
then passes that as a boolean parameter to 2.

The bug is that 1. passed the re release value as an unnamed param.
This commit corrects the param name.

Issue: [RE-2310](https://rpc-openstack.atlassian.net/browse/RE-2310)