### PR TITLE
RE-2355 Allow standard jobs to use internal slave

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1245,9 +1245,13 @@ void standard_job_slave(String slave_type, Closure body){
       body()
     }
   } else if (slave_type.startsWith("nodepool-")) {
-      use_node(slave_type){
-        body()
-      }
+    use_node(slave_type){
+      body()
+    }
+  } else if (slave_type == "internal"){
+    internal_slave(){
+      body()
+    }
   } else if (slave_type == "shared") {
       // don't need to wrap body in shared_slave here
       // as globalWraps will have already allocated a shared slave executor

--- a/rpc_jobs/rpc_jenkins_etl.yml
+++ b/rpc_jobs/rpc_jenkins_etl.yml
@@ -50,8 +50,8 @@
     repo_url: 'https://github.com/rcbops/rpc-jenkins-etl'
     branch: "master"
     image:
-      - xenial:
-          SLAVE_TYPE: "nodepool-ubuntu-xenial-g1-8"
+      - centos:
+          SLAVE_TYPE: "internal"
     scenario: "basic"
     action: "integration"
     credentials: "rpc_asc_creds"


### PR DESCRIPTION
Required so ASC can run their ETL job that collects data from
the Jenkins API.

Issue: [RE-2355](https://rpc-openstack.atlassian.net/browse/RE-2355)