### PR TITLE
RE-2338 Add slack support for notifying of build failures

### DIFF
--- a/job_dsl/rpc_repo_verify.groovy
+++ b/job_dsl/rpc_repo_verify.groovy
@@ -52,7 +52,7 @@ common.globalWraps(){
       // but IMO that means the job should fail.
       if(currentBuild.result == "UNSTABLE"){
         currentBuild.result = "FAILURE"
-        common.build_failure_issue("RE", ["rpc-repo","illegal-package-update"])
+        common.build_failure_notify("RE", ["rpc-repo","illegal-package-update"])
       }
     } // stage
   } // node

--- a/job_dsl/standard_job_checkmarx.groovy
+++ b/job_dsl/standard_job_checkmarx.groovy
@@ -28,12 +28,9 @@ common.globalWraps(){
     } catch(e) {
       print(e)
       // Only create failure card when run as a post-merge job
-      if (env.ghprbPullId == null && ! common.isAbortedBuild() && env.JIRA_PROJECT_KEY != '') {
-        print("Creating build failure issue.")
-        common.build_failure_issue(env.JIRA_PROJECT_KEY)
-      } else {
-        print("Skipping build failure issue creation.")
-      } // if
+      if (env.ghprbPullId == null && ! common.isAbortedBuild()) {
+        common.build_failure_notify(env.JIRA_PROJECT_KEY, [], env.SLACK_CHANNEL, env.SLACK_TEAM)
+      }
       throw e
     } // try
   }

--- a/job_dsl/standard_job_dep_update.groovy
+++ b/job_dsl/standard_job_dep_update.groovy
@@ -62,12 +62,9 @@ common.globalWraps(){
     } catch(e) {
       print(e)
       // Only create failure card when run as a post-merge job
-      if (env.ghprbPullId == null && ! common.isUserAbortedBuild() && env.JIRA_PROJECT_KEY != '') {
-        print("Creating build failure issue.")
-        common.build_failure_issue(env.JIRA_PROJECT_KEY)
-      } else {
-        print("Skipping build failure issue creation.")
-      } // if
+      if (env.ghprbPullId == null && ! common.isUserAbortedBuild()) {
+        common.build_failure_notify(env.JIRA_PROJECT_KEY, [], env.SLACK_CHANNEL, env.SLACK_TEAM)
+      }
       throw e
     } // try
   }

--- a/job_dsl/standard_job_lint_jenkins.groovy
+++ b/job_dsl/standard_job_lint_jenkins.groovy
@@ -70,11 +70,8 @@ common.globalWraps(){
     } catch(e) {
       print(e)
       // Only create failure card when run as a post-merge job
-      if (env.ghprbPullId == null && ! common.isUserAbortedBuild() && env.JIRA_PROJECT_KEY != '') {
-        print("Creating build failure issue.")
-        common.build_failure_issue(env.JIRA_PROJECT_KEY)
-      } else {
-        print("Skipping build failure issue creation.")
+      if (env.ghprbPullId == null && ! common.isUserAbortedBuild()) {
+        common.build_failure_notify(env.JIRA_PROJECT_KEY, [], env.SLACK_CHANNEL, env.SLACK_TEAM)
       }
       throw e
     }

--- a/rpc_jobs/defaults.yml
+++ b/rpc_jobs/defaults.yml
@@ -39,3 +39,5 @@
       - repo: git@github.com:rcbops/mk8s
         commitish: master
     checkmarx_exclude_folders: ""
+    slack_channel: ""
+    slack_team: ""

--- a/rpc_jobs/hardening.yml
+++ b/rpc_jobs/hardening.yml
@@ -4,6 +4,8 @@
     repo_url: "internal:hardening_repo_url"
     branch: "master"
     jira_project_key: "RQE"
+    slack_channel: "#qe-sec-build-failures"
+    slack_team: "@qe-security"
     image:
       - bionic_mnaio_no_artifacts:
           SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
@@ -22,6 +24,8 @@
     repo_url: "internal:hardening_repo_url"
     branch: "master"
     jira_project_key: "RQE"
+    slack_channel: "#qe-sec-build-failures"
+    slack_team: "@qe-security"
     image:
       - xenial_mnaio_no_artifacts:
           SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"
@@ -42,6 +46,8 @@
     repo_url: "internal:hardening_repo_url"
     branch: "master"
     jira_project_key: "RQE"
+    slack_channel: "#qe-sec-build-failures"
+    slack_team: "@qe-security"
     image:
       - xenial_mnaio_loose_artifacts:
           SLAVE_TYPE: "nodepool-ubuntu-bionic-om-io2"

--- a/rpc_jobs/jjb_setup.yml
+++ b/rpc_jobs/jjb_setup.yml
@@ -85,7 +85,7 @@
           }} catch(e) {{
             print(e)
             if (isBuildTriggeredByMergeToProduction) {{
-              common.build_failure_issue("RE")
+              common.build_failure_notify("RE")
             }}
             throw e
           }} // catch

--- a/rpc_jobs/periodic_cleanup.yml
+++ b/rpc_jobs/periodic_cleanup.yml
@@ -66,7 +66,7 @@
                 }
               } catch(e) {
                 print(e)
-                common.build_failure_issue("RE")
+                common.build_failure_notify("RE")
                 throw e
               }
             }
@@ -127,7 +127,7 @@
             }
           } catch(e) {
             print(e)
-            common.build_failure_issue("RE")
+            common.build_failure_notify("RE")
             throw e
           }
         }

--- a/rpc_jobs/phobos.yml
+++ b/rpc_jobs/phobos.yml
@@ -189,7 +189,7 @@
           } catch (e) {
             if(env.DEPLOY == "true"){
               slack_notify("Phobos Deploy Failed", "danger")
-              common.build_failure_issue("REO")
+              common.build_failure_notify("REO")
             } else {
               slack_notify("Phobos Verification Failed", "warning")
             }

--- a/rpc_jobs/standard_job_checkmarx.yml
+++ b/rpc_jobs/standard_job_checkmarx.yml
@@ -22,6 +22,8 @@
       - inject:
           properties-content: |
             JIRA_PROJECT_KEY={jira_project_key}
+            SLACK_CHANNEL={slack_channel}
+            SLACK_TEAM={slack_team}
             RE_JOB_NAME=${{JOB_NAME}}
             RE_JOB_REPO_NAME={repo_name}
     triggers:

--- a/rpc_jobs/standard_job_dep_update.yml
+++ b/rpc_jobs/standard_job_dep_update.yml
@@ -26,6 +26,8 @@
           properties-content: |
             BOOT_TIMEOUT=900
             JIRA_PROJECT_KEY={jira_project_key}
+            SLACK_CHANNEL={slack_channel}
+            SLACK_TEAM={slack_team}
             RE_JOB_NAME=${{JOB_NAME}}
             RE_JOB_REPO_NAME={repo_name}
             STAGES="Allocate Resources, Connect Slave, Cleanup, Destroy Slave"

--- a/rpc_jobs/standard_job_gate.yml
+++ b/rpc_jobs/standard_job_gate.yml
@@ -102,4 +102,4 @@
       }} else {{
         library "rpc-gating-master"
       }}
-      common.stdJob("gate", "{credentials}", "", "{wrappers}")
+      common.stdJob("gate", "{credentials}", "", "{wrappers}", "", "")

--- a/rpc_jobs/standard_job_lint_jenkins.yml
+++ b/rpc_jobs/standard_job_lint_jenkins.yml
@@ -23,6 +23,8 @@
           properties-content: |
             BOOT_TIMEOUT=900
             JIRA_PROJECT_KEY={jira_project_key}
+            SLACK_CHANNEL={slack_channel}
+            SLACK_TEAM={slack_team}
             RE_JOB_NAME=${{JOB_NAME}}
             RE_JOB_REPO_NAME={repo_name}
             STAGES="Allocate Resources, Connect Slave, Cleanup, Destroy Slave"

--- a/rpc_jobs/standard_job_postmerge.yml
+++ b/rpc_jobs/standard_job_postmerge.yml
@@ -40,6 +40,8 @@
     name: 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
     branch: "master"
     jira_project_key: ""
+    slack_channel: ""
+    slack_team: ""
     project-type: pipeline
     concurrent: true
     FLAVOR: "performance1-1"
@@ -95,4 +97,4 @@
       }} else {{
         library "rpc-gating-master"
       }}
-      common.stdJob("periodic", "{credentials}", "{jira_project_key}", "{wrappers}")
+      common.stdJob("periodic", "{credentials}", "{jira_project_key}", "{wrappers}", "{slack_channel}", "{slack_team}")

--- a/rpc_jobs/standard_job_premerge.yml
+++ b/rpc_jobs/standard_job_premerge.yml
@@ -93,5 +93,5 @@
         library "rpc-gating-master"
       }}
       if (! common.isSkippable(skip_pattern, "{credentials}")) {{
-        common.stdJob("check", "{credentials}", "", "{wrappers}")
+        common.stdJob("check", "{credentials}", "", "{wrappers}", "", "")
       }}

--- a/rpc_jobs/standard_job_release.yml
+++ b/rpc_jobs/standard_job_release.yml
@@ -191,6 +191,8 @@
     name: 'RELEASE_{repo_name}-{branch}-{image}-{scenario}-{action}'
     branch: "master"
     jira_project_key: ""
+    slack_channel: ""
+    slack_team: ""
     project-type: pipeline
     concurrent: false
     FLAVOR: "performance1-1"
@@ -236,4 +238,4 @@
           hold_on_error: "{hold_on_error}"
     dsl: |
       library "rpc-gating@${{RPC_GATING_BRANCH}}"
-      common.stdJob("release", "{credentials}", "{jira_project_key}", "{wrappers}")
+      common.stdJob("release", "{credentials}", "{jira_project_key}", "{wrappers}", "{slack_channel}", "{slack_team}")

--- a/rpc_jobs/unit/jira.yml
+++ b/rpc_jobs/unit/jira.yml
@@ -148,7 +148,7 @@
 
         // This stage uses the job name as a label rather than the build tag,
         // concurrent runs will interfere. A lock is used to serialise.
-        stage("Test build_failure_issue"){
+        stage("Test build_failure_notify"){
           lock("unit_test_jira_build_failure_issue_test"){
             try {
               labels = ["jenkins-build-failure", "jenkins", env.JOB_NAME ]
@@ -159,7 +159,7 @@
               assert issues.size() == 0
 
               // Create issue and add a comment
-              common.build_failure_issue(project)
+              common.build_failure_notify(project)
               issues = common.jira_query(issue_query)
               print issues
               assert issues.size() == 1
@@ -169,7 +169,7 @@
 
               // Ensure that duplicate issue is not created, and that
               // a comment is added to the existing issue
-              common.build_failure_issue(project)
+              common.build_failure_notify(project)
               issues = common.jira_query(issue_query)
               print issues
               assert issues.size() == 1


### PR DESCRIPTION
This change reworks `build_failure_issue` to be used more generally so
that it can also send messages on Slack if required. It is renamed to
`build_failure_notify` to account for this adjustment.

The hardening jobs have been updated to make use of Slack notifications.

Unit test failure expected due to change in function name requiring the job to be rebuilt. Tested manually with: https://rpc.jenkins.cit.rackspace.net/job/RE-unit-test-jira/2030/replay/diff

JIRA: RE-2338

Issue: [RE-2338](https://rpc-openstack.atlassian.net/browse/RE-2338)