### PR TITLE
RE-2310 Fix release modifier regex matches

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1976,7 +1976,7 @@ void runReleasesPullRequestWorkflow(String baseBranch, String prBranch, String j
 }
 
 Boolean skipPullRequestTests(String triggerPhrase){
-  return (ghprbCommentBody =~ /\s*${triggerPhrase}\s*/).matches()
+  return (ghprbCommentBody ==~ /.*${triggerPhrase}.*/)
 }
 
 /**
@@ -1986,7 +1986,7 @@ Boolean skipPullRequestTests(String triggerPhrase){
 * will be removed in order for the release to proceed
 */
 Boolean shouldReRelease(String reReleaseTriggerPhrase){
-  return (ghprbCommentBody =~ /\s*${reReleaseTriggerPhrase}\s*/).matches()
+  return (ghprbCommentBody ==~ /.*${reReleaseTriggerPhrase}.*/)
 }
 
 List getComponentChange(String baseBranch, String prBranch){


### PR DESCRIPTION
matcher.matches() will only return true if the pattern matches the whole
input string. The patterns in use do not cover the whole input string
only the trigger part and surrounding whitespace. That means that
using the current code .matches() won't trigger.

In a previous commit I removed .matches() and it caused release
jobs to fail because Jenkins CPS groovy does not cooerce matcher
objects to Boolean when matching method signatures, but vanilla
groovy does.

Consider the following snippet:
```
def func(Boolean f){
  print f
}

Boolean match(){
    return ("foo" =~ /oo/)
}
func(match())
```
This snippet returns true in groovy and:
java.lang.NoSuchMethodError: No such DSL method 'func'

in Pipeline/CPS groovy, because theres no method func(Matcher f).

This commit removes the .matches() call, but changes the operator to ==~
which requires an exact match, and always returns a Boolean.
To accomodate this, the patterns have been expanded to allow any
text before and after the required pattern.

Test code:
```
def func (Boolean f){
    print f
}

m = "before foo  after" ==~ /.*oo.*/
assert m instanceof Boolean
func(m)
```

This outputs "true" in both groovy and cps groovy.

Issue: [RE-2310](https://rpc-openstack.atlassian.net/browse/RE-2310)