### PR TITLE
Ensure that interfaces setup by glean are removed

### DIFF
--- a/nodepool/templates/nodepool.yml.j2
+++ b/nodepool/templates/nodepool.yml.j2
@@ -331,7 +331,7 @@ providers:
         image-name: rpc-r14.23.0-trusty_loose_artifacts-swift
         config-drive: true
       - name: rpc-r14-xenial_loose_artifacts-swift-image
-        image-name: rpc-r14.20.0-xenial_loose_artifacts-swift
+        image-name: rpc-r14.23.0-xenial_loose_artifacts-swift
         config-drive: true
       - name: rpc-r16-xenial_no_artifacts-swift-image
         image-name: rpc-r16.2.8-xenial_no_artifacts-swift

--- a/scripts/rax_instance_clean.sh
+++ b/scripts/rax_instance_clean.sh
@@ -69,6 +69,9 @@ if [[ -f /usr/lib/systemd/system/glean\@.service ]]; then
   systemctl enable glean@eth0.service
 fi
 
+# Ensure that the interfaces previous setup by glean are removed
+rm -f /etc/network/interfaces.d/eth{0,1}.cfg
+
 # Set the host ssh keys to regenerate at first boot if
 # they are missing.
 cp /etc/rc.local /etc/rc.local.bak


### PR DESCRIPTION
When booting up a snapshot, if there are previously implemented
interfaces present which were setup by glean, glean will skip
setting up new interfaces from config_drive. To ensure that the
new instance gets new interfaces setup, we force the removal of
the old interfaces.

For systemd environments, the clean-up happens automatically -
but for upstart environments that doesn't happen, so we need to
ensure it is forced.

Also, the snapshot bump job has been failing for some time due to
issues with the snapshots, and the job only caters for a single version
bump. RPC-O newton released several tags in quick succession, so
we need to manually bump this to the most recent release because
the job won't do it automatically.

Issue: [RE-2278](https://rpc-openstack.atlassian.net/browse/RE-2278)