### PR TITLE
Checkmarx Scan Failure Should Create a JIRA Ticket

### DIFF
--- a/pipeline_steps/checkmarx.groovy
+++ b/pipeline_steps/checkmarx.groovy
@@ -1,4 +1,5 @@
 import java.security.SecureRandom
+import com.rackspace.exceptions.REException
 
 // Upload all folders in the current working directory to checkmarx and scan for vulnerabilities.
 // If you wish to scan a subdir of the working dir, call this function within dir("subdir"){}
@@ -81,6 +82,10 @@ def scan(String scan_type, String repo_name, String exclude_folders){
                 throw e
             } //try
         } // retry
+
+        if (currentBuild.getRawBuild().getResult().isWorseThan(Result.fromString("SUCCESS"))) {
+            throw new REException("Checkmarx Scan Threshold Exceeded for repo: " + repo_name)
+        }
     } // withCredentials
 }
 

--- a/pipeline_steps/checkmarx.groovy
+++ b/pipeline_steps/checkmarx.groovy
@@ -83,7 +83,7 @@ def scan(String scan_type, String repo_name, String exclude_folders){
             } //try
         } // retry
 
-        if (currentBuild.getRawBuild().getResult().isWorseThan(Result.fromString("SUCCESS"))) {
+        if (Result.fromString(currentBuild.currentResult).isWorseThan(Result.fromString("SUCCESS"))) {
             throw new REException("Checkmarx Scan Threshold Exceeded for repo: " + repo_name)
         }
     } // withCredentials


### PR DESCRIPTION
* Added logic to check the build result and if unsuccessful throws a
REException which is caught in the calling function. From there the
common code will create a JIRA ticket if the JIRA_PROJECT_KEY is set.

JIRA: RE-2388

Issue: [RE-2388](https://rpc-openstack.atlassian.net/browse/RE-2388)