### PR TITLE
Fix build summary naming issue

### DIFF
--- a/rpc_jobs/build_summary.yml
+++ b/rpc_jobs/build_summary.yml
@@ -6,7 +6,7 @@
     parameters:
       - string:
           name: "IMAGE_NAME"
-          default: "buildsummary"
+          default: "build-summary"
           description: |
             Hours. Instances older than this will be removed.
       - rpc_gating_params


### PR DESCRIPTION
When the Build-Docker-Images-For-Master is ran, it uploads using a suffix
'build-summary'. The Build-Summary's job's default name is 'buildsummary'.
This results in a naming mismatch with Build-Summary causing it to fail. When
manually specifying build-summary, it completes without issue.  This change
updates the default value to match what is actually being uploaded to the docker
registry.