### PR TITLE
RE-2354 Install groovy in Jenkins Lint jobs

### DIFF
--- a/job_dsl/standard_job_lint_jenkins.groovy
+++ b/job_dsl/standard_job_lint_jenkins.groovy
@@ -24,6 +24,16 @@ common.globalWraps(){
       String git_repo_url = common.https_to_ssh_github_url(env.REPO_URL)
       jobSources.removeAll { it.repo == git_repo_url || it.repo == "git@github.com:rcbops/rpc-gating"}
       String sourcesArgs = jobSources.collect {"--job-source \"${it.repo};${it.commitish}\""}.join(' ')
+      stage("Install Apt Packages"){
+        sh """#!/bin/bash -xe
+          # Groovy must be installed or the lint script will skip the groovy syntax checks.
+          # Package list lifted from gating/common/run_lint.sh
+          # OK to install packages as this job uses a single use instance.
+          sudo apt-get update && sudo apt-get install -y \
+            groovy2 python-pip build-essential python-dev libssl-dev \
+            curl libffi-dev sudo git-core
+        """
+      }
       stage("Lint Jenkins"){
         withCredentials([
           string(


### PR DESCRIPTION
This template is used to created lint jobs for team repos that contain
jjb definitions. Currently it doesn't ensure groovy is installed
so groovy checks are omitted. This commit fixes that by installing
groovy so that groovy scripts can be syntax checked.

Issue: [RE-2354](https://rpc-openstack.atlassian.net/browse/RE-2354)