### PR TITLE
ASC-1623 add ASC creds to RPC-R system test job

### DIFF
--- a/rpc_jobs/osp_mnaio.yml
+++ b/rpc_jobs/osp_mnaio.yml
@@ -53,7 +53,7 @@
       - "osp_13_deploy-smoke-tests"
       - "osp_13_deploy-system-tests"
     jira_project_key: "RLM"
-    credentials: "rpc_osp"
+    credentials: "rpc_osp rpc_asc_creds"
     jobs:
       - 'PM_{repo_name}-{branch}-{image}-{scenario}-{action}'
     CRON: "{CRON_DAILY}"


### PR DESCRIPTION
@odyssey4me Can you tell me if I am specifying two sets of credentials correctly?  I tried to follow the instructions https://rpc-openstack.atlassian.net/wiki/spaces/RE/pages/19005457/RE+for+Projects#REforProjects-Credentials

Issue: [ASC-1623](https://rpc-openstack.atlassian.net/browse/ASC-1623)