### PR TITLE
RE-2355 Add internal registry creds to ETL job

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -1460,11 +1460,24 @@ List build_creds_array(String list_of_cred_ids){
         "RPC_OSP_REDHAT_POOL_ID",
         "RPC_OSP_REDHAT_PASSWORD",
         "RPC_OSP_REDHAT_USERNAME"
+      ],
+      "kronos_docker_registry": [
+       "kronos_docker_registry_domain_name",
+       "kronos_mk8s_jenkins_account"
       ]
     ]
     // only needs to contain creds that should be exposed.
     // every cred added should also be documented in RE for Projects
     Map available_creds = [
+      "kronos_docker_registry_domain_name": string(
+        credentialsId: 'kronos_docker_registry_domain_name',
+        variable: 'kronos_docker_registry_domain_name'
+      ),
+      "kronos_mk8s_jenkins_account": usernamePassword(
+        credentialsId: "kronos_mk8s_jenkins_account",
+        usernameVariable: "kronos_mk8s_jenkins_username",
+        passwordVariable: "kronos_mk8s_jenkins_password"
+      ),
       "dev_pubcloud_username": string(
         credentialsId: "dev_pubcloud_username",
         variable: "PUBCLOUD_USERNAME"

--- a/rpc_jobs/rpc_jenkins_etl.yml
+++ b/rpc_jobs/rpc_jenkins_etl.yml
@@ -54,6 +54,6 @@
           SLAVE_TYPE: "internal"
     scenario: "basic"
     action: "integration"
-    credentials: "rpc_asc_creds"
+    credentials: "rpc_asc_creds, kronos_docker_registry"
     jobs:
       - "PM_{repo_name}-{branch}-{image}-{scenario}-{action}"


### PR DESCRIPTION
This job requires access to the Jenkins API as it pulls data from there
to send to google big query.

The only nodes we have with access to the Jenkins api are the master
and one TES node. This node runs centos6, which is a pain as it
uses python2.6

This job uses a docker image to insulate it from the host, allow
modern python and package installs etc. In order to push/pull the image
from the repo, creds are required.

Issue: [RE-2355](https://rpc-openstack.atlassian.net/browse/RE-2355)