### PR TITLE
ASC-1564 Create healthcheck checkmarx job

### DIFF
--- a/rpc_jobs/rpc_asc.yml
+++ b/rpc_jobs/rpc_asc.yml
@@ -32,5 +32,8 @@
       - moleculerize:
           repo_url: "https://github.com/rcbops/moleculerize"
           branch: master
+      - rpc-openstack-healthcheck:
+          repo_url: "https://github.com/rcbops/rpc-openstack-healthcheck"
+          branch: master
     jobs:
       - '{trigger}-Checkmarx_{scan_type}-{repo_name}'


### PR DESCRIPTION
This commit adds the asc
[healthcheck repo](https://github.com/rcbops/rpc-openstack-healthcheck)
to the job list for checkmarx scanning.

Issue: [ASC-1564](https://rpc-openstack.atlassian.net/browse/ASC-1564)