### PR TITLE
Fix pull request release note testing

### DIFF
--- a/job_dsl/release.groovy
+++ b/job_dsl/release.groovy
@@ -4,19 +4,21 @@ common.globalWraps(){
     stage("Configure Git"){
       common.configure_git()
     }
+    stage("Install rpc_component"){
+      venv = "${WORKSPACE}/.componentvenv"
+      sh """#!/bin/bash -xe
+          virtualenv --python python3 ${venv}
+          set +x; . ${venv}/bin/activate; set -x
+          pip install -c '${env.WORKSPACE}/rpc-gating/constraints_rpc_component.txt' rpc_component
+      """
+    }
     stage("Verify component metadata"){
       // This stage is used by component pre-merge release tests only
       if ( env.ghprbPullId != null ) {
         common.clone_with_pr_refs(
           "${env.WORKSPACE}/${env.RE_JOB_REPO_NAME}",
         )
-        venv = "${WORKSPACE}/.componentvenv"
-        sh """#!/bin/bash -xe
-            virtualenv --python python3 ${venv}
-            set +x; . ${venv}/bin/activate; set -x
-            pip install -c '${env.WORKSPACE}/rpc-gating/constraints_rpc_component.txt' rpc_component
-        """
-        component_text = sh(
+        component_metadata_text = sh(
           script: """#!/bin/bash -xe
             set +x; . ${venv}/bin/activate; set -x
             cd "${env.WORKSPACE}/${env.RE_JOB_REPO_NAME}"
@@ -25,7 +27,7 @@ common.globalWraps(){
           returnStdout: true
         )
         println "=== component CLI standard out ==="
-        println component_text
+        println component_metadata_text
       }
     }
     stage("Release"){
@@ -33,6 +35,30 @@ common.globalWraps(){
       // of the environment variables automatically as
       // they will not be provided by a human.
       if ( env.ghprbPullId != null ) {
+        component_text = sh(
+          script: """#!/bin/bash -xe
+            set +x; . ${venv}/bin/activate; set -x
+            component get --component-name ${env.RE_JOB_REPO_NAME}
+          """,
+          returnStdout: true
+        )
+        componentData = readYaml text: component_text
+        String previousVersion
+        for (series in componentData.releases){
+          if (series.series == env.BRANCH){
+            previousVersion = series.versions[0].version
+            break
+          }
+        }
+        if (! previousVersion) {
+          try{
+            previousVersion = componentData.releases[0].versions[0].version
+          } catch (e){
+            previousVersion = env.BRANCH
+          }
+        }
+        println "Previous release version detected as '${previousVersion}'."
+        env.BRANCH = previousVersion
         List source_repo = env.ghprbGhRepository.split("/")
         env.ORG = source_repo[0]
         env.REPO = source_repo[1]


### PR DESCRIPTION
This change ensures that release notes pull requests test against the
most recent release, where most recent is dependent on the release
series. This ensures that the testing better matches the operation
performed by a release.

JIRA: RE-2360

Issue: [RE-2360](https://rpc-openstack.atlassian.net/browse/RE-2360)