### PR TITLE
Allow rpc-gating branch overrides for all jobs

### DIFF
--- a/job_dsl/release.groovy
+++ b/job_dsl/release.groovy
@@ -1,4 +1,8 @@
-library "rpc-gating-master"
+if (env.RPC_GATING_BRANCH != "master") {
+  library "rpc-gating@${env.RPC_GATING_BRANCH}"
+} else {
+  library "rpc-gating-master"
+}
 common.globalWraps(){
   common.standard_job_slave(env.SLAVE_TYPE) {
     stage("Configure Git"){

--- a/job_dsl/rpc_artifact_build.groovy
+++ b/job_dsl/rpc_artifact_build.groovy
@@ -1,7 +1,11 @@
 // Can't use env.FOO = {FOO} to transfer JJB vars to groovy
 // as this file won't be templated by JJB.
 // Alternative is to use parameters with JJB vars as the defaults.
-library "rpc-gating-master"
+if (env.RPC_GATING_BRANCH != "master") {
+  library "rpc-gating@${env.RPC_GATING_BRANCH}"
+} else {
+  library "rpc-gating-master"
+}
 common.globalWraps(){
   image_list = [
     "nodepool-rpco-14.2-xenial-base",

--- a/job_dsl/rpc_gating_merge_trigger.groovy
+++ b/job_dsl/rpc_gating_merge_trigger.groovy
@@ -1,7 +1,11 @@
 // Can't use env.FOO = {FOO} to transfer JJB vars to groovy
 // as this file won't be templated by JJB.
 // Alternative is to use parameters with JJB vars as the defaults.
-library "rpc-gating-master"
+if (env.RPC_GATING_BRANCH != "master") {
+  library "rpc-gating@${env.RPC_GATING_BRANCH}"
+} else {
+  library "rpc-gating-master"
+}
 common.globalWraps(){
 
   // We do not want to trigger any of these

--- a/job_dsl/rpc_repo_verify.groovy
+++ b/job_dsl/rpc_repo_verify.groovy
@@ -1,4 +1,8 @@
-library "rpc-gating-master"
+if (env.RPC_GATING_BRANCH != "master") {
+  library "rpc-gating@${env.RPC_GATING_BRANCH}"
+} else {
+  library "rpc-gating-master"
+}
 common.globalWraps(){
   common.use_node('ArtifactBuilder2') {
     // ArtifactBuilder2 only has a single executor, so no other jobs will be attempting to

--- a/job_dsl/standard_job_dep_update.groovy
+++ b/job_dsl/standard_job_dep_update.groovy
@@ -1,7 +1,11 @@
 // Can't use env.FOO = {FOO} to transfer JJB vars to groovy
 // as this file won't be templated by JJB.
 // Alternative is to use parameters with JJB vars as the defaults.
-library "rpc-gating-master"
+if (env.RPC_GATING_BRANCH != "master") {
+  library "rpc-gating@${env.RPC_GATING_BRANCH}"
+} else {
+  library "rpc-gating-master"
+}
 common.globalWraps(){
   common.standard_job_slave(env.SLAVE_TYPE) {
     try {

--- a/job_dsl/standard_job_lint_jenkins.groovy
+++ b/job_dsl/standard_job_lint_jenkins.groovy
@@ -1,4 +1,8 @@
-library "rpc-gating-master"
+if (env.RPC_GATING_BRANCH != "master") {
+  library "rpc-gating@${env.RPC_GATING_BRANCH}"
+} else {
+  library "rpc-gating-master"
+}
 common.globalWraps(){
   common.standard_job_slave(env.SLAVE_TYPE) {
     try {

--- a/rpc_jobs/bump_snapshots.yml
+++ b/rpc_jobs/bump_snapshots.yml
@@ -17,7 +17,12 @@
         }
       }
 
-      library "rpc-gating@${RPC_GATING_BRANCH}"
+      if (env.RPC_GATING_BRANCH != "master") {
+        library "rpc-gating@${env.RPC_GATING_BRANCH}"
+      } else {
+        library "rpc-gating-master"
+      }
+
       common.globalWraps(){
         // Outer try ensures that a Jira issue is created for unexpected failure
         List releases = []

--- a/rpc_jobs/standard_job_gate.yml
+++ b/rpc_jobs/standard_job_gate.yml
@@ -97,5 +97,9 @@
             A comma separated list of pull requsts IDs to enable the testing of a chain of pull requests.
 
     dsl: |
-      library "rpc-gating-master"
+      if (env.RPC_GATING_BRANCH != "master") {{
+        library "rpc-gating@${{env.RPC_GATING_BRANCH}}"
+      }} else {{
+        library "rpc-gating-master"
+      }}
       common.stdJob("gate", "{credentials}", "", "{wrappers}")

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -90,5 +90,9 @@
       - timed: "{CRON}"
 
     dsl: |
-      library "rpc-gating-master"
+      if (env.RPC_GATING_BRANCH != "master") {{
+        library "rpc-gating@${{env.RPC_GATING_BRANCH}}"
+      }} else {{
+        library "rpc-gating-master"
+      }}
       common.stdJob("periodic", "{credentials}", "{jira_project_key}", "{wrappers}")

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -84,9 +84,11 @@
           cancel-builds-on-update: true
 
     dsl: |
-      if ("{repo_name}" == "rpc-gating"){{
-        env.RPC_GATING_BRANCH = "origin/pr/${{env.ghprbPullId}}/merge"
-        library "rpc-gating@${{RPC_GATING_BRANCH}}"
+      if (env.RPC_GATING_BRANCH != "master") {{
+        if ("{repo_name}" == "rpc-gating") {{
+          env.RPC_GATING_BRANCH = "origin/pr/${{env.ghprbPullId}}/merge"
+        }}
+        library "rpc-gating@${{env.RPC_GATING_BRANCH}}"
       }} else {{
         library "rpc-gating-master"
       }}


### PR DESCRIPTION
Some jobs cannot currently have the rpc-gating branch changed.
This fixes that and ensures that they are all consistently
implemented.

Issue: [RE-2278](https://rpc-openstack.atlassian.net/browse/RE-2278)