### PR TITLE
Add retry logic to wiki release page updates

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -84,6 +84,7 @@ six==1.12.0
 smmap2==2.0.5
 soupsieve==1.7.1
 stevedore==1.30.0
+tenacity==5.0.3
 testtools==2.3.0
 toml==0.10.0
 tox==3.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,5 @@ rackspaceauth
 requests[security]
 sh
 six
+tenacity
 urllib3


### PR DESCRIPTION
Confluence protects against unknowingly updating a page that has been
modified by using a page version ID. The ID supplied when an update is
requested must be exactly one larger than the current page version ID.
However this means that if there is a conflict, publishing the update
will fail causing the release build to fail. This change adds retry
logic so that any failures when attempting to update the wiki, with a
new version of the release page, will result in the process being rerun.
This means any new updates will be incorporated in the subsequent
attempt.

JIRA: RE-2327

Issue: [RE-2327](https://rpc-openstack.atlassian.net/browse/RE-2327)