### PR TITLE
RE-2310 fix shouldrerelease logic

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1982,7 +1982,7 @@ Boolean skipPullRequestTests(String triggerPhrase){
 * will be removed in order for the release to proceed
 */
 Boolean shouldReRelease(String reReleaseTriggerPhrase){
-  return (ghprbCommentBody =~ /\s*${reReleaseTriggerPhrase}\s*/).matches()
+  return (ghprbCommentBody =~ /\s*${reReleaseTriggerPhrase}\s*/)
 }
 
 List getComponentChange(String baseBranch, String prBranch){


### PR DESCRIPTION
Previously this function used .matches() however that requires
the pattern to match the whole string. The intention was for
search behaviour, where true is returned if the pattern can be
found at any position in the input string.

.matches() was added to ensure the result is Boolean, but as the
method signature declare a Boolean result, the match object is
automatically casted to Boolean so the call is unnecessary.