### PR TITLE
ASC-1655 Add Ceph Scenario to Staging Job

### DIFF
--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -608,6 +608,7 @@
           SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
       - swift
+      - ceph
     action:
       - system_staging
       - system_maas

--- a/rpc_jobs/rpc_openstack.yml
+++ b/rpc_jobs/rpc_openstack.yml
@@ -604,8 +604,6 @@
     image:
       - bionic_mnaio_no_artifacts:
           SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
-      - xenial_mnaio_no_artifacts:
-          SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
     scenario:
       - swift
       - ceph


### PR DESCRIPTION
Add the "ceph" scenario to the system staging job so that we can start
creating Molecule tests for Ceph backends. Also, I dropped a redundant
image specification.

Issue: [ASC-1655](https://rpc-openstack.atlassian.net/browse/ASC-1655)