### PR TITLE
RE-2306: Use shared slave for addArtifactTypeToComponent

### DIFF
--- a/pipeline_steps/common.groovy
+++ b/pipeline_steps/common.groovy
@@ -468,75 +468,77 @@ def archive_artifacts(Map args = [:]){
 }
 
 void addArtifactTypeToComponent(String componentName, String artifactStoreName, String artifactType, String url, String jiraProjectKey){
-  String gatingVenv = "${WORKSPACE}/.venv"
-  String componentVenv = "${WORKSPACE}/.componentvenv"
-  sh """#!/bin/bash -xe
-      virtualenv --python python3 ${componentVenv}
-      set +x; . ${componentVenv}/bin/activate; set -x
-      pip install -c '${env.WORKSPACE}/rpc-gating/constraints_rpc_component.txt' rpc_component
-  """
+  shared_slave() {
+    String gatingVenv = "${WORKSPACE}/.venv"
+    String componentVenv = "${WORKSPACE}/.componentvenv"
+    sh """#!/bin/bash -xe
+        virtualenv --python python3 ${componentVenv}
+        set +x; . ${componentVenv}/bin/activate; set -x
+        pip install -c '${env.WORKSPACE}/rpc-gating/constraints_rpc_component.txt' rpc_component
+    """
 
-  String releasesDir = "${WORKSPACE}/releases"
+    String releasesDir = "${WORKSPACE}/releases"
 
-  clone_with_pr_refs("${releasesDir}", "https://github.com/rcbops/releases", "master")
+    clone_with_pr_refs("${releasesDir}", "https://github.com/rcbops/releases", "master")
 
-  withEnv(
-    [
-      "ISSUE_SUMMARY=Add artefact container public URL to releases for ${componentName}",
-      "ISSUE_DESCRIPTION=This issue was generated automatically when artefacts were uploaded to a new container.",
-      "LABELS=component-artifacts jenkins",
-      "JIRA_PROJECT_KEY=${jiraProjectKey}",
-      "TARGET_BRANCH=master",
-      "COMMIT_TITLE=Update ${componentName} with new artifact store ${artifactStoreName}",
-      "COMMIT_MESSAGE=This change adds a new artifact store to the component definition.",
-    ]
-  ){
-    withCredentials(
+    withEnv(
       [
-        string(
-          credentialsId: 'rpc-jenkins-svc-github-pat',
-          variable: 'PAT'
-        ),
-        usernamePassword(
-          credentialsId: "jira_user_pass",
-          usernameVariable: "JIRA_USER",
-          passwordVariable: "JIRA_PASS"
-        ),
+        "ISSUE_SUMMARY=Add artefact container public URL to releases for ${componentName}",
+        "ISSUE_DESCRIPTION=This issue was generated automatically when artefacts were uploaded to a new container.",
+        "LABELS=component-artifacts jenkins",
+        "JIRA_PROJECT_KEY=${jiraProjectKey}",
+        "TARGET_BRANCH=master",
+        "COMMIT_TITLE=Update ${componentName} with new artifact store ${artifactStoreName}",
+        "COMMIT_MESSAGE=This change adds a new artifact store to the component definition.",
       ]
     ){
-      sshagent (credentials:['rpc-jenkins-svc-github-ssh-key']){
-        try{
-          sh """#!/bin/bash -xe
-            cd ${releasesDir}
-            set +x; . ${componentVenv}/bin/activate; set -x
-            component \
-              --releases-dir . \
-              artifact-store \
-                --component-name ${componentName} \
-                get \
-                  --name ${artifactStoreName}
-          """
-        } catch (Exception e){
-          println "Failed to find artefact store, ${e}."
-          println "Adding new artefact store."
-          sh """#!/bin/bash -xe
-            cd ${releasesDir}
-            set +x; . ${componentVenv}/bin/activate; set -x
-            component \
-              --no-commit-changes \
-              --releases-dir . \
-              artifact-store \
-                --component-name ${componentName} \
-                add \
-                  --name ${artifactStoreName} \
-                  --type ${artifactType} \
-                  --public-url ${url}
-            deactivate
-            set +x; . ${gatingVenv}/bin/activate; set -x
-            git status
-            git diff
-            ${WORKSPACE}/rpc-gating/scripts/commit_and_pull_request.sh
-          """
+      withCredentials(
+        [
+          string(
+            credentialsId: 'rpc-jenkins-svc-github-pat',
+            variable: 'PAT'
+          ),
+          usernamePassword(
+            credentialsId: "jira_user_pass",
+            usernameVariable: "JIRA_USER",
+            passwordVariable: "JIRA_PASS"
+          ),
+        ]
+      ){
+        sshagent (credentials:['rpc-jenkins-svc-github-ssh-key']){
+          try{
+            sh """#!/bin/bash -xe
+              cd ${releasesDir}
+              set +x; . ${componentVenv}/bin/activate; set -x
+              component \
+                --releases-dir . \
+                artifact-store \
+                  --component-name ${componentName} \
+                  get \
+                    --name ${artifactStoreName}
+            """
+          } catch (Exception e){
+            println "Failed to find artefact store, ${e}."
+            println "Adding new artefact store."
+            sh """#!/bin/bash -xe
+              cd ${releasesDir}
+              set +x; . ${componentVenv}/bin/activate; set -x
+              component \
+                --no-commit-changes \
+                --releases-dir . \
+                artifact-store \
+                  --component-name ${componentName} \
+                  add \
+                    --name ${artifactStoreName} \
+                    --type ${artifactType} \
+                    --public-url ${url}
+              deactivate
+              set +x; . ${gatingVenv}/bin/activate; set -x
+              git status
+              git diff
+              ${WORKSPACE}/rpc-gating/scripts/commit_and_pull_request.sh
+            """
+          }
         }
       }
     }


### PR DESCRIPTION
addArtifactTypeToComponent requires a number of C libraries to be
installed which causes errors if the slave does not have them. This
change moves addArtifactTypeToComponent to use a shared slave so that
project slaves do not have additional requirements placed on them given
the potential for conflict or absence.

JIRA: RE-2306

Issue: [RE-2306](https://rpc-openstack.atlassian.net/browse/RE-2306)