### PR TITLE
RE-2348: Prevent failure when removing non-existent slave

### DIFF
--- a/pipeline_steps/pubcloud.groovy
+++ b/pipeline_steps/pubcloud.groovy
@@ -124,6 +124,7 @@ def delPubCloudSlave(Map args){
       input message: "Continue?"
     }
   )
+  ssh_slave.destroy(args.instance_name)
   common.conditionalStep(
     step_name: 'Cleanup',
     step: {
@@ -132,7 +133,6 @@ def delPubCloudSlave(Map args){
       cleanup (args)
     }
   )
-  ssh_slave.destroy(args.instance_name)
 }
 
 // if the instance params are set in the environment

--- a/scripts/jenkins_node.py
+++ b/scripts/jenkins_node.py
@@ -20,6 +20,7 @@ import os
 import re
 
 
+from jenkinsapi.custom_exceptions import UnknownNode
 from jenkinsapi.jenkins import Jenkins
 
 
@@ -44,8 +45,17 @@ def create_node(jenkins, host_ip, name, credential_description, executors,
 
 
 def delete_node(jenkins, name):
-    print("Removing Slave from Jenkins: {}".format(name))
-    jenkins.delete_node(nodename=name)
+    print("Removing node from Jenkins: {}".format(name))
+    try:
+        jenkins.delete_node(nodename=name)
+    except UnknownNode:
+        print(
+            "Node '{node}' does not exist, nothing to delete.".format(
+                node=name,
+            )
+        )
+    else:
+        print("Node '{node}' has been deleted.".format(node=name))
 
 
 def delete_inactive_nodes(jenkins, protected_prefix):


### PR DESCRIPTION
The legacy method of provisioning slaves using playbooks as part of the
build (not Nodepool) is still used in some cases. Part of the clean up
during the build is to delete the node from Jenkins. Removing the slave
from Jenkins when it does not exist causes a build failure. This change
updates the code to prevent false-positives from these failures causing
builds to fail or mask the true failure.

There are two changes made by this patch:
- The delete call in the Python script is wrapped with exception
  handling so that failures when deleting unknown nodes do not
  propagate.
- `ssh_slave.destroy` is used to delete the node from Jenkins and is now
  performed before the instance is destroyed so that it doesn't
  disappear from Jenkins while still registered and result in misleading
  logs.

Clean up when node present: https://rpc.jenkins.cit.rackspace.net/job/RE-unit-test-phobos-vpn/2056/console
Clean up when node absent: https://rpc.jenkins.cit.rackspace.net/job/RE-unit-test-phobos-vpn/2057/console

JIRA: RE-2348

Issue: [RE-2348](https://rpc-openstack.atlassian.net/browse/RE-2348)