### PR TITLE
RE-404 fix build summary image name

### DIFF
--- a/rpc_jobs/build_summary.yml
+++ b/rpc_jobs/build_summary.yml
@@ -22,9 +22,8 @@
             String shaName = docker_utils.toInternalRegistryName(env.IMAGE_NAME, sha, "re", env.RE_JOB_REPO_NAME, "-")
             image = docker_utils.pullOrBuild(shaName, null)
             if (env.RPC_GATING_BRANCH == "master"){
-              String latestName = docker_utils.toInternalRegistryName(env.IMAGE_NAME, "latest", "re", env.RE_JOB_REPO_NAME, "-")
-              image.tag(latestName)
-              docker_utils.withInternalRegistry({image.push(latestName)}, 3)
+              image.tag("latest")
+              docker_utils.withInternalRegistry({image.push("latest")}, 3)
             }
           }
         }


### PR DESCRIPTION
Previously the whole image URL was supplied as the tag name,
which lead to an invalid image name. This commit changes the
tag to "latest".

Issue: [RE-404](https://rpc-openstack.atlassian.net/browse/RE-404)