### PR TITLE
Ensure that glean sets up eth0 on boot of snapshots

### DIFF
--- a/scripts/rax_instance_clean.sh
+++ b/scripts/rax_instance_clean.sh
@@ -58,9 +58,15 @@ fi
 
 # Ensure that rc.local executes on startup
 # This is only required for SystemD and is
-# therefore only applied to Xenial.
-if [[ "${DISTRIB_CODENAME}" == "xenial" ]]; then
+# therefore not applied to trusty.
+if [[ "${DISTRIB_CODENAME}" != "trusty" ]]; then
     systemctl enable rc-local.service
+fi
+
+# Ensure that glean sets up the eth0 network interface
+# on boot.
+if [[ -f /usr/lib/systemd/system/glean\@.service ]]; then
+  systemctl enable glean@eth0.service
 fi
 
 # Set the host ssh keys to regenerate at first boot if


### PR DESCRIPTION
When booting up a snapshot, there are no network interfaces present.
The 'glean' service should set them up automagically once the devices
are present, but it is not working. To work around this, we enable
the service ourselves before we shut the instance down. It will then
start on boot and the new instance should have network connectivity.

Issue: [RE-2278](https://rpc-openstack.atlassian.net/browse/RE-2278)