### PR TITLE
Reduce nodepool host name length

### DIFF
--- a/nodepool/templates/nodepool.yml.j2
+++ b/nodepool/templates/nodepool.yml.j2
@@ -13,22 +13,22 @@ zookeeper-servers:
 
 labels:
   # rpco snapshots
-  - name: rpc-r14-trusty_loose_artifacts-swift
+  - name: rpc-r14-trusty-swift
     min-ready: 1
     max-ready-age: 86400
-  - name: rpc-r14-xenial_loose_artifacts-swift
+  - name: rpc-r14-xenial-swift
     min-ready: 1
     max-ready-age: 86400
-  - name: rpc-r16-xenial_no_artifacts-swift
+  - name: rpc-r16-xenial-swift
     min-ready: 1
     max-ready-age: 86400
-  - name: rpc-r17-xenial_no_artifacts-swift
+  - name: rpc-r17-xenial-swift
     min-ready: 1
     max-ready-age: 86400
-  - name: rpc-r18-xenial_no_artifacts-swift
+  - name: rpc-r18-xenial-swift
     min-ready: 1
     max-ready-age: 86400
-  - name: rpc-r18-bionic_no_artifacts-swift
+  - name: rpc-r18-bionic-swift
     min-ready: 1
     max-ready-age: 86400
 
@@ -75,13 +75,13 @@ providers:
     region-name: "RegionOne"
     cloud: phobos_nodepool
     boot-timeout: 600
-    hostname-format: nodepool-{label.name}-{provider.name}-{node.id}
+    hostname-format: nodepool-{label.name}-{node.id}
     cloud-images:
       - name: baremetal-ubuntu-bionic
         image-name: baremetal-ubuntu-bionic
       - name: baremetal-ubuntu-xenial
         image-name: baremetal-ubuntu-xenial
-    image-name-format: nodepool-phobos-{image_name}-{timestamp}
+    image-name-format: nodepool-{image_name}-{timestamp}
     diskimages:
       - name: ubuntu-bionic
         config-drive: true
@@ -180,7 +180,7 @@ providers:
     region-name: 'LON'
     cloud: pubcloud_uk
     boot-timeout: 600
-    hostname-format: nodepool-{label.name}-{provider.name}-{node.id}
+    hostname-format: nodepool-{label.name}-{node.id}
     cloud-images: &provider_cloudimage_block
       - name: ubuntu-bionic-onmetal
         image-name: "OnMetal - Ubuntu 18.04 LTS (Bionic Beaver)"
@@ -281,7 +281,7 @@ providers:
     region-name: 'ORD'
     cloud: public_cloud
     boot-timeout: 120
-    hostname-format: nodepool-{label.name}-{provider.name}-{node.id}
+    hostname-format: nodepool-{label.name}-{node.id}
     image-name-format: nodepool-{image_name}-{timestamp}
     diskimages: *provider_diskimage_block
     pools:
@@ -294,7 +294,7 @@ providers:
     region-name: 'IAD'
     cloud: public_cloud
     boot-timeout: 600
-    hostname-format: nodepool-{label.name}-{provider.name}-{node.id}
+    hostname-format: nodepool-{label.name}-{node.id}
     cloud-images: *provider_cloudimage_block
     image-name-format: nodepool-{image_name}-{timestamp}
     diskimages: *provider_diskimage_block
@@ -321,28 +321,28 @@ providers:
     cloud: public_cloud
     # Higher boot-timeout value that for other providers to support snapshots
     boot-timeout: 1800
-    hostname-format: nodepool-{label.name}-{provider.name}-{node.id}
+    hostname-format: nodepool-{label.name}-{node.id}
     cloud-images:
       - name: ubuntu-bionic-onmetal
         image-name: "OnMetal - Ubuntu 18.04 LTS (Bionic Beaver)"
       - name: ubuntu-xenial-onmetal
         image-name: "OnMetal - Ubuntu 16.04 LTS (Xenial Xerus)"
-      - name: rpc-r14-trusty_loose_artifacts-swift
+      - name: rpc-r14-trusty-swift-image
         image-name: rpc-r14.23.0-trusty_loose_artifacts-swift
         config-drive: true
-      - name: rpc-r14-xenial_loose_artifacts-swift-image
+      - name: rpc-r14-xenial-swift-image
         image-name: rpc-r14.23.0-xenial_loose_artifacts-swift
         config-drive: true
-      - name: rpc-r16-xenial_no_artifacts-swift-image
+      - name: rpc-r16-xenial-swift-image
         image-name: rpc-r16.2.8-xenial_no_artifacts-swift
         config-drive: true
-      - name: rpc-r17-xenial_no_artifacts-swift-image
+      - name: rpc-r17-xenial-swift-image
         image-name: rpc-r17.1.4-xenial_no_artifacts-swift
         config-drive: true
-      - name: rpc-r18-xenial_no_artifacts-swift-image
+      - name: rpc-r18-xenial-swift-image
         image-name: rpc-r18.0.0-xenial_no_artifacts-swift
         config-drive: true
-      - name: rpc-r18-bionic_no_artifacts-swift-image
+      - name: rpc-r18-bionic-swift-image
         image-name: rpc-r18.0.0-xenial_no_artifacts-swift
         config-drive: true
     image-name-format: nodepool-{image_name}-{timestamp}
@@ -373,28 +373,33 @@ providers:
         max-servers: 15
         availability-zones: []
         labels:
-          - name: rpc-r14-xenial_loose_artifacts-swift
-            cloud-image: rpc-r14-xenial_loose_artifacts-swift-image
+          - name: rpc-r14-trusty-swift
+            cloud-image: rpc-r14-trusty-swift-image
             flavor-name: "15GB Standard Instance"
             key-name: jenkins
             console-log: true
-          - name: rpc-r16-xenial_no_artifacts-swift
-            cloud-image: rpc-r16-xenial_no_artifacts-swift-image
+          - name: rpc-r14-xenial-swift
+            cloud-image: rpc-r14-xenial-swift-image
             flavor-name: "15GB Standard Instance"
             key-name: jenkins
             console-log: true
-          - name: rpc-r17-xenial_no_artifacts-swift
-            cloud-image: rpc-r17-xenial_no_artifacts-swift-image
+          - name: rpc-r16-xenial-swift
+            cloud-image: rpc-r16-xenial-swift-image
             flavor-name: "15GB Standard Instance"
             key-name: jenkins
             console-log: true
-          - name: rpc-r18-xenial_no_artifacts-swift
-            cloud-image: rpc-r18-xenial_no_artifacts-swift-image
+          - name: rpc-r17-xenial-swift
+            cloud-image: rpc-r17-xenial-swift-image
             flavor-name: "15GB Standard Instance"
             key-name: jenkins
             console-log: true
-          - name: rpc-r18-bionic_no_artifacts-swift
-            cloud-image: rpc-r18-bionic_no_artifacts-swift-image
+          - name: rpc-r18-xenial-swift
+            cloud-image: rpc-r18-xenial-swift-image
+            flavor-name: "15GB Standard Instance"
+            key-name: jenkins
+            console-log: true
+          - name: rpc-r18-bionic-swift
+            cloud-image: rpc-r18-bionic-swift-image
             flavor-name: "15GB Standard Instance"
             key-name: jenkins
             console-log: true

--- a/rpc_jobs/rpc_appformix.yml
+++ b/rpc_jobs/rpc_appformix.yml
@@ -14,13 +14,13 @@
 
     scenario:
       - newton:
-          SLAVE_TYPE: "nodepool-rpc-r14-xenial_loose_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r14-xenial-swift"
       - pike:
-          SLAVE_TYPE: "nodepool-rpc-r16-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r16-xenial-swift"
       - queens:
-          SLAVE_TYPE: "nodepool-rpc-r17-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r17-xenial-swift"
       - rocky:
-          SLAVE_TYPE: "nodepool-rpc-r18-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r18-xenial-swift"
     action:
       - "functional"
 
@@ -71,13 +71,13 @@
 
     scenario:
       - newton:
-          SLAVE_TYPE: "nodepool-rpc-r14-xenial_loose_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r14-xenial-swift"
       - pike:
-          SLAVE_TYPE: "nodepool-rpc-r16-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r16-xenial-swift"
       - queens:
-          SLAVE_TYPE: "nodepool-rpc-r17-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r17-xenial-swift"
       - rocky:
-          SLAVE_TYPE: "nodepool-rpc-r18-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r18-xenial-swift"
     action:
       - "functional"
 

--- a/rpc_jobs/rpc_barbican.yml
+++ b/rpc_jobs/rpc_barbican.yml
@@ -13,7 +13,7 @@
     hold_on_error: "4h"
     scenario:
       - rocky:
-          SLAVE_TYPE: "nodepool-rpc-r18-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r18-xenial-swift"
     action:
       - "deploy"
     jira_project_key: "RI"
@@ -33,7 +33,7 @@
       - xenial_snapshot
     scenario:
       - rocky:
-          SLAVE_TYPE: "nodepool-rpc-r18-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r18-xenial-swift"
     action:
       - "deploy"
     jira_project_key: "RI"

--- a/rpc_jobs/rpc_designate.yml
+++ b/rpc_jobs/rpc_designate.yml
@@ -16,7 +16,7 @@
 
     scenario:
       - rocky:
-          SLAVE_TYPE: "nodepool-rpc-r18-bionic_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r18-bionic-swift"
     action:
       - "deploy"
 
@@ -42,7 +42,7 @@
 
     scenario:
       - rocky:
-          SLAVE_TYPE: "nodepool-rpc-r18-bionic_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r18-bionic-swift"
     action:
       - "deploy"
 
@@ -70,13 +70,13 @@
 
     scenario:
       - newton:
-          SLAVE_TYPE: "nodepool-rpc-r14-xenial_loose_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r14-xenial-swift"
       - pike:
-          SLAVE_TYPE: "nodepool-rpc-r16-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r16-xenial-swift"
       - queens:
-          SLAVE_TYPE: "nodepool-rpc-r17-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r17-xenial-swift"
       - rocky:
-          SLAVE_TYPE: "nodepool-rpc-r18-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r18-xenial-swift"
     action:
       - "deploy"
 
@@ -99,13 +99,13 @@
 
     scenario:
       - newton:
-          SLAVE_TYPE: "nodepool-rpc-r14-xenial_loose_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r14-xenial-swift"
       - pike:
-          SLAVE_TYPE: "nodepool-rpc-r16-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r16-xenial-swift"
       - queens:
-          SLAVE_TYPE: "nodepool-rpc-r17-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r17-xenial-swift"
       - rocky:
-          SLAVE_TYPE: "nodepool-rpc-r18-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r18-xenial-swift"
     action:
       - "deploy"
 

--- a/rpc_jobs/rpc_maas.yml
+++ b/rpc_jobs/rpc_maas.yml
@@ -259,7 +259,7 @@
     CRON: "{CRON_DAILY}"
     image:
       - "rpc-r14-trusty_loose_artifacts-swift":
-          SLAVE_TYPE: "nodepool-rpc-r14-trusty_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r14-trusty-swift"
     scenario:
       - newton
     action:
@@ -275,8 +275,8 @@
     branch: "master"
     CRON: "{CRON_DAILY}"
     image:
-      - "rpc-r14-xenial_loose_artifacts-swift":
-          SLAVE_TYPE: "nodepool-rpc-r14-xenial_no_artifacts-swift"
+      - "rpc-r14-xenial-swift":
+          SLAVE_TYPE: "nodepool-rpc-r14-xenial-swift"
     scenario:
       - newton
     action:
@@ -293,7 +293,7 @@
     CRON: "{CRON_DAILY}"
     image:
       - "rpc-r16-xenial_loose_artifacts-swift":
-          SLAVE_TYPE: "nodepool-rpc-r16-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r16-xenial-swift"
     scenario:
       - pike
     action:
@@ -310,7 +310,7 @@
     CRON: "{CRON_DAILY}"
     image:
       - "rpc-r17-xenial_loose_artifacts-swift":
-          SLAVE_TYPE: "nodepool-rpc-r17-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r17-xenial-swift"
     scenario:
       - queens
     action:
@@ -327,7 +327,7 @@
     CRON: "{CRON_DAILY}"
     image:
       - "rpc-r18-xenial_loose_artifacts-swift":
-          SLAVE_TYPE: "nodepool-rpc-r18-xenial_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r18-xenial-swift"
     scenario:
       - rocky
     action:
@@ -344,7 +344,7 @@
     CRON: "{CRON_DAILY}"
     image:
       - "rpc-r18-bionic_loose_artifacts-swift":
-          SLAVE_TYPE: "nodepool-rpc-r18-bionic_no_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r18-bionic-swift"
     scenario:
       - rocky
     action:

--- a/rpc_jobs/rpc_octavia.yml
+++ b/rpc_jobs/rpc_octavia.yml
@@ -16,7 +16,7 @@
     # Use image for RPC-O install
     image:
       - xenial_snapshot:
-          SLAVE_TYPE: "nodepool-rpc-r14-xenial_loose_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r14-xenial-swift"
 
     # Octavia ignores that setting for now
     scenario:
@@ -44,7 +44,7 @@
     # upstream installer
     branch:
       - "master":
-          SLAVE_TYPE: "nodepool-rpc-r14-xenial_loose_artifacts-swift"
+          SLAVE_TYPE: "nodepool-rpc-r14-xenial-swift"
 
     # Use image for RPC-O install
     image:


### PR DESCRIPTION
The current nodepool nodes have a host name which includes a lot
of unnecessary information. For example, the provider does not
need to be included in the host name. Also, some of the label
names are based on very long image names, and the label name is
also included in the host name.

This, in some circumstances, results in a host name which exceeds
the maximum of 63 characters. For example, the following is 67
characters:

nodepool-rpc-r18-xenial_no_artifacts-swift-pubcloud-dfw-0000152558

When trying to set this host name, glean fails because the operating
system rejects it. This causes glean to fail and not continue to
implement the network interfaces, resulting in connectivity for the
node never coming up.

To resolve this, we remove the unnecessary inclusion of the provider
in the host name and we also shorten the nodepool labels to only
include the necessary information to differentiate it. We also then
change all the jobs to make use of the correct new labels.

Finally, we add a missing entry to ensure that the label
'rpc-r14-trusty-swift' has a provider.

ref: https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames
Issue: [RE-2278](https://rpc-openstack.atlassian.net/browse/RE-2278)