### PR TITLE
Nerf docker upload limit for image jobs

### DIFF
--- a/pipeline_steps/docker_utils.groovy
+++ b/pipeline_steps/docker_utils.groovy
@@ -25,6 +25,10 @@ void prepareHost(){
           apt-get update
           apt-get install -y docker.io
         fi
+        if [ ! -e /etc/docker/daemon.json ]; then
+          echo '{ "max-concurrent-uploads": 2 }' > /etc/docker/daemon.json
+          service docker restart
+        fi
       """
     )
   }


### PR DESCRIPTION
Docker is failing client side when pushing a large amount
of images in parallel. This is a change to limit the amount it
pushes to see if the image jobs become more stable.