### PR TITLE
Update presentation of releases in Confluence

### DIFF
--- a/scripts/confluence_annual_page.j2
+++ b/scripts/confluence_annual_page.j2
@@ -1,1 +1,0 @@
-<p><ac:structured-macro ac:name="children" ac:schema-version="2" ac:macro-id="{{uuid}}"><ac:parameter ac:name="all">true</ac:parameter><ac:parameter ac:name="sort">title</ac:parameter></ac:structured-macro></p>

--- a/scripts/confluence_release_page.j2
+++ b/scripts/confluence_release_page.j2
@@ -1,12 +1,10 @@
-<p><strong>Date</strong>: {{ date }}</p>
-<p><strong>Meta Version</strong>: {{ meta_version }}</p>
-<p><strong>Product versions included</strong></p>
+<p><strong>Releases</strong></p>
 <table class="wrapped">
 <colgroup><col /><col /><col /><col /></colgroup>
 <tbody>
-<tr><th>Product</th><th>Version</th><th>Release Notes</th><th>Comments</th></tr>
+<tr><th>Version</th><th>Date</th><th>Release Notes</th><th>Comments</th></tr>
 {% for row in rows %}
-<tr><td>{{ row.product }}</td><td>{{ row.version }}</td><td>{{ row.release_notes | urlize }}</td><td>{{ row.comments | urlize}}</td></tr>
+<tr><td>{{ row.version }}</td><td>{{ row.date }}</td><td>{{ row.release_notes | urlize }}</td><td>{{ row.comments | urlize}}</td></tr>
 {% endfor %}
 </tbody>
 </table>


### PR DESCRIPTION
Publishing releases by meta-release will no longer be done, releases are
now separated by project. This change updates the publishing code to
remove unnecessary logic and update the appropriate project page.

JIRA: RE-2370

Issue: [RE-2370](https://rpc-openstack.atlassian.net/browse/RE-2370)