### PR TITLE
RE-2358 Fix bump snapshots for single release series

### DIFF
--- a/nodepool/templates/nodepool.yml.j2
+++ b/nodepool/templates/nodepool.yml.j2
@@ -34,10 +34,10 @@ labels:
 
   #g1-8
   - name: ubuntu-bionic-g1-8
-    min-ready: 1
+    min-ready: 0
     max-ready-age: 86400
   - name: ubuntu-xenial-g1-8
-    min-ready: 1
+    min-ready: 0
     max-ready-age: 86400
   - name: ubuntu-trusty-g1-8
     min-ready: 0
@@ -48,7 +48,7 @@ labels:
     min-ready: 0
     max-ready-age: 86400
   - name: ubuntu-xenial-p2-15
-    min-ready: 1
+    min-ready: 0
     max-ready-age: 86400
   - name: ubuntu-trusty-p2-15
     min-ready: 0
@@ -56,7 +56,7 @@ labels:
 
   # onmetal io2
   - name: ubuntu-bionic-om-io2
-    min-ready: 1
+    min-ready: 0
     max-ready-age: 86400
   - name: ubuntu-xenial-om-io2
     min-ready: 0
@@ -64,10 +64,10 @@ labels:
 
   # rpco base images
   - name: rpco-14.2-xenial-base
-    min-ready: 1
+    min-ready: 0
     max-ready-age: 86400
   - name: rpco-14.2-trusty-base
-    min-ready: 1
+    min-ready: 0
     max-ready-age: 86400
 
 providers:

--- a/nodepool/templates/nodepool.yml.j2
+++ b/nodepool/templates/nodepool.yml.j2
@@ -13,6 +13,9 @@ zookeeper-servers:
 
 labels:
   # rpco snapshots
+  - name: rpc-r14-trusty_loose_artifacts-swift
+    min-ready: 1
+    max-ready-age: 86400
   - name: rpc-r14-xenial_loose_artifacts-swift
     min-ready: 1
     max-ready-age: 86400
@@ -324,6 +327,9 @@ providers:
         image-name: "OnMetal - Ubuntu 18.04 LTS (Bionic Beaver)"
       - name: ubuntu-xenial-onmetal
         image-name: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
+      - name: rpc-r14-trusty_loose_artifacts-swift
+        image-name: rpc-r14.23.0-trusty_loose_artifacts-swift
+        config-drive: true
       - name: rpc-r14-xenial_loose_artifacts-swift-image
         image-name: rpc-r14.20.0-xenial_loose_artifacts-swift
         config-drive: true

--- a/playbooks/allocate_pubcloud.yml
+++ b/playbooks/allocate_pubcloud.yml
@@ -130,7 +130,7 @@
             image: "{{ _image | default(image) }}"
             key_name: "{{ keyname }}"
             security_groups: []
-            userdata: "{{ lookup('file', user_data_path) }}"
+            userdata: "{{ lookup('file', playbook_dir ~ '/../scripts/user_data_pubcloud.sh') }}"
             config_drive: yes
             meta:
               build_config: core

--- a/rpc_jobs/bump_snapshots.yml
+++ b/rpc_jobs/bump_snapshots.yml
@@ -41,6 +41,11 @@
               def rpcoReleases = readYaml text: componentData
 
               for ( r in rpcoReleases['releases'] ) {
+                if (r['versions'].size < 2){
+                  // If theres only one version in a series, there can be no previous
+                  // version, so we have no string to match in order to do the replacement.
+                  continue
+                }
                 if (r['series'] == 'newton') {
                   for ( s in ['trusty', 'xenial'] ) {
                     def image = "${s}_loose_artifacts-swift"


### PR DESCRIPTION
```
 761cd52 (Hugh Saunders, 8 minutes ago)
    RE-2358 Min-ready to 0

    Set min-ready to 0 for all labels that are available in multiple regions.
    Min-ready is ineffective in this scenario as requests are randomly assigned
    to regions rather than being inteligently routed to regions that have ready
    nodes.

 bdd0ec6 (Hugh Saunders, 11 minutes ago)
    RE-2358 Add newton trusty snapshot

    These images exist but aren't exposed in nodepool config.

 725e162 (Hugh Saunders, 15 minutes ago)
    RE-2358 Undefined variable in allocate_pubcloud

    The primary and secondary provision tasks had different values for the
    userdata param, one of which was an undefined var, this commit sets them
    both to the same lookup.

 b37c70d (Hugh Saunders, 16 minutes ago)
    RE-2358 Bump Snapshots: skip single release series

    Theres no need to bump versions until theres at least two releases in a
    series.
```

Issue: [RE-2358](https://rpc-openstack.atlassian.net/browse/RE-2358)