### PR TITLE
[RI-656] Remove ELK Component from master gate

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -275,7 +275,6 @@
       - swift
     action:
       - deploy
-      - elk
       - sdqc
       - system
     # Required by RPC-ASC team to upload test results qTest


### PR DESCRIPTION
This removes the ELK component job from the master MNAIO gates.

JIRA: RI-656

Issue: [RI-656](https://rpc-openstack.atlassian.net/browse/RI-656)